### PR TITLE
Helper function for updating element_vector

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,30 +1,27 @@
 # Repository Guidelines
 
-## Project Structure & Modules
-- Source: `src/exogibbs/` with subpackages `io`, `equilibrium`, `thermo`, `optimize`, `api`, `presets`, `utils` and data files under `src/exogibbs/data/`.
+## Project Structure & Module Organization
+- Source: `src/exogibbs/` with subpackages `io/`, `equilibrium/`, `thermo/`, `optimize/`, `api/`, `presets/`, `utils/`; data files under `src/exogibbs/data/`.
 - Tests: `tests/unittests/` organized by domain (e.g., `io/`, `equilibrium/`); files named `*_test.py`.
-- Examples and docs: `examples/`, `documents/`.
+- Examples & docs: `examples/` and `documents/`.
 
-## Build, Test, and Development
-- Install (editable): `python -m pip install -e .` (requires Python >= 3.9). Uses `setuptools` + `setuptools-scm` for versioning.
-- Run tests: `pytest tests/unittests` (CI runs this and exports `results/pytest.xml`).
-- Optional build: `python -m pip install build && python -m build` (ensure Git tags exist for correct versioning).
+## Build, Test, and Development Commands
+- Install (editable): `python -m pip install -e .` (Python >= 3.9).
+- Run tests: `pytest tests/unittests` (CI exports `results/pytest.xml`).
+- Optional build: `python -m pip install build && python -m build` (ensure Git tags for correct versioning).
 
-## Coding Style & Naming
-- Language: Python with type hints where practical.
-- Indentation: 4 spaces; keep functions short and focused.
-- Naming: modules/functions/variables `snake_case`, classes `CapWords`, constants `UPPER_SNAKE_CASE`.
-- Docstrings: concise triple-quoted summaries; prefer argument/return descriptions on public functions.
+## Coding Style & Naming Conventions
+- Language: Python with type hints where practical; 4-space indentation; keep functions short and focused.
+- Naming: modules/functions/variables `snake_case`; classes `CapWords`; constants `UPPER_SNAKE_CASE`.
 - Imports: standard lib, third-party, then local; avoid unused imports.
 
 ## Testing Guidelines
-- Framework: `pytest`.
-- Location/pattern: place new tests under `tests/unittests/<area>/`, name `*_test.py` (e.g., `tests/unittests/thermo/new_feature_test.py`).
-- Behavior: keep tests deterministic (no network/GPU); use small fixtures and cover edge cases (e.g., parsing, interpolation bounds).
-- Goal: maintain/raise coverage of changed code and keep the suite green locally before pushing.
+- Framework: `pytest`; keep tests deterministic (no network/GPU). Use small fixtures and cover edge cases (e.g., parsing, interpolation bounds).
+- Location/pattern: place tests under `tests/unittests/<area>/`, name `*_test.py`.
+- Run locally: `pytest tests/unittests`. Aim to maintain/raise coverage of changed code.
 
 ## Commit & Pull Request Guidelines
-- Commits: concise, imperative (e.g., "thermo: fix electron parsing"), group related changes; reference issues (`#123`) when applicable.
+- Commits: concise, imperative (e.g., "thermo: fix electron parsing"); group related changes; reference issues (`#123`) when applicable.
 - PRs: include a clear description, motivation, and testing notes; link issues; add/adjust tests; update data packaging (`MANIFEST.in`) when adding files under `src/exogibbs/data/`.
 - CI: PRs to `develop`/`main` must pass the pytest workflow.
 

--- a/documents/presets/ykb4.rst
+++ b/documents/presets/ykb4.rst
@@ -16,7 +16,7 @@ Quick Start
 
    setup = prepare_ykb4_setup()
    T, P = 1500.0, 1.0  # K, bar
-   b = setup.b_element_vector_reference  # or your own jnp.array([...])
+   b = setup.element_vector_reference  # or your own jnp.array([...])
    result = equilibrium(setup, T=T, P=P, b=b)
    print(result.x)  # mole fractions (K,)
 
@@ -26,7 +26,7 @@ The following elements are included in this preset (including electrons as "e-")
 
 ``C, H, He, K, N, Na, O, P, S, Ti, V, e-``
 
-The reference elemental abundances (`b_element_vector_ref`) are taken from Asplund, Amarsi & Grevesse (2021).
+The reference elemental abundances (`element_vector_ref`) are taken from Asplund, Amarsi & Grevesse (2021).
 
 Species (JANAF key)
 -------------------

--- a/examples/benchmark/clfac_yk.py
+++ b/examples/benchmark/clfac_yk.py
@@ -52,7 +52,7 @@ b_old_ref = jnp.array(
 thermo_state = ThermoState(
     temperature=temperature,
     ln_normalized_pressure=ln_normalized_pressure,
-    b_element_vector=b_old_ref,
+    element_vector=b_old_ref,
 )
 
 # Convergence criteria

--- a/examples/comparisons/comparison_with_hcosystem.py
+++ b/examples/comparisons/comparison_with_hcosystem.py
@@ -67,10 +67,10 @@ def hvector_func(temperature):
 bH = 0.5
 bC = 0.2
 bO = 0.3
-b_element_vector = jnp.array([bH, bC, bO])  # H, C, O
+element_vector = jnp.array([bH, bC, bO])  # H, C, O
 
 # ThermoState instance
-thermo_state = ThermoState(temperature, ln_normalized_pressure, b_element_vector)
+thermo_state = ThermoState(temperature, ln_normalized_pressure, element_vector)
 
 # Convergence criteria
 epsilon_crit = 1e-11
@@ -110,8 +110,8 @@ assert jnp.abs(res) < epsilon_crit * 10.0
 from exogibbs.test.analytic_hcosystem import derivative_dlnnCO_db
 
 dlnn_db = jacrev(
-    lambda b_element_vector_in: minimize_gibbs(
-        ThermoState(temperature, ln_normalized_pressure, b_element_vector_in),
+    lambda element_vector_in: minimize_gibbs(
+        ThermoState(temperature, ln_normalized_pressure, element_vector_in),
         ln_nk,
         ln_ntot,
         formula_matrix,
@@ -119,7 +119,7 @@ dlnn_db = jacrev(
         epsilon_crit=epsilon_crit,
         max_iter=max_iter,
     )
-)(b_element_vector) # (n_species, n_elements)
+)(element_vector) # (n_species, n_elements)
 
 # analytical derivatives
 gradf = derivative_dlnnCO_db(ln_nk_result[1], bC, bH, bO, k)

--- a/examples/comparisons/comparison_with_hsystem.py
+++ b/examples/comparisons/comparison_with_hsystem.py
@@ -61,10 +61,10 @@ def hvector_func(temperature):
 
 
 # Element abundance constraint: total H nuclei = 1.0
-b_element_vector = jnp.array([1.0])
+element_vector = jnp.array([1.0])
 
 # ThermoState instance
-thermo_state = ThermoState(temperature, ln_normalized_pressure, b_element_vector)
+thermo_state = ThermoState(temperature, ln_normalized_pressure, element_vector)
 
 # Convergence criteria
 epsilon_crit = 1e-11
@@ -116,7 +116,7 @@ dln_dT = jacrev(
         ThermoState(
             temperature_in,
             ln_normalized_pressure,
-            b_element_vector,
+            element_vector,
         ),
         ln_nk,
         ln_ntot,
@@ -152,7 +152,7 @@ dln_dlogp = jacrev(
         ThermoState(
             temperature,
             ln_normalized_pressure,
-            b_element_vector,
+            element_vector,
         ),
         ln_nk,
         ln_ntot,
@@ -193,7 +193,7 @@ ln_ntot_init = 0.0
 # Vectorize minimize_gibbs over temperature axis
 def func(T):
         return minimize_gibbs(
-            ThermoState(T, ln_normalized_pressure, b_element_vector),
+            ThermoState(T, ln_normalized_pressure, element_vector),
             ln_nk_init,
             ln_ntot_init,
             formula_matrix,
@@ -327,7 +327,7 @@ print(f"Pressure range: {Parr[0]:.3f} to {Parr[-1]:.0f} bar ({len(Parr)} points)
 # Vectorize minimize_gibbs over temperature axis
 def funcp(logpin):
         return minimize_gibbs(
-            ThermoState(temperature, logpin, b_element_vector),
+            ThermoState(temperature, logpin, element_vector),
             ln_nk_init,
             ln_ntot_init,
             formula_matrix,

--- a/examples/layers/layer_ykb4.py
+++ b/examples/layers/layer_ykb4.py
@@ -34,7 +34,7 @@ res = equilibrium_profile(
     chem,
     Tarr,
     Parr,
-    chem.b_element_vector_reference,
+    chem.element_vector_reference,
     Pref=Pref,
     options=opts,
 )

--- a/examples/numpyro/example_nuts.py
+++ b/examples/numpyro/example_nuts.py
@@ -58,10 +58,10 @@ def hvector_func(temperature):
 bH_gt = 0.5
 bC_gt = 0.2
 bO_gt = 0.3
-b_element_vector_gt = jnp.array([bH_gt, bC_gt, bO_gt])  # H, C, O
+element_vector_gt = jnp.array([bH_gt, bC_gt, bO_gt])  # H, C, O
 
 # ThermoState instance
-thermo_state_gt = ThermoState(temperature_gt, ln_normalized_pressure, b_element_vector_gt)
+thermo_state_gt = ThermoState(temperature_gt, ln_normalized_pressure, element_vector_gt)
 
 # Convergence criteria
 epsilon_crit = 1e-11
@@ -98,13 +98,13 @@ def model_prob(ln_nk_obs):
     bH = numpyro.sample('bH', dist.Uniform(0.1, 1.0))
     bC = numpyro.sample('bC', dist.Uniform(0.1, 0.3))
     bO = numpyro.sample('bO', dist.Uniform(0.1, 0.5))
-    b_element_vector = jnp.array([bH, bC, bO]) 
+    element_vector = jnp.array([bH, bC, bO]) 
     logT = numpyro.sample('logT', dist.Uniform(3.0, 3.5)) 
     temperature = 10**(logT)
     numpyro.deterministic('temperature', temperature)
     
     # ThermoState instance
-    thermo_state = ThermoState(temperature, ln_normalized_pressure, b_element_vector)
+    thermo_state = ThermoState(temperature, ln_normalized_pressure, element_vector)
 
     mu_ln_nk = minimize_gibbs(
     thermo_state,

--- a/src/exogibbs/presets/ykb4.py
+++ b/src/exogibbs/presets/ykb4.py
@@ -48,7 +48,7 @@ def prepare_ykb4_setup() -> ChemicalSetup:
     
     # Reference elemental solar abundance b from AAG21 (from exojax.utils.zsol import nsol)
     # AAG21 = Asplund, M., Amarsi, A. M., & Grevesse, N. 2021, arXiv:2105.01661
-    b_element_vector_ref = jnp.array(
+    element_vector_ref = jnp.array(
         [
             2.6627135e-04,
             9.2326087e-01,
@@ -100,6 +100,6 @@ def prepare_ykb4_setup() -> ChemicalSetup:
         hvector_func=hvector_func_jit,
         elements=tuple(elements) if elements is not None else None,
         species=tuple(species) if species is not None else None,
-        b_element_vector_reference=b_element_vector_ref,
+        element_vector_reference=element_vector_ref,
         metadata={"source": "JANAF"},
     )

--- a/tests/unittests/api/chemistry_bvector_test.py
+++ b/tests/unittests/api/chemistry_bvector_test.py
@@ -1,0 +1,46 @@
+import jax
+import jax.numpy as jnp
+
+from exogibbs.api.chemistry import ChemicalSetup, update_element_vector, element_indices_by_name
+
+
+def test_update_b_vector_and_indices_jit_safe():
+    # Elements order (includes electron as last entry)
+    elements = ("C", "H", "He", "K", "N", "Na", "O", "P", "S", "Ti", "V", "e-")
+    K = len(elements)
+
+    # Reference abundances (arbitrary positive values)
+    b_ref = jnp.array([1.0, 10.0, 0.5, 0.01, 1.2, 0.02, 2.0, 0.03, 0.04, 0.005, 0.006, 0.0])
+
+    setup = ChemicalSetup(
+        formula_matrix=jnp.zeros((K, 1)),  # not used here
+        hvector_func=lambda T: jnp.zeros((1,)),  # not used here
+        elements=elements,
+    )
+
+    idx_COe = element_indices_by_name(setup, ["C", "O", "e-"])
+    idx_C, idx_O, idx_e = int(idx_COe[0]), int(idx_COe[1]), int(idx_COe[2])
+
+    # Scales for C and O; set electron to 0.0
+    def make_b(C_scale, O_scale):
+        return update_element_vector(
+            b_ref,
+            scale_indices=jnp.array([idx_C, idx_O]),
+            scales=jnp.array([C_scale, O_scale]),
+            set_indices=jnp.array([idx_e]),
+            set_values=jnp.array([0.0]),
+        )
+
+    # JIT compile to ensure trace-safety
+    make_b_jit = jax.jit(make_b)
+
+    C_scale = 0.8
+    O_scale = 1.1
+    out = make_b_jit(C_scale, O_scale)
+
+    # Expected: only C and O scaled; e- set to 0; others unchanged
+    expected = b_ref.at[idx_C].set(b_ref[idx_C] * C_scale)
+    expected = expected.at[idx_O].set(b_ref[idx_O] * O_scale)
+    expected = expected.at[idx_e].set(0.0)
+
+    assert jnp.allclose(out, expected)

--- a/tests/unittests/api/chemsetup_smoke_test.py
+++ b/tests/unittests/api/chemsetup_smoke_test.py
@@ -23,8 +23,8 @@ def test_prepare_ykb4_setup_basic():
     # optional metadata
     assert (setup.elements is None) or isinstance(setup.elements, tuple)
     assert (setup.species is None) or isinstance(setup.species, tuple)
-    assert (setup.b_element_vector_reference is None) or isinstance(
-        setup.b_element_vector_reference, (np.ndarray, jnp.ndarray)
+    assert (setup.element_vector_reference is None) or isinstance(
+        setup.element_vector_reference, (np.ndarray, jnp.ndarray)
     )
     assert (setup.metadata is None) or isinstance(setup.metadata, dict)
 
@@ -71,9 +71,9 @@ def test_dimension_consistency():
 
 
 def test_optional_b_reference_host_side():
-    """b_element_vector_reference is optional and (if present) host-side array."""
+    """element_vector_reference is optional and (if present) host-side array."""
     setup = prepare_ykb4_setup()
-    b_ref = setup.b_element_vector_reference
+    b_ref = setup.element_vector_reference
     if b_ref is not None:
         # Treat as reference only; ensure it’s not an unexpectedly huge DeviceArray
         assert isinstance(b_ref, (np.ndarray, jnp.ndarray))

--- a/tests/unittests/api/equilibrium_api_test.py
+++ b/tests/unittests/api/equilibrium_api_test.py
@@ -21,7 +21,7 @@ config.update("jax_enable_x64", True)
 @pytest.mark.smoke
 def test_equilibrium_grad_wrt_temperature():
     setup = prepare_ykb4_setup()
-    b_vec = setup.b_element_vector_reference
+    b_vec = setup.element_vector_reference
 
     def f(T):
         return jnp.sum(equilibrium(setup, T, 1.0, b_vec).ln_n)
@@ -159,7 +159,7 @@ def test_equilibrium_respects_init(monkeypatch):
 
 if __name__ == "__main__":
     setup = prepare_ykb4_setup()
-    b_vec = setup.b_element_vector_reference
+    b_vec = setup.element_vector_reference
 
     def f(T):
         return jnp.sum(equilibrium(setup, T, 1.0, b_vec).ln_n)

--- a/tests/unittests/api/equilibrium_jit_grad_test.py
+++ b/tests/unittests/api/equilibrium_jit_grad_test.py
@@ -20,7 +20,7 @@ def test_equilibrium_profile_jit_under_grad():
     It should compile and return a finite gradient.
     """
     setup = prepare_ykb4_setup()
-    b = setup.b_element_vector_reference
+    b = setup.element_vector_reference
 
     # Small profile to keep runtime minimal
     N = 5

--- a/tests/unittests/optimize/lagrange/hcosystem_test.py
+++ b/tests/unittests/optimize/lagrange/hcosystem_test.py
@@ -36,12 +36,12 @@ def hco_system_setup():
     bH = 0.5 
     bC = 0.2
     bO = 0.3
-    b_element_vector = jnp.array([bH, bC, bO])
+    element_vector = jnp.array([bH, bC, bO])
     
     epsilon_crit = 1e-11
     max_iter = 1000
     
-    thermo_state = ThermoState(temperature, ln_normalized_pressure, b_element_vector)
+    thermo_state = ThermoState(temperature, ln_normalized_pressure, element_vector)
     
     return {
         'hcosystem': hcosystem,
@@ -53,7 +53,7 @@ def hco_system_setup():
         'ln_nk': ln_nk,
         'ln_ntot': ln_ntot,
         'hvector_func': hvector_func,
-        'b_element_vector': b_element_vector,
+        'element_vector': element_vector,
         'bH': bH,
         'bC': bC,
         'bO': bO,

--- a/tests/unittests/optimize/lagrange/minimize_test.py
+++ b/tests/unittests/optimize/lagrange/minimize_test.py
@@ -31,11 +31,11 @@ def h_system_setup():
     def hvector_func(temperature): 
         return jnp.array([hsystem.hv_h(temperature), hsystem.hv_h2(temperature)])
     
-    b_element_vector = jnp.array([1.0])
+    element_vector = jnp.array([1.0])
     epsilon_crit = 1e-11
     max_iter = 1000
     
-    thermo_state = ThermoState(temperature, ln_normalized_pressure, b_element_vector)
+    thermo_state = ThermoState(temperature, ln_normalized_pressure, element_vector)
     
     return {
         'hsystem': hsystem,
@@ -46,7 +46,7 @@ def h_system_setup():
         'ln_nk': ln_nk,
         'ln_ntot': ln_ntot,
         'hvector_func': hvector_func,
-        'b_element_vector': b_element_vector,
+        'element_vector': element_vector,
         'thermo_state': thermo_state,
         'epsilon_crit': epsilon_crit,
         'max_iter': max_iter
@@ -85,7 +85,7 @@ def test_minimize_gibbs_temperature_gradient_h_system(h_system_setup):
     
     # Compute temperature gradient using jacrev
     dln_dT = jacrev(lambda temperature_in: minimize_gibbs(
-        ThermoState(temperature_in, setup['ln_normalized_pressure'], setup['b_element_vector']),
+        ThermoState(temperature_in, setup['ln_normalized_pressure'], setup['element_vector']),
         setup['ln_nk'],
         setup['ln_ntot'],
         setup['formula_matrix'],
@@ -112,7 +112,7 @@ def test_minimize_gibbs_pressure_gradient_h_system(h_system_setup):
     
     # Compute pressure gradient using jacrev
     dln_dlogp = jacrev(lambda ln_normalized_pressure_in: minimize_gibbs(
-        ThermoState(setup['temperature'], ln_normalized_pressure_in, setup['b_element_vector']),
+        ThermoState(setup['temperature'], ln_normalized_pressure_in, setup['element_vector']),
         setup['ln_nk'],
         setup['ln_ntot'],
         setup['formula_matrix'],
@@ -157,14 +157,14 @@ def test_minimize_gibbs_element_gradient_hco_system():
     bH = 0.5
     bC = 0.2
     bO = 0.3
-    b_element_vector = jnp.array([bH, bC, bO])
+    element_vector = jnp.array([bH, bC, bO])
     
     epsilon_crit = 1e-11
     max_iter = 1000
     
     # Get equilibrium solution first
     ln_nk_result = minimize_gibbs(
-        ThermoState(temperature, ln_normalized_pressure, b_element_vector),
+        ThermoState(temperature, ln_normalized_pressure, element_vector),
         ln_nk,
         ln_ntot,
         formula_matrix,
@@ -175,8 +175,8 @@ def test_minimize_gibbs_element_gradient_hco_system():
     
     # Compute element gradient using jacrev
     dlnn_db = jacrev(
-        lambda b_element_vector_in: minimize_gibbs(
-            ThermoState(temperature, ln_normalized_pressure, b_element_vector_in),
+        lambda element_vector_in: minimize_gibbs(
+            ThermoState(temperature, ln_normalized_pressure, element_vector_in),
             ln_nk,
             ln_ntot,
             formula_matrix,
@@ -184,7 +184,7 @@ def test_minimize_gibbs_element_gradient_hco_system():
             epsilon_crit=epsilon_crit,
             max_iter=max_iter,
         )
-    )(b_element_vector)
+    )(element_vector)
     
     # Analytical derivatives
     k = hcosystem.equilibrium_constant(temperature, P/Pref)

--- a/tests/unittests/optimize/lagrange/minimize_vmap_test.py
+++ b/tests/unittests/optimize/lagrange/minimize_vmap_test.py
@@ -21,7 +21,7 @@ def test_minimize_gibbs_vmap_h_system():
     ln_normalized_pressure = compute_ln_normalized_pressure(P, Pref)
     ln_nk_init = jnp.array([0.0, 0.0])
     ln_ntot_init = 0.0
-    b_element_vector = jnp.array([1.0])
+    element_vector = jnp.array([1.0])
     epsilon_crit = 1e-11
     max_iter = 1000
     
@@ -34,7 +34,7 @@ def test_minimize_gibbs_vmap_h_system():
     # Vectorized minimize_gibbs
     def func(T):
         return minimize_gibbs(
-            ThermoState(T, ln_normalized_pressure, b_element_vector),
+            ThermoState(T, ln_normalized_pressure, element_vector),
             ln_nk_init,
             ln_ntot_init,
             formula_matrix,
@@ -81,7 +81,7 @@ def test_minimize_gibbs_vmap_gradient_h_system():
     ln_normalized_pressure = compute_ln_normalized_pressure(P, Pref)
     ln_nk_init = jnp.array([0.0, 0.0])
     ln_ntot_init = 0.0
-    b_element_vector = jnp.array([1.0])
+    element_vector = jnp.array([1.0])
     epsilon_crit = 1e-11
     max_iter = 1000
     
@@ -94,7 +94,7 @@ def test_minimize_gibbs_vmap_gradient_h_system():
     # Vectorized temperature gradients
     def func(T):
         return minimize_gibbs(
-            ThermoState(T, ln_normalized_pressure, b_element_vector),
+            ThermoState(T, ln_normalized_pressure, element_vector),
             ln_nk_init,
             ln_ntot_init,
             formula_matrix,


### PR DESCRIPTION
We added a helper function for updating `element_vector`, which can improve an example for ExoJAX.

First we need to know indices for updating elements:
```python
from exogibbs.api.chemistry import element_indices_by_name, update_element_vector
# Compute indices once (outside jit/NumPyro tracing)
_idx_CO = element_indices_by_name(chem, ['C', 'O'])
_idx_C, _idx_O = map(int, list(_idx_CO))
```
Then, we can update the element vector with JIT-compatible as
```python
def model_prob(spectrum):

    # atmospheric/spectral model parameters priors
    logg = numpyro.sample("logg", dist.Uniform(4.0, 5.0))
    RV = numpyro.sample("RV", dist.Uniform(35.0, 45.0))
    T0 = numpyro.sample("T0", dist.Uniform(1000.0, 1500.0))
    alpha = numpyro.sample("alpha", dist.Uniform(0.05, 0.2))
    vsini = numpyro.sample("vsini", dist.Uniform(5.0, 15.0))
    logC = numpyro.sample("logC", dist.Uniform(-1.0, 1.0))  #  logC [solar]
    logO = numpyro.sample("logO", dist.Uniform(-1.0, 1.0))  #  logO [solar]
    C = 10**logC
    O = 10**logO

    # Build element vector in a JAX-safe way (scale C/O; set e- to 0)
    element_vector_in = update_element_vector(
        element_vector,
        scale_indices=jnp.array([_idx_C, _idx_O]),
        scales=jnp.array([C, O]),
        )

    mu = fspec(T0, alpha, 10**logg, RV, vsini, element_vector_in)

    # noise model parameters priors
    sigmain = numpyro.sample("sigmain", dist.Exponential(1.0e-3))
    numpyro.sample("spectrum", dist.Normal(mu, sigmain), obs=spectrum)
```

## renaming
`b_element_vector` -> `element_vector`