### PR TITLE
version: align runtime version with setuptools_scm

### DIFF
--- a/src/exogibbs/__init__.py
+++ b/src/exogibbs/__init__.py
@@ -1,8 +1,16 @@
-try:
-    from .ExoGibbs_version import __version__
-except Exception:
+from importlib import import_module
+from importlib.metadata import version as _pkg_version
+
+
+def _load_generated_version() -> str:
+    return import_module(".exogibbs_version", __name__).__version__
+
+
+def _load_version() -> str:
     try:
-        from importlib.metadata import version as _pkg_version
-        __version__ = _pkg_version("ExoGibbs")
-    except Exception:
-        __version__ = "0.0.0.dev0"
+        return _load_generated_version()
+    except (ImportError, AttributeError):
+        return _pkg_version("exogibbs")
+
+
+__version__ = _load_version()

--- a/tests/unittests/api/version_test.py
+++ b/tests/unittests/api/version_test.py
@@ -1,0 +1,16 @@
+import exogibbs
+from exogibbs import exogibbs_version
+
+
+def test_package_version_matches_scm_generated_module():
+    assert exogibbs.__version__ == exogibbs_version.__version__
+
+
+def test_load_version_falls_back_to_installed_metadata(monkeypatch):
+    def _raise_import_error():
+        raise ImportError("generated version module unavailable")
+
+    monkeypatch.setattr(exogibbs, "_load_generated_version", _raise_import_error)
+    monkeypatch.setattr(exogibbs, "_pkg_version", lambda name: "9.9.9")
+
+    assert exogibbs._load_version() == "9.9.9"


### PR DESCRIPTION
## Summary

  Align `exogibbs.__version__` with the existing `setuptools_scm` configuration so runtime version reporting matches
  build/install versioning.

  ## Motivation

  Version handling had drifted:

  - build/install version was already derived from `setuptools_scm`
  - runtime `exogibbs.__version__` still pointed at a removed/stale manual version path
  - editable installs and source-tree imports could therefore disagree with package metadata

  This change makes the SCM-managed version path the single runtime authority as well.

  ## Changes

  - Updated `src/exogibbs/__init__.py`
    - load `__version__` from the SCM-generated module `exogibbs.exogibbs_version`
    - keep a small fallback to `importlib.metadata.version("exogibbs")` if the generated module is unavailable
  - Added `tests/unittests/api/version_test.py`
    - verifies `exogibbs.__version__` matches `exogibbs.exogibbs_version.__version__`
    - verifies metadata fallback behavior

  ## Behavior After This PR

  These paths now resolve consistently through the SCM-managed version flow:

  - build/install version
  - source-tree import-time `exogibbs.__version__`
  - editable-install `exogibbs.__version__`

  ## User-Facing Impact

  No normal import path changed:

  ```python
  import exogibbs
  print(exogibbs.__version__)
  ```

  The only behavioral change is that __version__ now reflects the SCM/tag-derived version instead of any stale manual
  version file.

  ## Release / Tag Workflow

  No workflow change is required.

  - setuptools_scm remains the single authoritative version source
  - release tags continue to determine release versions
  - runtime __version__ now follows the same SCM-generated path

  ## Testing

  Ran:

  pytest tests/unittests/api/version_test.py
