### PR TITLE
api/potential: simplify gibbs_energies with direct batched hvector

### DIFF
--- a/src/exogibbs/api/potential.py
+++ b/src/exogibbs/api/potential.py
@@ -1,61 +1,11 @@
-"""Thermpodynamic potential functions for ExoGibbs API."""
+"""Thermodynamic potential functions for ExoGibbs API."""
 
 import jax.numpy as jnp
-from jax import vmap
 from typing import Optional
 
 from exogibbs.api.chemistry import ChemicalSetup
 from exogibbs.utils.constants import R_gas_constant_si
 from jax.scipy.special import logsumexp
-
-def gibbs_energy(
-    temperature: float,
-    pressure: float,
-    chem_gas: ChemicalSetup,
-    ln_ngas: jnp.ndarray,
-    chem_cond: Optional[ChemicalSetup] = None,
-    ln_ncond: Optional[jnp.ndarray] = None,
-    nomalize: bool = False,
-):
-    """Calculate Gibbs energy from chemical setup, temperature, and pressure.
-
-    Args:
-        temperature: float
-            Temperature at which to evaluate Gibbs energy.
-        pressure: float
-            Pressure at which to evaluate Gibbs energy.
-        chem_gas: ChemicalSetup
-            The chemical setup for gas phase.
-        ln_ngas: jnp.ndarray
-            Logarithm of amounts of gas species (K_gas,).
-        chem_cond: Optional[ChemicalSetup]
-            The chemical setup for condensed phase.
-        ln_ncond: Optional[jnp.ndarray]
-            Logarithm of amounts of condensed species (K_cond,).
-        nomalize: bool
-            If True, return normalized Gibbs energy (G/RT).
-
-    Returns:
-        float
-            Gibbs energy at given temperature and pressure.
-
-    """
-    if nomalize:
-        RT = 1.0
-    else:
-        RT = R_gas_constant_si * temperature
-    
-    ln_ntot = logsumexp(ln_ngas)
-    #hvector_gas = chem_gas.hvector_func(temperature) + jnp.log(pressure * ngas / ntot)
-    hvector_gas = chem_gas.hvector_func(temperature) + jnp.log(pressure) + ln_ngas - ln_ntot
-    g_gas = jnp.dot(jnp.exp(ln_ngas), hvector_gas) * RT
-
-    if chem_cond is not None and ln_ncond is not None:
-        hvector_cond = chem_cond.hvector_func(temperature)
-        g_cond = jnp.dot(jnp.exp(ln_ncond), hvector_cond) * RT
-        return g_gas + g_cond
-
-    return g_gas
 
 
 def gibbs_energies(
@@ -68,7 +18,7 @@ def gibbs_energies(
     nomalize: bool = False,
     ):
     """Vectorized Gibbs energy calculation over temperature and pressure arrays.
-    
+
     Args:
         temperatures: jnp.ndarray
             Array of temperatures at which to evaluate Gibbs energy.
@@ -88,21 +38,43 @@ def gibbs_energies(
     Returns:
         jnp.ndarray
             Array of Gibbs energies corresponding to input temperatures and pressures.
-    
+
     """
-    gibbs_energy_vmapped = vmap(
-        gibbs_energy,
-        in_axes=(0, 0, None, 0, None, 0, None),
-    )   
-    return gibbs_energy_vmapped(
-        temperatures,
-        pressures,
-        chem_gas,
-        ln_ngas,
-        chem_cond,
-        ln_ncond,
-        nomalize,
+    temperatures = jnp.asarray(temperatures)
+    pressures = jnp.asarray(pressures)
+    ln_ngas = jnp.asarray(ln_ngas)
+
+    if temperatures.ndim != 1 or pressures.ndim != 1:
+        raise ValueError("temperatures and pressures must be 1D arrays.")
+    if temperatures.shape[0] != pressures.shape[0]:
+        raise ValueError("temperatures and pressures must have the same length.")
+    if ln_ngas.ndim != 2 or ln_ngas.shape[0] != temperatures.shape[0]:
+        raise ValueError("ln_ngas must have shape (N, K_gas).")
+
+    if nomalize:
+        RT = jnp.ones_like(temperatures)
+    else:
+        RT = R_gas_constant_si * temperatures
+
+    ln_ntot = logsumexp(ln_ngas, axis=1)
+    hvector_gas = (
+        chem_gas.hvector_func(temperatures)
+        + jnp.log(pressures)[:, None]
+        + ln_ngas
+        - ln_ntot[:, None]
     )
+    g_gas = jnp.sum(jnp.exp(ln_ngas) * hvector_gas, axis=1) * RT
+
+    if chem_cond is None or ln_ncond is None:
+        return g_gas
+
+    ln_ncond = jnp.asarray(ln_ncond)
+    if ln_ncond.ndim != 2 or ln_ncond.shape[0] != temperatures.shape[0]:
+        raise ValueError("ln_ncond must have shape (N, K_cond).")
+
+    hvector_cond = chem_cond.hvector_func(temperatures)
+    g_cond = jnp.sum(jnp.exp(ln_ncond) * hvector_cond, axis=1) * RT
+    return g_gas + g_cond
 
 
 if __name__ == "__main__":
@@ -116,13 +88,13 @@ if __name__ == "__main__":
 
     gas = gassetup()
     cond = condsetup()
-    temperature = 1000.0 
-    pressure = 1.0 
-    ln_ngas = jnp.log(jnp.ones(len(gas.species)))
-    ln_ncond = jnp.log(jnp.ones(len(cond.species)))
-    g = gibbs_energy(
-        temperature=temperature,
-        pressure=pressure,
+    temperature = 1000.0
+    pressure = 1.0
+    ln_ngas = jnp.log(jnp.ones((1, len(gas.species))))
+    ln_ncond = jnp.log(jnp.ones((1, len(cond.species))))
+    g = gibbs_energies(
+        temperatures=jnp.array([temperature]),
+        pressures=jnp.array([pressure]),
         chem_gas=gas,
         ln_ngas=ln_ngas,
         chem_cond=cond,
@@ -131,15 +103,14 @@ if __name__ == "__main__":
     )
     print("Gibbs energy:", g)
 
-    n=100
-    
-    
+    n = 100
+
     temperatures = jnp.linspace(500.0, 3000.0, n)
     pressures = jnp.linspace(0.1, 10.0, n)
-    
+
     ln_ngas = jnp.log(jnp.ones((n, len(gas.species))))
     ln_ncond = jnp.log(jnp.ones((n, len(cond.species))))
-    
+
     gs = gibbs_energies(
         temperatures=temperatures,
         pressures=pressures,

--- a/tests/unittests/api/potential_test.py
+++ b/tests/unittests/api/potential_test.py
@@ -2,10 +2,11 @@ import jax.numpy as jnp
 from jax.scipy.special import logsumexp
 
 from exogibbs.api.chemistry import ChemicalSetup
-from exogibbs.api.potential import gibbs_energy, gibbs_energies
+from exogibbs.api.potential import gibbs_energies
+from exogibbs.utils.constants import R_gas_constant_si
 
 
-def test_gibbs_energy_with_condensed_phase_normalized():
+def test_gibbs_energies_with_condensed_phase_normalized():
     chem_gas = ChemicalSetup(
         formula_matrix=jnp.zeros((1, 2)),
         hvector_func=lambda T: jnp.array([1.0, 2.0]),
@@ -15,19 +16,22 @@ def test_gibbs_energy_with_condensed_phase_normalized():
         hvector_func=lambda T: jnp.array([4.0]),
     )
 
-    temperature = 1000.0
-    pressure = 2.0
-    ln_ngas = jnp.log(jnp.array([2.0, 3.0]))
-    ln_ncond = jnp.log(jnp.array([5.0]))
+    temperatures = jnp.array([1000.0])
+    pressures = jnp.array([2.0])
+    ln_ngas = jnp.log(jnp.array([[2.0, 3.0]]))
+    ln_ncond = jnp.log(jnp.array([[5.0]]))
 
-    ln_ntot = logsumexp(ln_ngas)
-    expected_gas = jnp.dot(jnp.exp(ln_ngas), jnp.array([1.0, 2.0]) + jnp.log(pressure) + ln_ngas - ln_ntot)
-    expected_cond = jnp.dot(jnp.exp(ln_ncond), jnp.array([4.0]))
-    expected = expected_gas + expected_cond
+    ln_ntot = logsumexp(ln_ngas[0])
+    expected_gas = jnp.dot(
+        jnp.exp(ln_ngas[0]),
+        jnp.array([1.0, 2.0]) + jnp.log(pressures[0]) + ln_ngas[0] - ln_ntot,
+    )
+    expected_cond = jnp.dot(jnp.exp(ln_ncond[0]), jnp.array([4.0]))
+    expected = jnp.array([expected_gas + expected_cond])
 
-    out = gibbs_energy(
-        temperature=temperature,
-        pressure=pressure,
+    out = gibbs_energies(
+        temperatures=temperatures,
+        pressures=pressures,
         chem_gas=chem_gas,
         ln_ngas=ln_ngas,
         chem_cond=chem_cond,
@@ -38,7 +42,7 @@ def test_gibbs_energy_with_condensed_phase_normalized():
     assert jnp.allclose(out, expected)
 
 
-def test_gibbs_energies_vectorized_matches_scalar_non_normalized():
+def test_gibbs_energies_vectorized_non_normalized():
     chem_gas = ChemicalSetup(
         formula_matrix=jnp.zeros((1, 2)),
         hvector_func=lambda T: jnp.array([1.0, 2.0]),
@@ -48,18 +52,13 @@ def test_gibbs_energies_vectorized_matches_scalar_non_normalized():
     pressures = jnp.array([2.0, 2.0])
     ln_ngas = jnp.log(jnp.array([[2.0, 3.0], [2.0, 3.0]]))
 
-    expected = jnp.array(
-        [
-            gibbs_energy(
-                temperature=temperatures[i],
-                pressure=pressures[i],
-                chem_gas=chem_gas,
-                ln_ngas=ln_ngas[i],
-                nomalize=False,
-            )
-            for i in range(2)
-        ]
-    )
+    rt = R_gas_constant_si * temperatures
+    expected = []
+    for i in range(2):
+        ln_ntot = logsumexp(ln_ngas[i])
+        hvector_gas = jnp.array([1.0, 2.0]) + jnp.log(pressures[i]) + ln_ngas[i] - ln_ntot
+        expected.append(jnp.dot(jnp.exp(ln_ngas[i]), hvector_gas) * rt[i])
+    expected = jnp.array(expected)
 
     out = gibbs_energies(
         temperatures=temperatures,


### PR DESCRIPTION
## Summary

  This PR simplifies api/potential.py by implementing gibbs_energies directly with batched thermochemical inputs, using:

  - chem_gas.hvector_func(temperatures) -> (N, K_gas)
  - chem_cond.hvector_func(temperatures) -> (N, K_cond) (when condensates are provided)

  It removes the scalar-per-layer helper/vmap path and computes Gibbs energy fully in batched form.

  ## What changed

  - Refactored gibbs_energies to:
      - operate directly on batched arrays,
      - compute gas and condensate contributions via elementwise/broadcasted operations,
      - avoid per-layer scalar callback logic.
  - Added explicit shape checks:
      - temperatures, pressures: (N,)
      - ln_ngas: (N, K_gas)
      - ln_ncond (if provided): (N, K_cond)
  - Removed internal scalar helper usage from the public execution path.

  ### Files

  - src/exogibbs/api/potential.py
  - tests/unittests/api/potential_test.py (already aligned to gibbs_energies-only usage)

  ## Why

  - Aligns with the new species-last batched convention ((N, K)).
  - Makes the implementation more readable and explicit.
  - Reduces indirection from scalar wrappers when the API itself is profile/batch oriented.

  ## Validation

  Ran:

  pytest tests/unittests/api/potential_test.py

  Result: all tests passed (2 passed).
