### PR TITLE
optimize: add condensate diagnostics wrapper

### DIFF
--- a/documents/ipynb/pipm/rgie/fastchem_cond_one.py
+++ b/documents/ipynb/pipm/rgie/fastchem_cond_one.py
@@ -93,6 +93,7 @@ print(formula_matrix_cond_eff)
 
 
 from exogibbs.optimize.pipm_rgie_cond import minimize_gibbs_cond_core
+from exogibbs.optimize.pipm_rgie_cond import minimize_gibbs_cond_with_diagnostics
 import jax.numpy as jnp
 from exogibbs.api.chemistry import ThermoState
 
@@ -153,12 +154,8 @@ thermo_state = ThermoState(
 )
 
 
-def pipm_fori_body(i, state):
-    ln_nk, ln_mk, ln_ntot = state
-    epsilon = epsilons[i]
-    rcrit = jnp.exp(epsilon)
-
-    ln_nk, ln_mk, ln_ntot, _ = minimize_gibbs_cond_core(
+def run_condensate_step(ln_nk, ln_mk, ln_ntot, epsilon, residual_crit):
+    return minimize_gibbs_cond_with_diagnostics(
         thermo_state,
         ln_nk_init=ln_nk,
         ln_mk_init=ln_mk,
@@ -168,11 +165,22 @@ def pipm_fori_body(i, state):
         hvector_func=gas.hvector_func,
         hvector_cond_func=cond.hvector_func,
         epsilon=epsilon,
-        residual_crit=rcrit,
+        residual_crit=residual_crit,
         max_iter=100,
         debug_nan=False,
     )
 
+
+def pipm_fori_body(i, state):
+    ln_nk, ln_mk, ln_ntot = state
+    epsilon = epsilons[i]
+    rcrit = jnp.exp(epsilon)
+
+    ln_nk, ln_mk, ln_ntot, diagnostics = run_condensate_step(
+        ln_nk, ln_mk, ln_ntot, epsilon, rcrit
+    )
+
+    _ = diagnostics
     return (ln_nk, ln_mk, ln_ntot)
 
 
@@ -183,8 +191,15 @@ ln_nk, ln_mk, ln_ntot = lax.fori_loop(
     (ln_nk, ln_mk, ln_ntot),
 )
 
+final_epsilon = epsilons[-1]
+final_rcrit = jnp.exp(final_epsilon)
+_, _, _, diagnostics = run_condensate_step(
+    ln_nk, ln_mk, ln_ntot, final_epsilon, final_rcrit
+)
+
 vmr_exogibbs = np.exp(ln_nk[29:])/np.sum(np.exp(ln_nk))
 print(ln_nk)
+print("Final condensate diagnostics:", diagnostics)
 #print(vmr_exogibbs)
 
 

--- a/documents/ipynb/pipm/rgie/fastchem_cond_prof.py
+++ b/documents/ipynb/pipm/rgie/fastchem_cond_prof.py
@@ -114,7 +114,7 @@ print(formula_matrix_cond_eff)
 # In[5]:
 
 
-from exogibbs.optimize.pipm_rgie_cond import minimize_gibbs_cond_core
+from exogibbs.optimize.pipm_rgie_cond import minimize_gibbs_cond_with_diagnostics
 import jax.numpy as jnp
 from exogibbs.api.chemistry import ThermoState
 
@@ -176,7 +176,7 @@ def minimize_gibbs_cond(
         epsilon = epsilons[i]
         rcrit = jnp.exp(epsilon)
 
-        ln_nk, ln_mk, ln_ntot, _ = minimize_gibbs_cond_core(
+        ln_nk, ln_mk, ln_ntot, diagnostics = minimize_gibbs_cond_with_diagnostics(
             thermo_state,
             ln_nk_init=ln_nk,
             ln_mk_init=ln_mk,
@@ -190,6 +190,7 @@ def minimize_gibbs_cond(
             max_iter=100,
         )
 
+        _ = diagnostics
         return (ln_nk, ln_mk, ln_ntot)
 
     ln_nk, ln_mk, ln_ntot = lax.fori_loop(
@@ -200,6 +201,35 @@ def minimize_gibbs_cond(
     )
 
     return ln_nk, ln_mk, ln_ntot
+
+
+def minimize_gibbs_cond_diagnostics(
+    temperature,
+    ln_normalized_pressure,
+    ln_nk_init,
+    ln_mk_init,
+    ln_ntot_init,
+):
+    thermo_state = ThermoState(
+        temperature=temperature,
+        ln_normalized_pressure=ln_normalized_pressure,
+        element_vector=b_ref,
+    )
+    epsilon = jnp.asarray(-40.0)
+    residual_crit = jnp.exp(epsilon)
+    return minimize_gibbs_cond_with_diagnostics(
+        thermo_state,
+        ln_nk_init=ln_nk_init,
+        ln_mk_init=ln_mk_init,
+        ln_ntot_init=ln_ntot_init,
+        formula_matrix=formula_matrix_gas_eff,
+        formula_matrix_cond=formula_matrix_cond_eff,
+        hvector_func=gas.hvector_func,
+        hvector_cond_func=cond.hvector_func,
+        epsilon=epsilon,
+        residual_crit=residual_crit,
+        max_iter=100,
+    )
 
 from jax import vmap
 from jax import jit
@@ -245,6 +275,14 @@ ln_nk, ln_mk, ln_ntot = jit_vmap_minimize_gibbs_cond(
 )
 end = time.time()
 print("Computation time (s):", end - start)
+_, _, _, profile_diag0 = minimize_gibbs_cond_diagnostics(
+    jnp.array(temperatures)[0],
+    jnp.array(ln_normalized_pressures)[0],
+    ln_nk_init[0],
+    ln_mk_init[0],
+    ln_ntot_init[0],
+)
+print("Layer-0 condensate diagnostics:", profile_diag0)
 
 ln_ntot = logsumexp(ln_nk, axis=1)[:, None]
 

--- a/src/exogibbs/optimize/minimize_cond.py
+++ b/src/exogibbs/optimize/minimize_cond.py
@@ -1,0 +1,11 @@
+"""Backward-compatible import path for condensate minimization.
+
+This module preserves the legacy ``minimize_gibbs_cond_core`` import while also
+exposing a diagnostics-returning wrapper around the active-in-practice RGIE
+condensate solver used by the repository examples.
+"""
+
+from exogibbs.optimize.pdipm_cond import minimize_gibbs_cond_core
+from exogibbs.optimize.pipm_rgie_cond import minimize_gibbs_cond_with_diagnostics
+
+__all__ = ["minimize_gibbs_cond_core", "minimize_gibbs_cond_with_diagnostics"]

--- a/src/exogibbs/optimize/pipm_rgie_cond.py
+++ b/src/exogibbs/optimize/pipm_rgie_cond.py
@@ -3,7 +3,7 @@ from jax import debug as jdebug
 from jax.lax import while_loop
 from jax.lax import cond
 from jax.scipy.linalg import lu_factor, lu_solve
-from typing import Tuple, Optional
+from typing import Dict, Tuple, Optional
 
 from exogibbs.api.chemistry import ThermoState
 from exogibbs.optimize.core import _A_diagn_At
@@ -287,7 +287,127 @@ def _update_all(
     )
     if debug_nan:
         _debug_array("residual", jnp.array([residual]), iter_count)
-    return ln_nk, ln_mk, ln_ntot, gk, An, Am, residual
+    return ln_nk, ln_mk, ln_ntot, gk, An, Am, residual, lam
+
+
+def _contains_invalid_numbers(*arrays) -> jnp.ndarray:
+    invalid_flags = []
+    for array in arrays:
+        arr = jnp.asarray(array)
+        invalid_flags.append(jnp.any(jnp.isnan(arr) | jnp.isinf(arr)))
+    return jnp.any(jnp.stack(invalid_flags))
+
+
+def _minimize_gibbs_cond_core_impl(
+    state: ThermoState,
+    ln_nk_init: jnp.ndarray,
+    ln_mk_init: jnp.ndarray,
+    ln_ntot_init: float,
+    formula_matrix: jnp.ndarray,
+    formula_matrix_cond: jnp.ndarray,
+    hvector_func,
+    hvector_cond_func,
+    epsilon: float,
+    residual_crit: float = 1.0e-11,
+    max_iter: int = 1000,
+    element_indices: Optional[jnp.ndarray] = None,
+    debug_nan: bool = False,
+) -> Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+    """Shared implementation for condensate solves and diagnostics wrappers."""
+
+    n_elements = formula_matrix.shape[0]
+    if formula_matrix_cond.shape[0] != n_elements:
+        raise ValueError(
+            "formula_matrix and formula_matrix_cond must have the same number of element rows."
+        )
+
+    b = (
+        jnp.asarray(state.element_vector)
+        if element_indices is None
+        else jnp.asarray(state.element_vector)[jnp.asarray(element_indices)]
+    )
+    if b.shape[0] != n_elements:
+        raise ValueError(
+            "ThermoState.element_vector length does not match the number of element rows "
+            f"in the formula matrices (got {b.shape[0]}, expected {n_elements}). "
+            "Provide element_indices that map the state vector onto the reduced element set."
+        )
+
+    hvector = hvector_func(state.temperature)
+    hvector_cond = hvector_cond_func(state.temperature)
+
+    def cond_fun(carry):
+        *_, residual, counter, _last_step_size = carry
+        return (residual > residual_crit) & (counter < max_iter)
+
+    def body_fun(carry):
+        ln_nk, ln_mk, ln_ntot, gk, An, Am, residual, counter, _last_step_size = carry
+        (
+            ln_nk_new,
+            ln_mk_new,
+            ln_ntot_new,
+            gk,
+            An,
+            Am,
+            residual,
+            last_step_size,
+        ) = _update_all(
+            ln_nk,
+            ln_mk,
+            ln_ntot,
+            formula_matrix,
+            formula_matrix_cond,
+            b,
+            state.temperature,
+            state.ln_normalized_pressure,
+            hvector,
+            hvector_cond,
+            gk,
+            An,
+            Am,
+            epsilon,
+            counter,
+            debug_nan,
+        )
+        return (
+            ln_nk_new,
+            ln_mk_new,
+            ln_ntot_new,
+            gk,
+            An,
+            Am,
+            residual,
+            counter + 1,
+            last_step_size,
+        )
+
+    gk = _compute_gk(
+        state.temperature,
+        ln_nk_init,
+        ln_ntot_init,
+        hvector,
+        state.ln_normalized_pressure,
+    )
+    An_in = formula_matrix @ jnp.exp(ln_nk_init)
+    Am_in = formula_matrix_cond @ jnp.exp(ln_mk_init)
+    init_last_step_size = jnp.asarray(0.0, dtype=ln_nk_init.dtype)
+
+    ln_nk, ln_mk, ln_ntot, _gk, _An, _Am, residual, counter, last_step_size = while_loop(
+        cond_fun,
+        body_fun,
+        (
+            ln_nk_init,
+            ln_mk_init,
+            ln_ntot_init,
+            gk,
+            An_in,
+            Am_in,
+            jnp.inf,
+            0,
+            init_last_step_size,
+        ),
+    )
+    return ln_nk, ln_mk, ln_ntot, counter, residual, last_step_size
 
 
 def minimize_gibbs_cond_core(
@@ -328,75 +448,79 @@ def minimize_gibbs_cond_core(
             - Number of iterations performed.
     """
 
-    n_elements = formula_matrix.shape[0]
-    if formula_matrix_cond.shape[0] != n_elements:
-        raise ValueError(
-            "formula_matrix and formula_matrix_cond must have the same number of element rows."
-        )
-
-    b = (
-        jnp.asarray(state.element_vector)
-        if element_indices is None
-        else jnp.asarray(state.element_vector)[jnp.asarray(element_indices)]
-    )
-    if b.shape[0] != n_elements:
-        raise ValueError(
-            "ThermoState.element_vector length does not match the number of element rows "
-            f"in the formula matrices (got {b.shape[0]}, expected {n_elements}). "
-            "Provide element_indices that map the state vector onto the reduced element set."
-        )
-
-    hvector = hvector_func(state.temperature)
-    hvector_cond = hvector_cond_func(state.temperature)
-
-    def cond_fun(carry):
-        *_, residual, counter = carry
-        return (residual > residual_crit) & (counter < max_iter)
-
-    def body_fun(carry):
-        ln_nk, ln_mk, ln_ntot, gk, An, Am, residual, counter = carry
-        ln_nk_new, ln_mk_new, ln_ntot_new, gk, An, Am, residual = _update_all(
-            ln_nk,
-            ln_mk,
-            ln_ntot,
-            formula_matrix,
-            formula_matrix_cond,
-            b,
-            state.temperature,
-            state.ln_normalized_pressure,
-            hvector,
-            hvector_cond,
-            gk,
-            An,
-            Am,
-            epsilon,
-            counter,
-            debug_nan,
-        )
-        return (
-            ln_nk_new,
-            ln_mk_new,
-            ln_ntot_new,
-            gk,
-            An,
-            Am,
-            residual,
-            counter + 1,
-        )
-
-    gk = _compute_gk(
-        state.temperature,
+    ln_nk, ln_mk, ln_ntot, counter, _residual, _last_step_size = _minimize_gibbs_cond_core_impl(
+        state,
         ln_nk_init,
+        ln_mk_init,
         ln_ntot_init,
-        hvector,
-        state.ln_normalized_pressure,
-    )
-    An_in = formula_matrix @ jnp.exp(ln_nk_init)
-    Am_in = formula_matrix_cond @ jnp.exp(ln_mk_init)
-
-    ln_nk, ln_mk, ln_ntot, gk, Am, An, residual, counter = while_loop(
-        cond_fun,
-        body_fun,
-        (ln_nk_init, ln_mk_init, ln_ntot_init, gk, An_in, Am_in, jnp.inf, 0),
+        formula_matrix,
+        formula_matrix_cond,
+        hvector_func,
+        hvector_cond_func,
+        epsilon,
+        residual_crit=residual_crit,
+        max_iter=max_iter,
+        element_indices=element_indices,
+        debug_nan=debug_nan,
     )
     return ln_nk, ln_mk, ln_ntot, counter
+
+
+def minimize_gibbs_cond_with_diagnostics(
+    state: ThermoState,
+    ln_nk_init: jnp.ndarray,
+    ln_mk_init: jnp.ndarray,
+    ln_ntot_init: float,
+    formula_matrix: jnp.ndarray,
+    formula_matrix_cond: jnp.ndarray,
+    hvector_func,
+    hvector_cond_func,
+    epsilon: float,
+    residual_crit: float = 1.0e-11,
+    max_iter: int = 1000,
+    element_indices: Optional[jnp.ndarray] = None,
+    debug_nan: bool = False,
+) -> Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, Dict[str, jnp.ndarray]]:
+    """Run the active condensate solver and return lightweight convergence diagnostics."""
+
+    ln_nk, ln_mk, ln_ntot, n_iter, final_residual, last_step_size = _minimize_gibbs_cond_core_impl(
+        state,
+        ln_nk_init,
+        ln_mk_init,
+        ln_ntot_init,
+        formula_matrix,
+        formula_matrix_cond,
+        hvector_func,
+        hvector_cond_func,
+        epsilon,
+        residual_crit=residual_crit,
+        max_iter=max_iter,
+        element_indices=element_indices,
+        debug_nan=debug_nan,
+    )
+
+    residual_crit_used = jnp.asarray(residual_crit, dtype=final_residual.dtype)
+    max_iter_used = jnp.asarray(max_iter, dtype=n_iter.dtype)
+    epsilon_used = jnp.asarray(epsilon, dtype=final_residual.dtype)
+    converged = final_residual <= residual_crit_used
+    hit_max_iter = (n_iter >= max_iter_used) & (~converged)
+    invalid_numbers_detected = _contains_invalid_numbers(
+        ln_nk,
+        ln_mk,
+        ln_ntot,
+        last_step_size,
+    )
+
+    diagnostics = {
+        "n_iter": n_iter,
+        "converged": converged,
+        "hit_max_iter": hit_max_iter,
+        "final_residual": final_residual,
+        "residual_crit": residual_crit_used,
+        "max_iter": max_iter_used,
+        "epsilon": epsilon_used,
+        "final_step_size": last_step_size,
+        "invalid_numbers_detected": invalid_numbers_detected,
+        "debug_nan": jnp.asarray(debug_nan),
+    }
+    return ln_nk, ln_mk, ln_ntot, diagnostics

--- a/tests/unittests/optimize/minimize_cond_diagnostics_test.py
+++ b/tests/unittests/optimize/minimize_cond_diagnostics_test.py
@@ -1,0 +1,64 @@
+import jax.numpy as jnp
+from jax import config
+
+config.update("jax_enable_x64", True)
+
+from exogibbs.api.chemistry import ThermoState
+from exogibbs.optimize.pipm_rgie_cond import minimize_gibbs_cond_with_diagnostics
+
+
+def test_minimize_gibbs_cond_with_diagnostics_smoke():
+    formula_matrix = jnp.array([[1.0]], dtype=jnp.float64)
+    formula_matrix_cond = jnp.array([[1.0]], dtype=jnp.float64)
+
+    state = ThermoState(
+        temperature=jnp.asarray(1000.0, dtype=jnp.float64),
+        ln_normalized_pressure=jnp.asarray(0.0, dtype=jnp.float64),
+        element_vector=jnp.array([1.0], dtype=jnp.float64),
+    )
+
+    ln_nk, ln_mk, ln_ntot, diagnostics = minimize_gibbs_cond_with_diagnostics(
+        state,
+        ln_nk_init=jnp.array([0.0], dtype=jnp.float64),
+        ln_mk_init=jnp.array([0.0], dtype=jnp.float64),
+        ln_ntot_init=jnp.asarray(0.0, dtype=jnp.float64),
+        formula_matrix=formula_matrix,
+        formula_matrix_cond=formula_matrix_cond,
+        hvector_func=lambda temperature: jnp.array([0.0], dtype=jnp.float64),
+        hvector_cond_func=lambda temperature: jnp.array([2.0], dtype=jnp.float64),
+        epsilon=-5.0,
+        residual_crit=1.0e-8,
+        max_iter=0,
+    )
+
+    assert ln_nk.shape == (1,)
+    assert ln_mk.shape == (1,)
+    assert ln_ntot.shape == ()
+
+    expected_fields = {
+        "n_iter",
+        "converged",
+        "hit_max_iter",
+        "final_residual",
+        "residual_crit",
+        "max_iter",
+        "epsilon",
+        "final_step_size",
+        "invalid_numbers_detected",
+        "debug_nan",
+    }
+    assert expected_fields.issubset(diagnostics.keys())
+
+    assert diagnostics["n_iter"].shape == ()
+    assert diagnostics["final_residual"].shape == ()
+    assert diagnostics["residual_crit"].shape == ()
+    assert diagnostics["epsilon"].shape == ()
+    assert diagnostics["final_step_size"].shape == ()
+
+    assert int(diagnostics["n_iter"]) == 0
+    assert int(diagnostics["max_iter"]) == 0
+    assert not bool(diagnostics["converged"])
+    assert bool(diagnostics["hit_max_iter"])
+    assert not bool(diagnostics["invalid_numbers_detected"])
+    assert not bool(diagnostics["debug_nan"])
+    assert not (bool(diagnostics["converged"]) and bool(diagnostics["hit_max_iter"]))


### PR DESCRIPTION
## Summary

  This PR implements Phase 0 instrumentation for the condensate-enabled solver path.

  It adds a diagnostics-returning wrapper around the active condensate solver used in practice, exposes that wrapper
  through the compatibility module, and wires minimal example/test coverage so convergence behavior can be inspected
  without changing solver math.

  ## Motivation

  The condensate-enabled path currently lags behind the gas-only path mainly in diagnostics visibility and API
  usability.

  This PR is intentionally limited to instrumentation:
  - no algorithm redesign
  - no hot-start implementation
  - no epsilon-schedule redesign
  - no gas-only behavior changes

  The goal is to make convergence behavior visible first, so later phases can be guided by actual data rather than
  speculation.

  ## What Changed

  ### Active condensate solver diagnostics
  In [`src/exogibbs/optimize/pipm_rgie_cond.py`](/home/kawahara/exogibbs/src/exogibbs/optimize/pipm_rgie_cond.py), this
  PR adds:

  - a shared internal implementation path for the active RGIE condensate solver
  - a new diagnostics-returning wrapper:
    - `minimize_gibbs_cond_with_diagnostics`

  The new wrapper returns:
  - `ln_nk`
  - `ln_mk`
  - `ln_ntot`
  - `diagnostics`

  Current diagnostics fields:
  - `n_iter`
  - `converged`
  - `hit_max_iter`
  - `final_residual`
  - `residual_crit`
  - `max_iter`
  - `epsilon`
  - `final_step_size`
  - `invalid_numbers_detected`
  - `debug_nan`

  ### Compatibility export
  In [`src/exogibbs/optimize/minimize_cond.py`](/home/kawahara/exogibbs/src/exogibbs/optimize/minimize_cond.py), this PR
  exposes the new diagnostics wrapper through the compatibility module while preserving the legacy
  `minimize_gibbs_cond_core` import.

  ### Minimal example usage
  Minimal diagnostics usage was added to:
  - [`documents/ipynb/pipm/rgie/fastchem_cond_one.py`](/home/kawahara/exogibbs/documents/ipynb/pipm/rgie/
  fastchem_cond_one.py)
  - [`documents/ipynb/pipm/rgie/fastchem_cond_prof.py`](/home/kawahara/exogibbs/documents/ipynb/pipm/rgie/
  fastchem_cond_prof.py)

  This is only enough to exercise and print the new diagnostics path.

  ### Focused test
  A smoke test was added in:
  - [`tests/unittests/optimize/minimize_cond_diagnostics_test.py`](/home/kawahara/exogibbs/tests/unittests/optimize/
  minimize_cond_diagnostics_test.py)

  It verifies:
  - the diagnostics API runs
  - expected fields are present
  - scalar shapes are sensible
  - `converged` / `hit_max_iter` semantics are internally consistent

  ## What Did Not Change

  This PR does not:
  - change the condensate numerical method
  - add hot start
  - refactor profile solving structure
  - unify condensate entry points broadly
  - change gas-only production behavior

  ## Notes

  Two tiny instrumentation-specific details were handled during implementation:

  1. `final_step_size` now has a finite zero-iteration default instead of a `NaN` sentinel.
     This keeps diagnostics usable for `max_iter=0` smoke tests.

  2. `invalid_numbers_detected` is scoped to final state / step-size outputs rather than the intentional pre-iteration
  residual sentinel.
     This avoids false positives for zero-iteration diagnostics calls.

  These changes are limited to diagnostics reporting and do not alter the solver update math.

  ## Testing

  Ran:
  - `python -m py_compile src/exogibbs/optimize/pipm_rgie_cond.py`
  - `python -m py_compile src/exogibbs/optimize/minimize_cond.py`
  - `python -m py_compile tests/unittests/optimize/minimize_cond_diagnostics_test.py`
  - `pytest tests/unittests/optimize/minimize_cond_diagnostics_test.py`

  ## Recommended Next Step

  Phase 1 should build a slightly more usable condensate-facing diagnostics/result layer above this wrapper, so callers
  can request structured convergence information without manually managing epsilon scheduling in example code.
