### PR TITLE
an example NUTS/numpyro for infering element abundance and temperature from log number data (HCO system)

### DIFF
--- a/examples/numpyro/example_nuts.py
+++ b/examples/numpyro/example_nuts.py
@@ -35,7 +35,7 @@ formula_matrix = jnp.array(
     [[2.0, 0.0, 0.0], [0.0, 1.0, 1.0], [4.0, 1.0, 0.0], [2.0, 0.0, 1.0]]
 ).T
 
-# check if the formula matrix is full raw rank
+# check if the formula matrix is full row rank
 rank = np.linalg.matrix_rank(formula_matrix)
 print("formula matrix is row-full rank",rank == formula_matrix.shape[0])
 


### PR DESCRIPTION
addresses #19 

See: `examples/numpyro/example_nuts.py`

This example demonstrates how to use Numpyro's NUTS sampler to perform Bayesian inference on a thermochemical equilibrium problem, specifically for the HCO system. It includes Gibbs minimization and analytical validation.
We infer the temperature and element abundances (bH, bC, bO) from noisy log number densities of species in the HCO system.
<img width="1850" height="977" alt="ahmc" src="https://github.com/user-attachments/assets/6317a193-e077-433e-8083-064f2c485dd5" />

### ground truth
 bH_gt = 0.5
 bC_gt = 0.2 
 bO_gt = 0.3
 T = 1500 K