### PR TITLE
api/equilibrium: add equilibrium_profile (vectorized), fix layer example, improve vmap-compat

### DIFF
--- a/examples/layers/layer_ykb4.py
+++ b/examples/layers/layer_ykb4.py
@@ -8,8 +8,7 @@ Updated to use the high-level API: exogibbs.api.equilibrium.equilibrium.
 """
 
 from exogibbs.presets.ykb4 import prepare_ykb4_setup
-from exogibbs.api.equilibrium import equilibrium, EquilibriumOptions
-from jax import vmap
+from exogibbs.api.equilibrium import equilibrium_profile, EquilibriumOptions
 import numpy as np
 import jax.numpy as jnp
 from jax import config
@@ -31,19 +30,14 @@ chem = prepare_ykb4_setup()
 # ------------------------------------
 opts = EquilibriumOptions(epsilon_crit=1e-11, max_iter=1000)
 
-# Vectorize over T and P via a wrapper to avoid mapping kwargs
-equilibrium_layer = vmap(
-    lambda T, P: equilibrium(
-        chem,
-        T,
-        P,
-        chem.b_element_vector_reference,
-        Pref=Pref,
-        options=opts,
-    ),
-    in_axes=(0, 0),
+res = equilibrium_profile(
+    chem,
+    Tarr,
+    Parr,
+    chem.b_element_vector_reference,
+    Pref=Pref,
+    options=opts,
 )
-res = equilibrium_layer(Tarr, Parr)
 
 ##############################################################################
 nk_result = res.n

--- a/examples/layers/layer_ykb4.py
+++ b/examples/layers/layer_ykb4.py
@@ -1,0 +1,50 @@
+"""
+Validation of Gibbs Minimization for Layered Systems 
+===================================================================================
+
+This example demonstrates and validates the ExoGibbs thermochemical equilibrium for the layered system
+
+Updated to use the high-level API: exogibbs.api.equilibrium.equilibrium.
+"""
+
+from exogibbs.presets.ykb4 import prepare_ykb4_setup
+from exogibbs.api.equilibrium import equilibrium, EquilibriumOptions
+from jax import vmap
+import numpy as np
+import jax.numpy as jnp
+from jax import config
+
+config.update("jax_enable_x64", True)
+
+
+# Thermodynamic conditions
+Pref = 1.0  # bar, reference pressure
+Parr = jnp.logspace(-8, 2, 10)/Pref  # bar
+Tarr = 1500*Parr**0.1
+
+
+#chemical setup
+chem = prepare_ykb4_setup()
+
+##############################################################################
+# Solve equilibrium via high-level API
+# ------------------------------------
+opts = EquilibriumOptions(epsilon_crit=1e-11, max_iter=1000)
+
+# Vectorize over T and P via a wrapper to avoid mapping kwargs
+equilibrium_layer = vmap(
+    lambda T, P: equilibrium(
+        chem,
+        T,
+        P,
+        chem.b_element_vector_reference,
+        Pref=Pref,
+        options=opts,
+    ),
+    in_axes=(0, 0),
+)
+res = equilibrium_layer(Tarr, Parr)
+
+##############################################################################
+nk_result = res.n
+print(nk_result)

--- a/src/exogibbs/api/equilibrium.py
+++ b/src/exogibbs/api/equilibrium.py
@@ -150,4 +150,63 @@ def equilibrium(
         ln_n=ln_n, n=n, x=x, ntot=ntot, iterations=None, metadata=None
     )
 
-__all__ = ["equilibrium", "EquilibriumOptions", "EquilibriumInit", "EquilibriumResult"]
+def equilibrium_profile(
+    setup: ChemicalSetup,
+    T: Array,
+    P: Array,
+    b: Array,
+    *,
+    Pref: float = 1.0,
+    options: Optional[EquilibriumOptions] = None,
+) -> EquilibriumResult:
+    """Vectorized equilibrium along a 1D T/P profile (layers).
+
+    This computes equilibrium independently for each (T[i], P[i]) pair while
+    keeping the elemental abundances ``b`` fixed across layers.
+
+    Args:
+        setup: ChemicalSetup with formula matrix and hvector_func(T).
+        T: Temperatures, shape (N,).
+        P: Pressures, shape (N,).
+        b: Elemental abundances, shape (E,), shared across layers.
+        Pref: Reference pressure (bar).
+        options: Solver options.
+
+    Returns:
+        Batched EquilibriumResult with fields stacked over the leading dimension N:
+        - ln_n: (N, K)
+        - n: (N, K)
+        - x: (N, K)
+        - ntot: (N,)
+    """
+    T = jnp.asarray(T)
+    P = jnp.asarray(P)
+    if T.ndim != 1 or P.ndim != 1:
+        raise ValueError("T and P must be 1D arrays of equal length.")
+    if T.shape[0] != P.shape[0]:
+        raise ValueError("T and P must have the same length.")
+    if b.ndim != 1:
+        raise ValueError("b must be a 1D array shared across layers.")
+
+    # Vectorize over T and P; keep setup and b static. Pass Pref/options as kwargs.
+    layer_fn = jax.vmap(
+        lambda Ti, Pi: equilibrium(
+            setup,
+            Ti,
+            Pi,
+            b,
+            Pref=Pref,
+            options=options,
+        ),
+        in_axes=(0, 0),
+    )
+    return layer_fn(T, P)
+
+
+__all__ = [
+    "equilibrium",
+    "equilibrium_profile",
+    "EquilibriumOptions",
+    "EquilibriumInit",
+    "EquilibriumResult",
+]

--- a/src/exogibbs/api/equilibrium.py
+++ b/src/exogibbs/api/equilibrium.py
@@ -60,7 +60,9 @@ class EquilibriumResult:
 
     # Make this dataclass a JAX pytree (so vmap/jit can pass it around)
     def tree_flatten(self):
-        children = (self.ln_n, self.n, self.x, jnp.asarray(self.ntot))
+        # Avoid coercing to jnp.asarray here to keep compatibility with
+        # transformation-time abstract values (e.g., vmap/jit tracing).
+        children = (self.ln_n, self.n, self.x, self.ntot)
         aux = (self.iterations, self.metadata)
         return children, aux
 

--- a/tests/unittests/api/equilibrium_profile_test.py
+++ b/tests/unittests/api/equilibrium_profile_test.py
@@ -1,0 +1,61 @@
+import importlib
+import jax.numpy as jnp
+
+import exogibbs.api.equilibrium as eqmod
+from exogibbs.api.equilibrium import EquilibriumOptions
+
+
+class FakeSetup:
+    """Minimal stand-in for ChemicalSetup for vectorized API testing."""
+
+    def __init__(self, A):
+        self.formula_matrix = A
+
+    def hvector_func(self, T):
+        K = self.formula_matrix.shape[1]
+        return jnp.zeros((K,))
+
+
+def test_equilibrium_profile_shapes_and_values(monkeypatch):
+    """Simple happy-path test for equilibrium_profile with a stubbed minimizer.
+
+    Ensures batched shapes are correct and values match the stub behavior
+    (ln_n = 0 => n = 1, x uniform, ntot = K) across all layers.
+    """
+    E, K, N = 2, 3, 4
+    A = jnp.array([[1, 0, 1], [0, 1, 0]], dtype=jnp.float64)
+    setup = FakeSetup(A)
+
+    def stub_minimize_gibbs(state, ln_nk0, ln_ntot0, A_in, hfunc, **kwargs):
+        # Basic sanity checks on inputs
+        assert A_in.shape == A.shape
+        assert ln_nk0.shape == (K,)
+        assert ln_ntot0.shape == ()
+        return jnp.zeros((K,), dtype=jnp.result_type(ln_nk0, A_in.dtype))
+
+    monkeypatch.setattr(
+        "exogibbs.api.equilibrium.minimize_gibbs", stub_minimize_gibbs, raising=True
+    )
+
+    # Profile inputs (N layers)
+    T = jnp.linspace(1000.0, 2000.0, N)
+    P = jnp.linspace(0.1, 1.0, N)
+    b = jnp.array([1.0, 2.0], dtype=jnp.float64)
+
+    out = eqmod.equilibrium_profile(
+        setup, T, P, b, options=EquilibriumOptions(epsilon_crit=1e-11, max_iter=50)
+    )
+
+    # Batched shapes
+    assert out.ln_n.shape == (N, K)
+    assert out.n.shape == (N, K)
+    assert out.x.shape == (N, K)
+    assert out.ntot.shape == (N,)
+
+    # Stub behavior reflected across layers
+    assert jnp.allclose(out.ln_n, 0.0)
+    assert jnp.allclose(out.n, 1.0)
+    assert jnp.allclose(out.x, jnp.ones((N, K)) / K)
+    assert jnp.allclose(out.ntot, K)
+    assert jnp.allclose(jnp.sum(out.x, axis=1), 1.0)
+


### PR DESCRIPTION
# Summary

- Adds a simple, official vectorized API `equilibrium_profile` for layered T/P profiles with a
shared elemental vector b.
- Updates the YKB4 layer example to use the new API
- Improves EquilibriumResult pytree handling to play nicely with vmap/jit.

# Motivation

- We’re vectorizing `api.equilibrium` over atmospheric layers. The example previously attempted an
ad-hoc vmap and failed due to argument mapping and pytree flattening of ntot.
- Provide a clear, public API name (`api.equilibrium_profile`) 

# Changes

- New API: equilibrium_profile in src/exogibbs/api/equilibrium.py
    - Vectorizes over 1D T and P, keeps b fixed across layers (1D).
    - Validates T/P length and dimensionality.
    - Returns a batched EquilibriumResult:
    - `ln_n`, `n`, `x`: shape `(N, K)`; `ntot`: shape `(N,)`.
- Pytree flattening: EquilibriumResult.tree_flatten
    - Stops forcing ntot through jnp.asarray during tracing; avoids dtype resolution errors
under vmap/jit.
    - No behavior change for downstream code; ntot remains a JAX array produced in equilibrium.
- Example: examples/layers/layer_ykb4.py
    - Switches to equilibrium_profile.
    - Removes stray from torch import eq.
- Tests: tests/unittests/api/equilibrium_profile_test.py
    - Simple stubbed test verifying batched shapes and values.

# Behavior

- equilibrium_profile(setup, T, P, b, Pref=1.0, options=None) computes per-layer equilibrium for
each (T[i], P[i]), requiring b to be 1D (shared).
- No bifurcation on b dimensionality; errors if not 1D.

# Usage

- Example:
    ```python
    res = equilibrium_profile(chem, Tarr, Parr, chem.b_element_vector_reference, Pref=1.0,options=opts)
    ```
    - res.ln_n, res.n, res.x have shape (N, K), res.ntot has shape (N,).

