### PR TITLE
api: add opt-in Newton solver diagnostics

### DIFF
--- a/src/exogibbs/api/equilibrium.py
+++ b/src/exogibbs/api/equilibrium.py
@@ -14,7 +14,7 @@ import jax.numpy as jnp
 from jax import tree_util
 import jax
 from exogibbs.api.chemistry import ChemicalSetup, ThermoState
-from exogibbs.optimize.minimize import minimize_gibbs
+from exogibbs.optimize.minimize import minimize_gibbs, minimize_gibbs_with_diagnostics
 
 Array = jax.Array
 
@@ -107,7 +107,8 @@ def equilibrium(
     Pref: float = 1.0,
     init: Optional[EquilibriumInit] = None,
     options: Optional[EquilibriumOptions] = None,
-) -> EquilibriumResult:
+    return_diagnostics: bool = False,
+) -> Union[EquilibriumResult, Tuple[EquilibriumResult, Mapping[str, Array]]]:
     """Compute equilibrium composition at (T, P, b) via Gibbs minimization.
 
     Args:
@@ -121,6 +122,8 @@ def equilibrium(
 
     Returns:
         EquilibriumResult with ln n, n, mole fractions x, and n_tot.
+        If ``return_diagnostics=True``, returns ``(result, diagnostics)`` where
+        diagnostics is a pytree-compatible mapping with solver metrics.
     """
     opts = options or EquilibriumOptions()
     A = setup.formula_matrix
@@ -137,22 +140,37 @@ def equilibrium(
 
     hfunc = setup.hvector_func
     state = ThermoState(T, lnP, b)
-    ln_n = minimize_gibbs(
-        state,
-        ln_nk0,
-        ln_ntot0,
-        A,
-        hfunc,
-        epsilon_crit=opts.epsilon_crit,
-        max_iter=opts.max_iter,
-    )
+    diagnostics = None
+    if return_diagnostics:
+        ln_n, diagnostics = minimize_gibbs_with_diagnostics(
+            state,
+            ln_nk0,
+            ln_ntot0,
+            A,
+            hfunc,
+            epsilon_crit=opts.epsilon_crit,
+            max_iter=opts.max_iter,
+        )
+    else:
+        ln_n = minimize_gibbs(
+            state,
+            ln_nk0,
+            ln_ntot0,
+            A,
+            hfunc,
+            epsilon_crit=opts.epsilon_crit,
+            max_iter=opts.max_iter,
+        )
 
     n = jnp.exp(ln_n)
     ntot = jnp.asarray(jnp.sum(n))
     x = n / jnp.clip(ntot, 1e-300)
-    return EquilibriumResult(
+    result = EquilibriumResult(
         ln_n=ln_n, n=n, x=x, ntot=ntot, iterations=None, metadata=None
     )
+    if return_diagnostics:
+        return result, diagnostics
+    return result
 
 def equilibrium_profile(
     setup: ChemicalSetup,
@@ -162,7 +180,8 @@ def equilibrium_profile(
     *,
     Pref: float = 1.0,
     options: Optional[EquilibriumOptions] = None,
-) -> EquilibriumResult:
+    return_diagnostics: bool = False,
+) -> Union[EquilibriumResult, Tuple[EquilibriumResult, Mapping[str, Array]]]:
     """Vectorized equilibrium along a 1D T/P profile (layers).
 
     This computes equilibrium independently for each (T[i], P[i]) pair while
@@ -175,6 +194,7 @@ def equilibrium_profile(
         b: Elemental abundances, shape (E,), shared across layers.
         Pref: Reference pressure (bar).
         options: Solver options.
+        return_diagnostics: If True, returns per-layer solver diagnostics.
 
     Returns:
         Batched EquilibriumResult with fields stacked over the leading dimension N:
@@ -193,6 +213,21 @@ def equilibrium_profile(
         raise ValueError("b must be a 1D array shared across layers.")
 
     # Vectorize over T and P; keep setup and b static. Pass Pref/options as kwargs.
+    if return_diagnostics:
+        layer_fn = jax.vmap(
+            lambda Ti, Pi: equilibrium(
+                setup,
+                Ti,
+                Pi,
+                b,
+                Pref=Pref,
+                options=options,
+                return_diagnostics=True,
+            ),
+            in_axes=(0, 0),
+        )
+        return layer_fn(T, P)
+
     layer_fn = jax.vmap(
         lambda Ti, Pi: equilibrium(
             setup,
@@ -201,6 +236,7 @@ def equilibrium_profile(
             b,
             Pref=Pref,
             options=options,
+            return_diagnostics=False,
         ),
         in_axes=(0, 0),
     )

--- a/src/exogibbs/optimize/minimize.py
+++ b/src/exogibbs/optimize/minimize.py
@@ -4,7 +4,7 @@ from jax import jacrev
 from jax.lax import while_loop, stop_gradient
 from jax.scipy.linalg import cho_factor
 from jax.scipy.linalg import cho_solve
-from typing import Tuple, Callable
+from typing import Tuple, Callable, Dict
 
 from exogibbs.api.chemistry import ThermoState
 from exogibbs.optimize.core import _A_diagn_At
@@ -150,7 +150,7 @@ def minimize_gibbs_core(
     hvector_func,
     epsilon_crit: float = 1.0e-11,
     max_iter: int = 1000,
-) -> Tuple[jnp.ndarray, float, int]:
+) -> Tuple[jnp.ndarray, float, int, jnp.ndarray]:
     """Compute log(number of species) by minimizing the Gibbs energy using the Lagrange multipliers method.
 
     Args:
@@ -167,6 +167,7 @@ def minimize_gibbs_core(
             - Final log number of species vector (n_species,).
             - Final log total number of species.
             - Number of iterations performed.
+            - Final residual norm used in convergence checks.
     """
 
     hvector = hvector_func(state.temperature)
@@ -199,10 +200,10 @@ def minimize_gibbs_core(
     )
     An = formula_matrix @ jnp.exp(ln_nk_init)
 
-    ln_nk, ln_tot, _, _, _, counter = while_loop(
+    ln_nk, ln_tot, _, _, epsilon, counter = while_loop(
         cond_fun, body_fun, (ln_nk_init, ln_ntot_init, gk, An, jnp.inf, 0)
     )
-    return ln_nk, ln_tot, counter
+    return ln_nk, ln_tot, counter, epsilon
 
 
 # Only function and scalar options are non-differentiable.
@@ -236,7 +237,7 @@ def minimize_gibbs(
     # arguments, which can become JAX Tracers under vmap/jit.
     @custom_vjp
     def _solve(inner_state: ThermoState, ln_nk0: jnp.ndarray, ln_ntot0: float) -> jnp.ndarray:
-        ln_nk, _, _ = minimize_gibbs_core(
+        ln_nk, _, _, _ = minimize_gibbs_core(
             inner_state,
             ln_nk0,
             ln_ntot0,
@@ -248,7 +249,7 @@ def minimize_gibbs(
         return ln_nk
 
     def _solve_fwd(inner_state: ThermoState, ln_nk0: jnp.ndarray, ln_ntot0: float):
-        ln_nk, ln_ntot, _ = minimize_gibbs_core(
+        ln_nk, ln_ntot, _, _ = minimize_gibbs_core(
             inner_state,
             ln_nk0,
             ln_ntot0,
@@ -295,6 +296,41 @@ def minimize_gibbs(
     ln_nk0 = stop_gradient(ln_nk_init)
     ln_ntot0 = stop_gradient(ln_ntot_init)
     return _solve(state, ln_nk0, ln_ntot0)
+
+
+def minimize_gibbs_with_diagnostics(
+    state: ThermoState,
+    ln_nk_init: jnp.ndarray,
+    ln_ntot_init: float,
+    formula_matrix: jnp.ndarray,
+    hvector_func: Callable[[float], jnp.ndarray],
+    epsilon_crit: float = 1.0e-11,
+    max_iter: int = 1000,
+) -> Tuple[jnp.ndarray, Dict[str, jnp.ndarray]]:
+    """Run Gibbs minimization and return lightweight convergence diagnostics."""
+    ln_nk, _, n_iter, final_residual = minimize_gibbs_core(
+        state,
+        ln_nk_init,
+        ln_ntot_init,
+        formula_matrix,
+        hvector_func,
+        epsilon_crit,
+        max_iter,
+    )
+    epsilon_crit_used = jnp.asarray(epsilon_crit, dtype=final_residual.dtype)
+    max_iter_used = jnp.asarray(max_iter, dtype=n_iter.dtype)
+    converged = final_residual <= epsilon_crit_used
+    hit_max_iter = (n_iter >= max_iter_used) & (~converged)
+
+    diagnostics = {
+        "n_iter": n_iter,
+        "converged": converged,
+        "hit_max_iter": hit_max_iter,
+        "final_residual": final_residual,
+        "epsilon_crit": epsilon_crit_used,
+        "max_iter": max_iter_used,
+    }
+    return ln_nk, diagnostics
 
 
 # Note: custom_vjp is defined inside minimize_gibbs to capture static arrays.

--- a/tests/unittests/api/equilibrium_api_test.py
+++ b/tests/unittests/api/equilibrium_api_test.py
@@ -157,6 +157,47 @@ def test_equilibrium_respects_init(monkeypatch):
     assert out.ntot.shape == ()
     assert jnp.isclose(out.x.sum(), 1.0)
 
+
+def test_equilibrium_return_diagnostics(monkeypatch):
+    E, K = 2, 3
+    A = jnp.array([[1, 0, 1], [0, 1, 0]], dtype=jnp.float32)
+    setup = FakeSetup(A)
+
+    def stub_minimize_gibbs_with_diagnostics(state, ln_nk0, ln_ntot0, A_in, hfunc, **kwargs):
+        assert A_in.shape == A.shape
+        ln_n = jnp.zeros((K,), dtype=jnp.float32)
+        diagnostics = {
+            "n_iter": jnp.asarray(7, dtype=jnp.int32),
+            "converged": jnp.asarray(True),
+            "hit_max_iter": jnp.asarray(False),
+            "final_residual": jnp.asarray(1.0e-12, dtype=jnp.float32),
+            "epsilon_crit": jnp.asarray(kwargs["epsilon_crit"], dtype=jnp.float32),
+            "max_iter": jnp.asarray(kwargs["max_iter"], dtype=jnp.int32),
+        }
+        return ln_n, diagnostics
+
+    monkeypatch.setattr(
+        "exogibbs.api.equilibrium.minimize_gibbs_with_diagnostics",
+        stub_minimize_gibbs_with_diagnostics,
+        raising=True,
+    )
+
+    b = jnp.array([1.0, 1.0], dtype=jnp.float32)
+    result, diagnostics = eqmod.equilibrium(
+        setup,
+        T=1000.0,
+        P=1.0,
+        b=b,
+        options=EquilibriumOptions(epsilon_crit=1e-11, max_iter=50),
+        return_diagnostics=True,
+    )
+
+    assert result.ln_n.shape == (K,)
+    assert bool(diagnostics["converged"])
+    assert not bool(diagnostics["hit_max_iter"])
+    assert int(diagnostics["n_iter"]) == 7
+    assert int(diagnostics["max_iter"]) == 50
+
 if __name__ == "__main__":
     chemsetup = chemsetup()
     b_vec = chemsetup.element_vector_reference

--- a/tests/unittests/api/equilibrium_profile_test.py
+++ b/tests/unittests/api/equilibrium_profile_test.py
@@ -59,3 +59,47 @@ def test_equilibrium_profile_shapes_and_values(monkeypatch):
     assert jnp.allclose(out.ntot, K)
     assert jnp.allclose(jnp.sum(out.x, axis=1), 1.0)
 
+
+def test_equilibrium_profile_return_diagnostics(monkeypatch):
+    E, K, N = 2, 3, 4
+    A = jnp.array([[1, 0, 1], [0, 1, 0]], dtype=jnp.float64)
+    setup = FakeSetup(A)
+
+    def stub_minimize_gibbs_with_diagnostics(state, ln_nk0, ln_ntot0, A_in, hfunc, **kwargs):
+        ln_n = jnp.zeros((K,), dtype=jnp.result_type(ln_nk0, A_in.dtype))
+        diagnostics = {
+            "n_iter": jnp.asarray(3, dtype=jnp.int32),
+            "converged": jnp.asarray(True),
+            "hit_max_iter": jnp.asarray(False),
+            "final_residual": jnp.asarray(1e-12, dtype=jnp.float64),
+            "epsilon_crit": jnp.asarray(kwargs["epsilon_crit"], dtype=jnp.float64),
+            "max_iter": jnp.asarray(kwargs["max_iter"], dtype=jnp.int32),
+        }
+        return ln_n, diagnostics
+
+    monkeypatch.setattr(
+        "exogibbs.api.equilibrium.minimize_gibbs_with_diagnostics",
+        stub_minimize_gibbs_with_diagnostics,
+        raising=True,
+    )
+
+    T = jnp.linspace(1000.0, 2000.0, N)
+    P = jnp.linspace(0.1, 1.0, N)
+    b = jnp.array([1.0, 2.0], dtype=jnp.float64)
+    out, diag = eqmod.equilibrium_profile(
+        setup,
+        T,
+        P,
+        b,
+        options=EquilibriumOptions(epsilon_crit=1e-11, max_iter=50),
+        return_diagnostics=True,
+    )
+
+    assert out.ln_n.shape == (N, K)
+    assert diag["n_iter"].shape == (N,)
+    assert diag["converged"].shape == (N,)
+    assert diag["hit_max_iter"].shape == (N,)
+    assert diag["final_residual"].shape == (N,)
+    assert jnp.all(diag["n_iter"] == 3)
+    assert jnp.all(diag["converged"])
+    assert not jnp.any(diag["hit_max_iter"])

--- a/tests/unittests/optimize/lagrange/hcosystem_test.py
+++ b/tests/unittests/optimize/lagrange/hcosystem_test.py
@@ -68,7 +68,7 @@ def test_minimize_gibbs_core_hco_system(hco_system_setup):
     setup = hco_system_setup
     
     # Run Gibbs minimization
-    ln_nk_result, ln_ntot_result, counter = minimize_gibbs_core(
+    ln_nk_result, ln_ntot_result, counter, _ = minimize_gibbs_core(
         setup['thermo_state'],
         setup['ln_nk'],
         setup['ln_ntot'],

--- a/tests/unittests/optimize/lagrange/minimize_test.py
+++ b/tests/unittests/optimize/lagrange/minimize_test.py
@@ -60,7 +60,7 @@ def test_minimize_gibbs_core_h_system(h_system_setup):
     setup = h_system_setup
     
     # Run Gibbs minimization
-    ln_nk_result, ln_ntot_result, counter = minimize_gibbs_core(
+    ln_nk_result, ln_ntot_result, counter, _ = minimize_gibbs_core(
         setup['thermo_state'],
         setup['ln_nk'],
         setup['ln_ntot'],


### PR DESCRIPTION
## Summary

  This PR adds opt-in Newton solver diagnostics for ExoGibbs equilibrium solves, with minimal/local changes and no
  algorithmic changes.

  It exposes per-solve (and per-layer under vmap) convergence visibility needed for upcoming scan-vs-vmap benchmarking.

  ## Motivation

  Before evaluating hot-start scan solves, we need explicit observability of current solver behavior:

  - iterations actually used
  - convergence vs max-iteration termination
  - final residual metric used by stopping criterion
  - effective epsilon_crit and max_iter per solve

  ## What Changed

  ### 1. Core solver diagnostics plumbing

  - Updated minimize_gibbs_core(...) to also return final residual (epsilon) from the existing stopping metric.
  - Added minimize_gibbs_with_diagnostics(...) returning:
      - n_iter
      - converged
      - hit_max_iter
      - final_residual
      - epsilon_crit
      - max_iter

  ### 2. API-level opt-in diagnostics

  - Added return_diagnostics: bool = False to:
      - equilibrium(...)
      - equilibrium_profile(...)
  - Default behavior unchanged.
  - If return_diagnostics=True, both APIs return:
      - (EquilibriumResult, diagnostics_dict)

  ### 3. Tests

  - Added/updated tests for diagnostics return path and profile batching behavior.
  - Adjusted tests for updated minimize_gibbs_core return arity.

  ## API Compatibility

  - Backward compatible by default (return_diagnostics=False).
  - No numerical-method change.
  - No debug printing / host callbacks introduced.
  - JAX-friendly diagnostics format (array-based mapping, vmap-compatible).

  ## Example Usage
 ```python
  res, diag = equilibrium_profile(
      setup, T_profile, P_profile, b_vec,
      options=EquilibriumOptions(epsilon_crit=1e-11, max_iter=300),
      return_diagnostics=True,
  )
  print(diag.n_iter) # iteration number 
```
  # per-layer diagnostics
  diag["n_iter"]
  diag["converged"]
  diag["hit_max_iter"]
  diag["final_residual"]
  diag["epsilon_crit"]
  diag["max_iter"]

  ## Validation

  Ran:

  - pytest tests/unittests/api/equilibrium_api_test.py
  - pytest tests/unittests/api/equilibrium_profile_test.py
  - pytest tests/unittests/optimize/lagrange/minimize_test.py
  - pytest tests/unittests/optimize/lagrange/hcosystem_test.py

  Result: 13 passed.
  - All of the unit tests passed