### PR TITLE
optimize: add structured condensate api

### DIFF
--- a/documents/ipynb/pipm/rgie/fastchem_cond_one.py
+++ b/documents/ipynb/pipm/rgie/fastchem_cond_one.py
@@ -93,7 +93,8 @@ print(formula_matrix_cond_eff)
 
 
 from exogibbs.optimize.pipm_rgie_cond import minimize_gibbs_cond_core
-from exogibbs.optimize.pipm_rgie_cond import minimize_gibbs_cond_with_diagnostics
+from exogibbs.optimize.minimize_cond import CondensateEquilibriumInit
+from exogibbs.optimize.minimize_cond import minimize_gibbs_cond as structured_minimize_gibbs_cond
 import jax.numpy as jnp
 from exogibbs.api.chemistry import ThermoState
 
@@ -154,12 +155,10 @@ thermo_state = ThermoState(
 )
 
 
-def run_condensate_step(ln_nk, ln_mk, ln_ntot, epsilon, residual_crit):
-    return minimize_gibbs_cond_with_diagnostics(
+def run_condensate_step(init, epsilon, residual_crit):
+    return structured_minimize_gibbs_cond(
         thermo_state,
-        ln_nk_init=ln_nk,
-        ln_mk_init=ln_mk,
-        ln_ntot_init=ln_ntot,
+        init=init,
         formula_matrix=formula_matrix_gas_eff,
         formula_matrix_cond=formula_matrix_cond_eff,
         hvector_func=gas.hvector_func,
@@ -171,31 +170,34 @@ def run_condensate_step(ln_nk, ln_mk, ln_ntot, epsilon, residual_crit):
     )
 
 
-def pipm_fori_body(i, state):
-    ln_nk, ln_mk, ln_ntot = state
+init = CondensateEquilibriumInit(
+    ln_nk=ln_nk,
+    ln_mk=ln_mk,
+    ln_ntot=ln_ntot,
+)
+
+
+def pipm_fori_body(i, init_state):
     epsilon = epsilons[i]
     rcrit = jnp.exp(epsilon)
-
-    ln_nk, ln_mk, ln_ntot, diagnostics = run_condensate_step(
-        ln_nk, ln_mk, ln_ntot, epsilon, rcrit
-    )
-
-    _ = diagnostics
-    return (ln_nk, ln_mk, ln_ntot)
+    result = run_condensate_step(init_state, epsilon, rcrit)
+    return result.to_init()
 
 
-ln_nk, ln_mk, ln_ntot = lax.fori_loop(
+final_init = lax.fori_loop(
     0,
     n_step,
     pipm_fori_body,
-    (ln_nk, ln_mk, ln_ntot),
+    init,
 )
 
 final_epsilon = epsilons[-1]
 final_rcrit = jnp.exp(final_epsilon)
-_, _, _, diagnostics = run_condensate_step(
-    ln_nk, ln_mk, ln_ntot, final_epsilon, final_rcrit
-)
+final_result = run_condensate_step(final_init, final_epsilon, final_rcrit)
+ln_nk = final_result.ln_nk
+ln_mk = final_result.ln_mk
+ln_ntot = final_result.ln_ntot
+diagnostics = final_result.diagnostics.asdict()
 
 vmr_exogibbs = np.exp(ln_nk[29:])/np.sum(np.exp(ln_nk))
 print(ln_nk)

--- a/documents/ipynb/pipm/rgie/fastchem_cond_prof.py
+++ b/documents/ipynb/pipm/rgie/fastchem_cond_prof.py
@@ -114,7 +114,8 @@ print(formula_matrix_cond_eff)
 # In[5]:
 
 
-from exogibbs.optimize.pipm_rgie_cond import minimize_gibbs_cond_with_diagnostics
+from exogibbs.optimize.minimize_cond import CondensateEquilibriumInit
+from exogibbs.optimize.minimize_cond import minimize_gibbs_cond as structured_minimize_gibbs_cond
 import jax.numpy as jnp
 from exogibbs.api.chemistry import ThermoState
 
@@ -145,7 +146,7 @@ from jax.scipy.special import logsumexp
 init_setup = "gas_only"  # "zeros" or "gas_only"
 
 
-def minimize_gibbs_cond(
+def minimize_gibbs_cond_layer(
     temperature,
     ln_normalized_pressure,
     ln_nk_init,
@@ -176,11 +177,13 @@ def minimize_gibbs_cond(
         epsilon = epsilons[i]
         rcrit = jnp.exp(epsilon)
 
-        ln_nk, ln_mk, ln_ntot, diagnostics = minimize_gibbs_cond_with_diagnostics(
+        result = structured_minimize_gibbs_cond(
             thermo_state,
-            ln_nk_init=ln_nk,
-            ln_mk_init=ln_mk,
-            ln_ntot_init=ln_ntot,
+            init=CondensateEquilibriumInit(
+                ln_nk=ln_nk,
+                ln_mk=ln_mk,
+                ln_ntot=ln_ntot,
+            ),
             formula_matrix=formula_matrix_gas_eff,
             formula_matrix_cond=formula_matrix_cond_eff,
             hvector_func=gas.hvector_func,
@@ -190,8 +193,7 @@ def minimize_gibbs_cond(
             max_iter=100,
         )
 
-        _ = diagnostics
-        return (ln_nk, ln_mk, ln_ntot)
+        return result.ln_nk, result.ln_mk, result.ln_ntot
 
     ln_nk, ln_mk, ln_ntot = lax.fori_loop(
         0,
@@ -217,11 +219,13 @@ def minimize_gibbs_cond_diagnostics(
     )
     epsilon = jnp.asarray(-40.0)
     residual_crit = jnp.exp(epsilon)
-    return minimize_gibbs_cond_with_diagnostics(
+    return structured_minimize_gibbs_cond(
         thermo_state,
-        ln_nk_init=ln_nk_init,
-        ln_mk_init=ln_mk_init,
-        ln_ntot_init=ln_ntot_init,
+        init=CondensateEquilibriumInit(
+            ln_nk=ln_nk_init,
+            ln_mk=ln_mk_init,
+            ln_ntot=ln_ntot_init,
+        ),
         formula_matrix=formula_matrix_gas_eff,
         formula_matrix_cond=formula_matrix_cond_eff,
         hvector_func=gas.hvector_func,
@@ -260,6 +264,17 @@ elif init_setup == "zeros":
 else:
     raise ValueError("Invalid init_setup option")
 
+def minimize_gibbs_cond(temperature, ln_normalized_pressure, ln_nk_init, ln_mk_init, ln_ntot_init):
+    result = minimize_gibbs_cond_layer(
+        temperature,
+        ln_normalized_pressure,
+        ln_nk_init,
+        ln_mk_init,
+        ln_ntot_init,
+    )
+    return result
+
+
 vmap_minimize_gibbs_cond = vmap(minimize_gibbs_cond, in_axes=(0, 0, 0, 0, 0))
 jit_vmap_minimize_gibbs_cond = jit(vmap_minimize_gibbs_cond)
 
@@ -275,14 +290,14 @@ ln_nk, ln_mk, ln_ntot = jit_vmap_minimize_gibbs_cond(
 )
 end = time.time()
 print("Computation time (s):", end - start)
-_, _, _, profile_diag0 = minimize_gibbs_cond_diagnostics(
+profile_result0 = minimize_gibbs_cond_diagnostics(
     jnp.array(temperatures)[0],
     jnp.array(ln_normalized_pressures)[0],
     ln_nk_init[0],
     ln_mk_init[0],
     ln_ntot_init[0],
 )
-print("Layer-0 condensate diagnostics:", profile_diag0)
+print("Layer-0 condensate diagnostics:", profile_result0.diagnostics.asdict())
 
 ln_ntot = logsumexp(ln_nk, axis=1)[:, None]
 

--- a/src/exogibbs/optimize/minimize_cond.py
+++ b/src/exogibbs/optimize/minimize_cond.py
@@ -1,11 +1,202 @@
-"""Backward-compatible import path for condensate minimization.
+"""Backward-compatible import path and structured API for condensate minimization."""
 
-This module preserves the legacy ``minimize_gibbs_cond_core`` import while also
-exposing a diagnostics-returning wrapper around the active-in-practice RGIE
-condensate solver used by the repository examples.
-"""
+from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Optional
+
+import jax
+import jax.numpy as jnp
+from jax import tree_util
+
+from exogibbs.api.chemistry import ThermoState
 from exogibbs.optimize.pdipm_cond import minimize_gibbs_cond_core
-from exogibbs.optimize.pipm_rgie_cond import minimize_gibbs_cond_with_diagnostics
+from exogibbs.optimize.pipm_rgie_cond import (
+    minimize_gibbs_cond_with_diagnostics as _minimize_gibbs_cond_with_diagnostics_raw,
+)
 
-__all__ = ["minimize_gibbs_cond_core", "minimize_gibbs_cond_with_diagnostics"]
+Array = jax.Array
+
+
+@tree_util.register_pytree_node_class
+@dataclass(frozen=True)
+class CondensateEquilibriumInit:
+    """Explicit condensate solver initialization state.
+
+    This is intentionally small and can be reused as a future hot-start carrier.
+    """
+
+    ln_nk: Optional[Array] = None
+    ln_mk: Optional[Array] = None
+    ln_ntot: Optional[Array] = None
+
+    def tree_flatten(self):
+        children = (self.ln_nk, self.ln_mk, self.ln_ntot)
+        return children, None
+
+    @classmethod
+    def tree_unflatten(cls, aux_data, children):
+        del aux_data
+        ln_nk, ln_mk, ln_ntot = children
+        return cls(ln_nk=ln_nk, ln_mk=ln_mk, ln_ntot=ln_ntot)
+
+
+@tree_util.register_pytree_node_class
+@dataclass(frozen=True)
+class CondensateEquilibriumDiagnostics:
+    """Lightweight convergence diagnostics for one condensate solve."""
+
+    n_iter: Array
+    converged: Array
+    hit_max_iter: Array
+    final_residual: Array
+    residual_crit: Array
+    max_iter: Array
+    epsilon: Array
+    final_step_size: Array
+    invalid_numbers_detected: Array
+    debug_nan: Array
+
+    def tree_flatten(self):
+        children = (
+            self.n_iter,
+            self.converged,
+            self.hit_max_iter,
+            self.final_residual,
+            self.residual_crit,
+            self.max_iter,
+            self.epsilon,
+            self.final_step_size,
+            self.invalid_numbers_detected,
+            self.debug_nan,
+        )
+        return children, None
+
+    @classmethod
+    def tree_unflatten(cls, aux_data, children):
+        del aux_data
+        return cls(*children)
+
+    @classmethod
+    def from_mapping(cls, diagnostics):
+        return cls(
+            n_iter=diagnostics["n_iter"],
+            converged=diagnostics["converged"],
+            hit_max_iter=diagnostics["hit_max_iter"],
+            final_residual=diagnostics["final_residual"],
+            residual_crit=diagnostics["residual_crit"],
+            max_iter=diagnostics["max_iter"],
+            epsilon=diagnostics["epsilon"],
+            final_step_size=diagnostics["final_step_size"],
+            invalid_numbers_detected=diagnostics["invalid_numbers_detected"],
+            debug_nan=diagnostics["debug_nan"],
+        )
+
+    def asdict(self):
+        return {
+            "n_iter": self.n_iter,
+            "converged": self.converged,
+            "hit_max_iter": self.hit_max_iter,
+            "final_residual": self.final_residual,
+            "residual_crit": self.residual_crit,
+            "max_iter": self.max_iter,
+            "epsilon": self.epsilon,
+            "final_step_size": self.final_step_size,
+            "invalid_numbers_detected": self.invalid_numbers_detected,
+            "debug_nan": self.debug_nan,
+        }
+
+
+@tree_util.register_pytree_node_class
+@dataclass(frozen=True)
+class CondensateEquilibriumResult:
+    """Structured condensate solve result with final state and diagnostics."""
+
+    ln_nk: Array
+    ln_mk: Array
+    ln_ntot: Array
+    diagnostics: CondensateEquilibriumDiagnostics
+
+    def tree_flatten(self):
+        children = (self.ln_nk, self.ln_mk, self.ln_ntot, self.diagnostics)
+        return children, None
+
+    @classmethod
+    def tree_unflatten(cls, aux_data, children):
+        del aux_data
+        ln_nk, ln_mk, ln_ntot, diagnostics = children
+        return cls(ln_nk=ln_nk, ln_mk=ln_mk, ln_ntot=ln_ntot, diagnostics=diagnostics)
+
+    def to_init(self) -> CondensateEquilibriumInit:
+        return CondensateEquilibriumInit(
+            ln_nk=self.ln_nk,
+            ln_mk=self.ln_mk,
+            ln_ntot=self.ln_ntot,
+        )
+
+
+def _prepare_condensate_init(init: CondensateEquilibriumInit) -> CondensateEquilibriumInit:
+    if init.ln_nk is None or init.ln_mk is None or init.ln_ntot is None:
+        raise ValueError(
+            "CondensateEquilibriumInit requires ln_nk, ln_mk, and ln_ntot for the current solver path."
+        )
+    return CondensateEquilibriumInit(
+        ln_nk=jnp.asarray(init.ln_nk),
+        ln_mk=jnp.asarray(init.ln_mk),
+        ln_ntot=jnp.asarray(init.ln_ntot),
+    )
+
+
+def minimize_gibbs_cond(
+    state: ThermoState,
+    init: CondensateEquilibriumInit,
+    formula_matrix: jnp.ndarray,
+    formula_matrix_cond: jnp.ndarray,
+    hvector_func,
+    hvector_cond_func,
+    epsilon: float,
+    residual_crit: float = 1.0e-11,
+    max_iter: int = 1000,
+    element_indices: Optional[jnp.ndarray] = None,
+    debug_nan: bool = False,
+) -> CondensateEquilibriumResult:
+    """Run the active condensate solver using a structured init/result interface."""
+
+    init_prepared = _prepare_condensate_init(init)
+    ln_nk, ln_mk, ln_ntot, diagnostics_raw = _minimize_gibbs_cond_with_diagnostics_raw(
+        state,
+        ln_nk_init=init_prepared.ln_nk,
+        ln_mk_init=init_prepared.ln_mk,
+        ln_ntot_init=init_prepared.ln_ntot,
+        formula_matrix=formula_matrix,
+        formula_matrix_cond=formula_matrix_cond,
+        hvector_func=hvector_func,
+        hvector_cond_func=hvector_cond_func,
+        epsilon=epsilon,
+        residual_crit=residual_crit,
+        max_iter=max_iter,
+        element_indices=element_indices,
+        debug_nan=debug_nan,
+    )
+    return CondensateEquilibriumResult(
+        ln_nk=ln_nk,
+        ln_mk=ln_mk,
+        ln_ntot=ln_ntot,
+        diagnostics=CondensateEquilibriumDiagnostics.from_mapping(diagnostics_raw),
+    )
+
+
+def minimize_gibbs_cond_with_diagnostics(*args, **kwargs) -> CondensateEquilibriumResult:
+    """Alias of :func:`minimize_gibbs_cond` kept for explicit diagnostics-oriented callers."""
+
+    return minimize_gibbs_cond(*args, **kwargs)
+
+
+__all__ = [
+    "CondensateEquilibriumDiagnostics",
+    "CondensateEquilibriumInit",
+    "CondensateEquilibriumResult",
+    "minimize_gibbs_cond",
+    "minimize_gibbs_cond_core",
+    "minimize_gibbs_cond_with_diagnostics",
+]

--- a/tests/unittests/optimize/minimize_cond_api_test.py
+++ b/tests/unittests/optimize/minimize_cond_api_test.py
@@ -1,0 +1,172 @@
+import jax.numpy as jnp
+from jax import config
+
+config.update("jax_enable_x64", True)
+
+from exogibbs.api.chemistry import ThermoState
+import exogibbs.optimize.minimize_cond as condmod
+from exogibbs.optimize.pipm_rgie_cond import minimize_gibbs_cond_with_diagnostics as raw_minimize_gibbs_cond_with_diagnostics
+
+
+def test_minimize_gibbs_cond_structured_wrapper(monkeypatch):
+    captured = {}
+
+    def stub_raw(state, ln_nk_init, ln_mk_init, ln_ntot_init, **kwargs):
+        captured["ln_nk_init"] = ln_nk_init
+        captured["ln_mk_init"] = ln_mk_init
+        captured["ln_ntot_init"] = ln_ntot_init
+        captured["epsilon"] = kwargs["epsilon"]
+        return (
+            jnp.asarray([0.1, 0.2], dtype=jnp.float64),
+            jnp.asarray([0.3], dtype=jnp.float64),
+            jnp.asarray(1.7, dtype=jnp.float64),
+            {
+                "n_iter": jnp.asarray(7, dtype=jnp.int32),
+                "converged": jnp.asarray(True),
+                "hit_max_iter": jnp.asarray(False),
+                "final_residual": jnp.asarray(1.0e-12, dtype=jnp.float64),
+                "residual_crit": jnp.asarray(kwargs["residual_crit"], dtype=jnp.float64),
+                "max_iter": jnp.asarray(kwargs["max_iter"], dtype=jnp.int32),
+                "epsilon": jnp.asarray(kwargs["epsilon"], dtype=jnp.float64),
+                "final_step_size": jnp.asarray(0.5, dtype=jnp.float64),
+                "invalid_numbers_detected": jnp.asarray(False),
+                "debug_nan": jnp.asarray(kwargs["debug_nan"]),
+            },
+        )
+
+    monkeypatch.setattr(
+        condmod,
+        "_minimize_gibbs_cond_with_diagnostics_raw",
+        stub_raw,
+    )
+
+    init = condmod.CondensateEquilibriumInit(
+        ln_nk=jnp.asarray([1.0, 2.0], dtype=jnp.float64),
+        ln_mk=jnp.asarray([3.0], dtype=jnp.float64),
+        ln_ntot=jnp.asarray(4.0, dtype=jnp.float64),
+    )
+    state = ThermoState(
+        temperature=jnp.asarray(1000.0, dtype=jnp.float64),
+        ln_normalized_pressure=jnp.asarray(0.0, dtype=jnp.float64),
+        element_vector=jnp.asarray([1.0], dtype=jnp.float64),
+    )
+
+    result = condmod.minimize_gibbs_cond(
+        state,
+        init=init,
+        formula_matrix=jnp.asarray([[1.0, 1.0]], dtype=jnp.float64),
+        formula_matrix_cond=jnp.asarray([[1.0]], dtype=jnp.float64),
+        hvector_func=lambda temperature: jnp.asarray([0.0, 0.0], dtype=jnp.float64),
+        hvector_cond_func=lambda temperature: jnp.asarray([0.0], dtype=jnp.float64),
+        epsilon=-6.0,
+        residual_crit=1.0e-9,
+        max_iter=25,
+        debug_nan=False,
+    )
+
+    assert jnp.allclose(captured["ln_nk_init"], init.ln_nk)
+    assert jnp.allclose(captured["ln_mk_init"], init.ln_mk)
+    assert jnp.allclose(captured["ln_ntot_init"], init.ln_ntot)
+    assert captured["epsilon"] == -6.0
+
+    assert isinstance(result, condmod.CondensateEquilibriumResult)
+    assert isinstance(result.diagnostics, condmod.CondensateEquilibriumDiagnostics)
+    assert result.ln_nk.shape == (2,)
+    assert result.ln_mk.shape == (1,)
+    assert result.ln_ntot.shape == ()
+    assert int(result.diagnostics.n_iter) == 7
+    assert bool(result.diagnostics.converged)
+    assert not bool(result.diagnostics.hit_max_iter)
+
+
+def test_condensate_result_to_init_roundtrip():
+    diagnostics = condmod.CondensateEquilibriumDiagnostics(
+        n_iter=jnp.asarray(3, dtype=jnp.int32),
+        converged=jnp.asarray(True),
+        hit_max_iter=jnp.asarray(False),
+        final_residual=jnp.asarray(1.0e-12, dtype=jnp.float64),
+        residual_crit=jnp.asarray(1.0e-10, dtype=jnp.float64),
+        max_iter=jnp.asarray(100, dtype=jnp.int32),
+        epsilon=jnp.asarray(-5.0, dtype=jnp.float64),
+        final_step_size=jnp.asarray(0.25, dtype=jnp.float64),
+        invalid_numbers_detected=jnp.asarray(False),
+        debug_nan=jnp.asarray(False),
+    )
+    result = condmod.CondensateEquilibriumResult(
+        ln_nk=jnp.asarray([0.1, 0.2], dtype=jnp.float64),
+        ln_mk=jnp.asarray([0.3], dtype=jnp.float64),
+        ln_ntot=jnp.asarray(0.4, dtype=jnp.float64),
+        diagnostics=diagnostics,
+    )
+
+    init = result.to_init()
+
+    assert isinstance(init, condmod.CondensateEquilibriumInit)
+    assert jnp.allclose(init.ln_nk, result.ln_nk)
+    assert jnp.allclose(init.ln_mk, result.ln_mk)
+    assert jnp.allclose(init.ln_ntot, result.ln_ntot)
+
+
+def test_minimize_gibbs_cond_structured_smoke():
+    formula_matrix = jnp.array([[1.0]], dtype=jnp.float64)
+    formula_matrix_cond = jnp.array([[1.0]], dtype=jnp.float64)
+    state = ThermoState(
+        temperature=jnp.asarray(1000.0, dtype=jnp.float64),
+        ln_normalized_pressure=jnp.asarray(0.0, dtype=jnp.float64),
+        element_vector=jnp.array([1.0], dtype=jnp.float64),
+    )
+    init = condmod.CondensateEquilibriumInit(
+        ln_nk=jnp.array([0.0], dtype=jnp.float64),
+        ln_mk=jnp.array([0.0], dtype=jnp.float64),
+        ln_ntot=jnp.asarray(0.0, dtype=jnp.float64),
+    )
+
+    result = condmod.minimize_gibbs_cond_with_diagnostics(
+        state,
+        init=init,
+        formula_matrix=formula_matrix,
+        formula_matrix_cond=formula_matrix_cond,
+        hvector_func=lambda temperature: jnp.array([0.0], dtype=jnp.float64),
+        hvector_cond_func=lambda temperature: jnp.array([2.0], dtype=jnp.float64),
+        epsilon=-5.0,
+        residual_crit=1.0e-8,
+        max_iter=0,
+    )
+
+    assert isinstance(result, condmod.CondensateEquilibriumResult)
+    assert result.ln_nk.shape == (1,)
+    assert result.ln_mk.shape == (1,)
+    assert result.ln_ntot.shape == ()
+    assert int(result.diagnostics.n_iter) == 0
+    assert bool(result.diagnostics.hit_max_iter)
+    assert not bool(result.diagnostics.converged)
+
+
+def test_raw_phase0_api_still_available():
+    formula_matrix = jnp.array([[1.0]], dtype=jnp.float64)
+    formula_matrix_cond = jnp.array([[1.0]], dtype=jnp.float64)
+    state = ThermoState(
+        temperature=jnp.asarray(1000.0, dtype=jnp.float64),
+        ln_normalized_pressure=jnp.asarray(0.0, dtype=jnp.float64),
+        element_vector=jnp.array([1.0], dtype=jnp.float64),
+    )
+
+    ln_nk, ln_mk, ln_ntot, diagnostics = raw_minimize_gibbs_cond_with_diagnostics(
+        state,
+        ln_nk_init=jnp.array([0.0], dtype=jnp.float64),
+        ln_mk_init=jnp.array([0.0], dtype=jnp.float64),
+        ln_ntot_init=jnp.asarray(0.0, dtype=jnp.float64),
+        formula_matrix=formula_matrix,
+        formula_matrix_cond=formula_matrix_cond,
+        hvector_func=lambda temperature: jnp.array([0.0], dtype=jnp.float64),
+        hvector_cond_func=lambda temperature: jnp.array([2.0], dtype=jnp.float64),
+        epsilon=-5.0,
+        residual_crit=1.0e-8,
+        max_iter=0,
+    )
+
+    assert ln_nk.shape == (1,)
+    assert ln_mk.shape == (1,)
+    assert ln_ntot.shape == ()
+    assert isinstance(diagnostics, dict)
+    assert "n_iter" in diagnostics


### PR DESCRIPTION
## Summary

  This PR implements Phase 1 of the condensate-enabled solver improvement plan.

  It adds a small structured public API layer above the active condensate solver path so callers no longer need to hand-
  manage raw `(ln_nk, ln_mk, ln_ntot, diagnostics)` tuples in example code.

  The active solver math and execution model remain unchanged.

  ## Motivation

  Phase 0 exposed diagnostics around the active RGIE/PIPM condensate solver, but the practical calling pattern was still
  low-level:
  - callers passed raw state arrays directly
  - callers received loose tuple outputs
  - callers manually unpacked diagnostics mappings
  - example code still had to manage solver state plumbing itself

  Phase 1 is intended to improve API footing without expanding scope into:
  - hot start
  - profile scan redesign
  - epsilon scheduling redesign
  - numerical-method changes

  ## What Changed

  ### Structured condensate API layer
  In [`src/exogibbs/optimize/minimize_cond.py`](/home/kawahara/exogibbs/src/exogibbs/optimize/minimize_cond.py), this PR
  adds a thin structured interface on top of the active solver diagnostics path:

  - `CondensateEquilibriumInit`
  - `CondensateEquilibriumDiagnostics`
  - `CondensateEquilibriumResult`
  - `minimize_gibbs_cond(...)`
  - `minimize_gibbs_cond_with_diagnostics(...)`

  The new public wrapper:
  - takes a structured init object instead of separate raw `ln_nk`, `ln_mk`, `ln_ntot` arguments
  - returns a structured result object containing:
    - `ln_nk`
    - `ln_mk`
    - `ln_ntot`
    - `diagnostics`

  ### Diagnostics object
  `CondensateEquilibriumDiagnostics` wraps the Phase 0 diagnostics fields and exposes them as attributes rather than a
  loose mapping.

  Current fields are:
  - `n_iter`
  - `converged`
  - `hit_max_iter`
  - `final_residual`
  - `residual_crit`
  - `max_iter`
  - `epsilon`
  - `final_step_size`
  - `invalid_numbers_detected`
  - `debug_nan`

  It also provides `asdict()` for code that still wants mapping-style access.

  ### Result-to-init bridge
  `CondensateEquilibriumResult.to_init()` was added so the final state can be converted back into a structured init
  object.

  This is intentionally small, but it gives Phase 2 a clean state carrier for future hot-start work.

  ### Example updates
  The condensate examples were updated minimally to use the new structured wrapper:

  - [`documents/ipynb/pipm/rgie/fastchem_cond_one.py`](/home/kawahara/exogibbs/documents/ipynb/pipm/rgie/
  fastchem_cond_one.py)
  - [`documents/ipynb/pipm/rgie/fastchem_cond_prof.py`](/home/kawahara/exogibbs/documents/ipynb/pipm/rgie/
  fastchem_cond_prof.py)

  The single-layer example now carries a `CondensateEquilibriumInit` object through the epsilon schedule.
  The profile example uses the structured wrapper internally, but keeps the current `vmap`/cold-start execution model
  unchanged.

  ### Focused contract tests
  Added:
  - [`tests/unittests/optimize/minimize_cond_api_test.py`](/home/kawahara/exogibbs/tests/unittests/optimize/
  minimize_cond_api_test.py)

  These tests verify:
  - the structured wrapper is callable
  - structured init/result/diagnostics objects are produced correctly
  - `to_init()` round-trips the final state cleanly
  - the Phase 0 raw diagnostics path remains available

  The existing Phase 0 diagnostics smoke test remains in place.

  ## What Did Not Change

  This PR does not:
  - change the condensate solver update math
  - change convergence criteria
  - change damping logic
  - change epsilon scheduling policy
  - add hot start
  - switch profile solves from `vmap` to `scan`
  - refactor gas-only behavior
  - attempt broad unification of historical condensate entry points

  ## Design Notes

  This is intentionally a light dataclass-based layer.

  The API is structured enough to reduce raw tuple plumbing now, while also making future hot-start work
  straightforward:
  - `CondensateEquilibriumInit` is a natural state carrier
  - `CondensateEquilibriumResult.to_init()` provides a direct bridge to future reuse

  The raw active solver path is still available, so existing lower-level usage is not blocked.

  ## Testing

  Ran:
  - `python -m py_compile src/exogibbs/optimize/minimize_cond.py`
  - `python -m py_compile documents/ipynb/pipm/rgie/fastchem_cond_one.py`
  - `python -m py_compile documents/ipynb/pipm/rgie/fastchem_cond_prof.py`
  - `python -m py_compile tests/unittests/optimize/minimize_cond_api_test.py`
  - `python -m py_compile tests/unittests/optimize/minimize_cond_diagnostics_test.py`
  - `pytest tests/unittests/optimize/minimize_cond_api_test.py tests/unittests/optimize/
  minimize_cond_diagnostics_test.py`

  ## Recommended Next Step

  Phase 2 should build on this new init/result layer to add explicit hot-start state flow for profile calculations,
  without needing another API-format change first.

