### PR TITLE
optimize: add top-down condensate profile scan

### DIFF
--- a/documents/ipynb/pipm/rgie/fastchem_cond_prof.py
+++ b/documents/ipynb/pipm/rgie/fastchem_cond_prof.py
@@ -116,6 +116,7 @@ print(formula_matrix_cond_eff)
 
 from exogibbs.optimize.minimize_cond import CondensateEquilibriumInit
 from exogibbs.optimize.minimize_cond import minimize_gibbs_cond as structured_minimize_gibbs_cond
+from exogibbs.optimize.minimize_cond import minimize_gibbs_cond_profile
 import jax.numpy as jnp
 from exogibbs.api.chemistry import ThermoState
 
@@ -140,69 +141,10 @@ if N != vmr_ref.shape[1]:
 print("Set up complete.")
 
 import jax.numpy as jnp
-from jax import lax, vmap
 from jax.scipy.special import logsumexp
 
 init_setup = "gas_only"  # "zeros" or "gas_only"
-
-
-def minimize_gibbs_cond_layer(
-    temperature,
-    ln_normalized_pressure,
-    ln_nk_init,
-    ln_mk_init,
-    ln_ntot_init,
-):
-    thermo_state = ThermoState(
-        temperature=temperature,
-        ln_normalized_pressure=ln_normalized_pressure,
-        element_vector=b_ref,
-    )
-
-    ln_nk = ln_nk_init
-    ln_mk = ln_mk_init
-    ln_ntot = ln_ntot_init
-
-    epsilon_start = 0.0
-    epsilon_crit = -40.0
-    n_step = 100
-
-    # epsilon schedule (static, safe)
-    epsilons = jnp.linspace(epsilon_start, epsilon_crit, n_step + 1)[1:]
-
-
-    def body_fn(i, state):
-        ln_nk, ln_mk, ln_ntot = state
-
-        epsilon = epsilons[i]
-        rcrit = jnp.exp(epsilon)
-
-        result = structured_minimize_gibbs_cond(
-            thermo_state,
-            init=CondensateEquilibriumInit(
-                ln_nk=ln_nk,
-                ln_mk=ln_mk,
-                ln_ntot=ln_ntot,
-            ),
-            formula_matrix=formula_matrix_gas_eff,
-            formula_matrix_cond=formula_matrix_cond_eff,
-            hvector_func=gas.hvector_func,
-            hvector_cond_func=cond.hvector_func,
-            epsilon=epsilon,
-            residual_crit=rcrit,
-            max_iter=100,
-        )
-
-        return result.ln_nk, result.ln_mk, result.ln_ntot
-
-    ln_nk, ln_mk, ln_ntot = lax.fori_loop(
-        0,
-        n_step,
-        body_fn,
-        (ln_nk, ln_mk, ln_ntot),
-    )
-
-    return ln_nk, ln_mk, ln_ntot
+profile_method = "scan_hot_from_bottom"  # or "vmap_cold" or "scan_hot_from_top"
 
 
 def minimize_gibbs_cond_diagnostics(
@@ -235,10 +177,6 @@ def minimize_gibbs_cond_diagnostics(
         max_iter=100,
     )
 
-from jax import vmap
-from jax import jit
-
-
 if init_setup == "gas_only":
     from exogibbs.api.equilibrium import equilibrium
 
@@ -264,42 +202,37 @@ elif init_setup == "zeros":
 else:
     raise ValueError("Invalid init_setup option")
 
-def minimize_gibbs_cond(temperature, ln_normalized_pressure, ln_nk_init, ln_mk_init, ln_ntot_init):
-    result = minimize_gibbs_cond_layer(
-        temperature,
-        ln_normalized_pressure,
-        ln_nk_init,
-        ln_mk_init,
-        ln_ntot_init,
-    )
-    return result
-
-
-vmap_minimize_gibbs_cond = vmap(minimize_gibbs_cond, in_axes=(0, 0, 0, 0, 0))
-jit_vmap_minimize_gibbs_cond = jit(vmap_minimize_gibbs_cond)
-
 import time
 
 start = time.time()
-ln_nk, ln_mk, ln_ntot = jit_vmap_minimize_gibbs_cond(
+profile_result = minimize_gibbs_cond_profile(
     jnp.array(temperatures),
     jnp.array(ln_normalized_pressures),
-    ln_nk_init,
-    ln_mk_init,
-    ln_ntot_init,
+    b_ref,
+    init=CondensateEquilibriumInit(
+        ln_nk=ln_nk_init,
+        ln_mk=ln_mk_init,
+        ln_ntot=ln_ntot_init,
+    ),
+    formula_matrix=formula_matrix_gas_eff,
+    formula_matrix_cond=formula_matrix_cond_eff,
+    hvector_func=gas.hvector_func,
+    hvector_cond_func=cond.hvector_func,
+    epsilon_start=0.0,
+    epsilon_crit=-40.0,
+    n_step=100,
+    max_iter=100,
+    method=profile_method,
 )
 end = time.time()
 print("Computation time (s):", end - start)
-profile_result0 = minimize_gibbs_cond_diagnostics(
-    jnp.array(temperatures)[0],
-    jnp.array(ln_normalized_pressures)[0],
-    ln_nk_init[0],
-    ln_mk_init[0],
-    ln_ntot_init[0],
-)
-print("Layer-0 condensate diagnostics:", profile_result0.diagnostics.asdict())
+print("Profile solve method:", profile_method)
 
-ln_ntot = logsumexp(ln_nk, axis=1)[:, None]
+ln_nk = profile_result.ln_nk
+ln_mk = profile_result.ln_mk
+ln_ntot = profile_result.ln_ntot[:, None]
+profile_diagnostics = profile_result.diagnostics.asdict()
+print("Layer-0 condensate diagnostics:", {k: v[0] for k, v in profile_diagnostics.items()})
 
 # Gibbs energy
 from exogibbs.api.potential import gibbs_energies

--- a/src/exogibbs/optimize/minimize_cond.py
+++ b/src/exogibbs/optimize/minimize_cond.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Literal, Optional
 
 import jax
 import jax.numpy as jnp
-from jax import tree_util
+from jax import lax, tree_util
 
 from exogibbs.api.chemistry import ThermoState
 from exogibbs.optimize.pdipm_cond import minimize_gibbs_cond_core
@@ -16,6 +16,7 @@ from exogibbs.optimize.pipm_rgie_cond import (
 )
 
 Array = jax.Array
+CondensateProfileMethod = Literal["vmap_cold", "scan_hot_from_top", "scan_hot_from_bottom"]
 
 
 @tree_util.register_pytree_node_class
@@ -147,6 +148,82 @@ def _prepare_condensate_init(init: CondensateEquilibriumInit) -> CondensateEquil
     )
 
 
+def _validate_profile_inputs(
+    temperatures: Array,
+    ln_normalized_pressures: Array,
+    element_vector: Array,
+) -> tuple[Array, Array, Array]:
+    temperatures = jnp.asarray(temperatures)
+    ln_normalized_pressures = jnp.asarray(ln_normalized_pressures)
+    element_vector = jnp.asarray(element_vector)
+
+    if temperatures.ndim != 1 or ln_normalized_pressures.ndim != 1:
+        raise ValueError("temperatures and ln_normalized_pressures must be 1D arrays.")
+    if temperatures.shape[0] != ln_normalized_pressures.shape[0]:
+        raise ValueError("temperatures and ln_normalized_pressures must have the same length.")
+    if element_vector.ndim != 1:
+        raise ValueError("element_vector must be a 1D array shared across profile layers.")
+    return temperatures, ln_normalized_pressures, element_vector
+
+
+def _profile_init_is_batched(init: CondensateEquilibriumInit, n_layers: int) -> bool:
+    prepared = _prepare_condensate_init(init)
+    ln_nk = prepared.ln_nk
+    ln_mk = prepared.ln_mk
+    ln_ntot = prepared.ln_ntot
+
+    if ln_nk.ndim == 1 and ln_mk.ndim == 1 and ln_ntot.ndim == 0:
+        return False
+    if ln_nk.ndim == 2 and ln_mk.ndim == 2 and ln_ntot.ndim == 1:
+        if (
+            ln_nk.shape[0] != n_layers
+            or ln_mk.shape[0] != n_layers
+            or ln_ntot.shape[0] != n_layers
+        ):
+            raise ValueError("Batched condensate profile init must have leading dimension equal to the number of layers.")
+        return True
+    raise ValueError(
+        "CondensateEquilibriumInit for profile solves must be either unbatched "
+        "(ln_nk[K], ln_mk[M], ln_ntot[]) or batched "
+        "(ln_nk[N,K], ln_mk[N,M], ln_ntot[N])."
+    )
+
+
+def _profile_init_at(
+    init: CondensateEquilibriumInit,
+    n_layers: int,
+    layer_index: int,
+) -> CondensateEquilibriumInit:
+    prepared = _prepare_condensate_init(init)
+    if not _profile_init_is_batched(prepared, n_layers):
+        return prepared
+    return CondensateEquilibriumInit(
+        ln_nk=prepared.ln_nk[layer_index],
+        ln_mk=prepared.ln_mk[layer_index],
+        ln_ntot=prepared.ln_ntot[layer_index],
+    )
+
+
+def _broadcast_profile_init(
+    init: CondensateEquilibriumInit,
+    n_layers: int,
+) -> CondensateEquilibriumInit:
+    prepared = _prepare_condensate_init(init)
+    if _profile_init_is_batched(prepared, n_layers):
+        return prepared
+    return CondensateEquilibriumInit(
+        ln_nk=jnp.broadcast_to(prepared.ln_nk, (n_layers,) + prepared.ln_nk.shape),
+        ln_mk=jnp.broadcast_to(prepared.ln_mk, (n_layers,) + prepared.ln_mk.shape),
+        ln_ntot=jnp.broadcast_to(prepared.ln_ntot, (n_layers,)),
+    )
+
+
+def _flip_condensate_profile_result(
+    result: CondensateEquilibriumResult,
+) -> CondensateEquilibriumResult:
+    return tree_util.tree_map(lambda x: jnp.flip(x, axis=0), result)
+
+
 def minimize_gibbs_cond(
     state: ThermoState,
     init: CondensateEquilibriumInit,
@@ -192,11 +269,156 @@ def minimize_gibbs_cond_with_diagnostics(*args, **kwargs) -> CondensateEquilibri
     return minimize_gibbs_cond(*args, **kwargs)
 
 
+def minimize_gibbs_cond_profile(
+    temperatures: Array,
+    ln_normalized_pressures: Array,
+    element_vector: Array,
+    init: CondensateEquilibriumInit,
+    formula_matrix: jnp.ndarray,
+    formula_matrix_cond: jnp.ndarray,
+    hvector_func,
+    hvector_cond_func,
+    *,
+    epsilon_start: float = 0.0,
+    epsilon_crit: float = -40.0,
+    n_step: int = 100,
+    max_iter: int = 100,
+    method: CondensateProfileMethod = "scan_hot_from_bottom",
+    element_indices: Optional[jnp.ndarray] = None,
+    debug_nan: bool = False,
+) -> CondensateEquilibriumResult:
+    """Run the condensate solver over a 1D profile with cold- or hot-start execution.
+
+    The per-layer epsilon continuation schedule is intentionally unchanged from the
+    current example path: each layer steps from ``epsilon_start`` to
+    ``epsilon_crit`` and then performs one final solve at ``epsilon_crit`` so the
+    returned diagnostics correspond to the final layer solve.
+
+    ``method="scan_hot_from_top"`` and ``method="scan_hot_from_bottom"`` carry
+    structured :class:`CondensateEquilibriumInit` state layer-to-layer using
+    :meth:`CondensateEquilibriumResult.to_init`. ``method="vmap_cold"`` keeps the
+    existing independent-layer behavior.
+    """
+
+    if n_step < 1:
+        raise ValueError("n_step must be at least 1.")
+    valid_methods = ("vmap_cold", "scan_hot_from_top", "scan_hot_from_bottom")
+    if method not in valid_methods:
+        raise ValueError(f"Unknown condensate profile solve method '{method}'. Expected one of {valid_methods}.")
+
+    temperatures, ln_normalized_pressures, element_vector = _validate_profile_inputs(
+        temperatures,
+        ln_normalized_pressures,
+        element_vector,
+    )
+    n_layers = int(temperatures.shape[0])
+    epsilons = jnp.linspace(epsilon_start, epsilon_crit, n_step + 1)[1:]
+
+    def solve_layer(
+        temperature: Array,
+        ln_normalized_pressure: Array,
+        layer_init: CondensateEquilibriumInit,
+    ) -> CondensateEquilibriumResult:
+        thermo_state = ThermoState(
+            temperature=temperature,
+            ln_normalized_pressure=ln_normalized_pressure,
+            element_vector=element_vector,
+        )
+
+        def body_fn(i, init_state):
+            epsilon = epsilons[i]
+            residual_crit = jnp.exp(epsilon)
+            result = minimize_gibbs_cond(
+                thermo_state,
+                init=init_state,
+                formula_matrix=formula_matrix,
+                formula_matrix_cond=formula_matrix_cond,
+                hvector_func=hvector_func,
+                hvector_cond_func=hvector_cond_func,
+                epsilon=epsilon,
+                residual_crit=residual_crit,
+                max_iter=max_iter,
+                element_indices=element_indices,
+                debug_nan=debug_nan,
+            )
+            return result.to_init()
+
+        final_init = lax.fori_loop(
+            0,
+            n_step,
+            body_fn,
+            _prepare_condensate_init(layer_init),
+        )
+        final_epsilon = epsilons[-1]
+        return minimize_gibbs_cond(
+            thermo_state,
+            init=final_init,
+            formula_matrix=formula_matrix,
+            formula_matrix_cond=formula_matrix_cond,
+            hvector_func=hvector_func,
+            hvector_cond_func=hvector_cond_func,
+            epsilon=final_epsilon,
+            residual_crit=jnp.exp(final_epsilon),
+            max_iter=max_iter,
+            element_indices=element_indices,
+            debug_nan=debug_nan,
+        )
+
+    if method == "vmap_cold":
+        batched_init = _broadcast_profile_init(init, n_layers)
+        return jax.vmap(
+            solve_layer,
+            in_axes=(
+                0,
+                0,
+                CondensateEquilibriumInit(ln_nk=0, ln_mk=0, ln_ntot=0),
+            ),
+        )(
+            temperatures,
+            ln_normalized_pressures,
+            batched_init,
+        )
+
+    def scan_body(carry_init, layer_inputs):
+        temperature, ln_normalized_pressure = layer_inputs
+        result = solve_layer(temperature, ln_normalized_pressure, carry_init)
+        return result.to_init(), result
+
+    def run_scan(
+        temperatures_scan: Array,
+        ln_pressures_scan: Array,
+        init0: CondensateEquilibriumInit,
+        *,
+        reverse_output: bool,
+    ) -> CondensateEquilibriumResult:
+        _, result_seq = lax.scan(scan_body, init0, (temperatures_scan, ln_pressures_scan))
+        if reverse_output:
+            return _flip_condensate_profile_result(result_seq)
+        return result_seq
+
+    if method == "scan_hot_from_top":
+        return run_scan(
+            temperatures,
+            ln_normalized_pressures,
+            _profile_init_at(init, n_layers, 0),
+            reverse_output=False,
+        )
+
+    return run_scan(
+        jnp.flip(temperatures, axis=0),
+        jnp.flip(ln_normalized_pressures, axis=0),
+        _profile_init_at(init, n_layers, n_layers - 1),
+        reverse_output=True,
+    )
+
+
 __all__ = [
     "CondensateEquilibriumDiagnostics",
     "CondensateEquilibriumInit",
+    "CondensateProfileMethod",
     "CondensateEquilibriumResult",
     "minimize_gibbs_cond",
+    "minimize_gibbs_cond_profile",
     "minimize_gibbs_cond_core",
     "minimize_gibbs_cond_with_diagnostics",
 ]

--- a/tests/unittests/optimize/minimize_cond_api_test.py
+++ b/tests/unittests/optimize/minimize_cond_api_test.py
@@ -170,3 +170,195 @@ def test_raw_phase0_api_still_available():
     assert ln_ntot.shape == ()
     assert isinstance(diagnostics, dict)
     assert "n_iter" in diagnostics
+
+
+def test_minimize_gibbs_cond_profile_scan_hot_from_bottom_carries_structured_state(monkeypatch):
+    def stub_minimize_gibbs_cond(state, init, **kwargs):
+        return condmod.CondensateEquilibriumResult(
+            ln_nk=jnp.asarray(init.ln_nk) + 1.0,
+            ln_mk=jnp.asarray(init.ln_mk) + 2.0,
+            ln_ntot=jnp.asarray(init.ln_ntot) + 3.0,
+            diagnostics=condmod.CondensateEquilibriumDiagnostics(
+                n_iter=jnp.asarray(4, dtype=jnp.int32),
+                converged=jnp.asarray(True),
+                hit_max_iter=jnp.asarray(False),
+                final_residual=jnp.asarray(1.0e-12, dtype=jnp.float64),
+                residual_crit=jnp.asarray(kwargs["residual_crit"], dtype=jnp.float64),
+                max_iter=jnp.asarray(kwargs["max_iter"], dtype=jnp.int32),
+                epsilon=jnp.asarray(kwargs["epsilon"], dtype=jnp.float64),
+                final_step_size=jnp.asarray(0.5, dtype=jnp.float64),
+                invalid_numbers_detected=jnp.asarray(False),
+                debug_nan=jnp.asarray(kwargs["debug_nan"]),
+            ),
+        )
+
+    monkeypatch.setattr(condmod, "minimize_gibbs_cond", stub_minimize_gibbs_cond)
+
+    init = condmod.CondensateEquilibriumInit(
+        ln_nk=jnp.asarray([[10.0], [20.0], [30.0]], dtype=jnp.float64),
+        ln_mk=jnp.asarray([[1.0], [2.0], [3.0]], dtype=jnp.float64),
+        ln_ntot=jnp.asarray([100.0, 200.0, 300.0], dtype=jnp.float64),
+    )
+
+    result = condmod.minimize_gibbs_cond_profile(
+        temperatures=jnp.asarray([1000.0, 1100.0, 1200.0], dtype=jnp.float64),
+        ln_normalized_pressures=jnp.asarray([-1.0, 0.0, 1.0], dtype=jnp.float64),
+        element_vector=jnp.asarray([1.0], dtype=jnp.float64),
+        init=init,
+        formula_matrix=jnp.asarray([[1.0]], dtype=jnp.float64),
+        formula_matrix_cond=jnp.asarray([[1.0]], dtype=jnp.float64),
+        hvector_func=lambda temperature: jnp.asarray([0.0], dtype=jnp.float64),
+        hvector_cond_func=lambda temperature: jnp.asarray([0.0], dtype=jnp.float64),
+        n_step=1,
+        max_iter=25,
+        method="scan_hot_from_bottom",
+    )
+
+    # Each layer runs one scheduled step plus one final epsilon_crit solve.
+    assert jnp.allclose(result.ln_nk[:, 0], jnp.asarray([36.0, 34.0, 32.0], dtype=jnp.float64))
+    assert jnp.allclose(result.ln_mk[:, 0], jnp.asarray([15.0, 11.0, 7.0], dtype=jnp.float64))
+    assert jnp.allclose(result.ln_ntot, jnp.asarray([318.0, 312.0, 306.0], dtype=jnp.float64))
+    assert result.diagnostics.n_iter.shape == (3,)
+    assert jnp.all(result.diagnostics.converged)
+
+
+def test_minimize_gibbs_cond_profile_scan_hot_from_top_runs_in_input_order(monkeypatch):
+    def stub_minimize_gibbs_cond(state, init, **kwargs):
+        return condmod.CondensateEquilibriumResult(
+            ln_nk=jnp.asarray(init.ln_nk) + 1.0,
+            ln_mk=jnp.asarray(init.ln_mk) + 2.0,
+            ln_ntot=jnp.asarray(init.ln_ntot) + 3.0,
+            diagnostics=condmod.CondensateEquilibriumDiagnostics(
+                n_iter=jnp.asarray(4, dtype=jnp.int32),
+                converged=jnp.asarray(True),
+                hit_max_iter=jnp.asarray(False),
+                final_residual=jnp.asarray(1.0e-12, dtype=jnp.float64),
+                residual_crit=jnp.asarray(kwargs["residual_crit"], dtype=jnp.float64),
+                max_iter=jnp.asarray(kwargs["max_iter"], dtype=jnp.int32),
+                epsilon=jnp.asarray(kwargs["epsilon"], dtype=jnp.float64),
+                final_step_size=jnp.asarray(0.5, dtype=jnp.float64),
+                invalid_numbers_detected=jnp.asarray(False),
+                debug_nan=jnp.asarray(kwargs["debug_nan"]),
+            ),
+        )
+
+    monkeypatch.setattr(condmod, "minimize_gibbs_cond", stub_minimize_gibbs_cond)
+
+    result = condmod.minimize_gibbs_cond_profile(
+        temperatures=jnp.asarray([1000.0, 1100.0, 1200.0], dtype=jnp.float64),
+        ln_normalized_pressures=jnp.asarray([-1.0, 0.0, 1.0], dtype=jnp.float64),
+        element_vector=jnp.asarray([1.0], dtype=jnp.float64),
+        init=condmod.CondensateEquilibriumInit(
+            ln_nk=jnp.asarray([[10.0], [20.0], [30.0]], dtype=jnp.float64),
+            ln_mk=jnp.asarray([[1.0], [2.0], [3.0]], dtype=jnp.float64),
+            ln_ntot=jnp.asarray([100.0, 200.0, 300.0], dtype=jnp.float64),
+        ),
+        formula_matrix=jnp.asarray([[1.0]], dtype=jnp.float64),
+        formula_matrix_cond=jnp.asarray([[1.0]], dtype=jnp.float64),
+        hvector_func=lambda temperature: jnp.asarray([0.0], dtype=jnp.float64),
+        hvector_cond_func=lambda temperature: jnp.asarray([0.0], dtype=jnp.float64),
+        n_step=1,
+        max_iter=25,
+        method="scan_hot_from_top",
+    )
+
+    # Output order remains the same as the input profile order.
+    assert jnp.allclose(result.ln_nk[:, 0], jnp.asarray([12.0, 14.0, 16.0], dtype=jnp.float64))
+    assert jnp.allclose(result.ln_mk[:, 0], jnp.asarray([5.0, 9.0, 13.0], dtype=jnp.float64))
+    assert jnp.allclose(result.ln_ntot, jnp.asarray([106.0, 112.0, 118.0], dtype=jnp.float64))
+    assert result.diagnostics.n_iter.shape == (3,)
+    assert result.diagnostics.final_residual.shape == (3,)
+    assert result.diagnostics.epsilon.shape == (3,)
+    assert jnp.all(result.diagnostics.converged)
+
+
+def test_minimize_gibbs_cond_profile_vmap_cold_still_available(monkeypatch):
+    def stub_minimize_gibbs_cond(state, init, **kwargs):
+        return condmod.CondensateEquilibriumResult(
+            ln_nk=jnp.asarray(init.ln_nk) + 1.0,
+            ln_mk=jnp.asarray(init.ln_mk) + 1.0,
+            ln_ntot=jnp.asarray(init.ln_ntot) + 1.0,
+            diagnostics=condmod.CondensateEquilibriumDiagnostics(
+                n_iter=jnp.asarray(2, dtype=jnp.int32),
+                converged=jnp.asarray(True),
+                hit_max_iter=jnp.asarray(False),
+                final_residual=jnp.asarray(1.0e-12, dtype=jnp.float64),
+                residual_crit=jnp.asarray(kwargs["residual_crit"], dtype=jnp.float64),
+                max_iter=jnp.asarray(kwargs["max_iter"], dtype=jnp.int32),
+                epsilon=jnp.asarray(kwargs["epsilon"], dtype=jnp.float64),
+                final_step_size=jnp.asarray(0.25, dtype=jnp.float64),
+                invalid_numbers_detected=jnp.asarray(False),
+                debug_nan=jnp.asarray(kwargs["debug_nan"]),
+            ),
+        )
+
+    monkeypatch.setattr(condmod, "minimize_gibbs_cond", stub_minimize_gibbs_cond)
+
+    result = condmod.minimize_gibbs_cond_profile(
+        temperatures=jnp.asarray([1000.0, 1100.0, 1200.0], dtype=jnp.float64),
+        ln_normalized_pressures=jnp.asarray([-1.0, 0.0, 1.0], dtype=jnp.float64),
+        element_vector=jnp.asarray([1.0], dtype=jnp.float64),
+        init=condmod.CondensateEquilibriumInit(
+            ln_nk=jnp.asarray([[10.0], [20.0], [30.0]], dtype=jnp.float64),
+            ln_mk=jnp.asarray([[1.0], [2.0], [3.0]], dtype=jnp.float64),
+            ln_ntot=jnp.asarray([100.0, 200.0, 300.0], dtype=jnp.float64),
+        ),
+        formula_matrix=jnp.asarray([[1.0]], dtype=jnp.float64),
+        formula_matrix_cond=jnp.asarray([[1.0]], dtype=jnp.float64),
+        hvector_func=lambda temperature: jnp.asarray([0.0], dtype=jnp.float64),
+        hvector_cond_func=lambda temperature: jnp.asarray([0.0], dtype=jnp.float64),
+        n_step=1,
+        max_iter=25,
+        method="vmap_cold",
+    )
+
+    assert jnp.allclose(result.ln_nk[:, 0], jnp.asarray([12.0, 22.0, 32.0], dtype=jnp.float64))
+    assert jnp.allclose(result.ln_mk[:, 0], jnp.asarray([3.0, 4.0, 5.0], dtype=jnp.float64))
+    assert jnp.allclose(result.ln_ntot, jnp.asarray([102.0, 202.0, 302.0], dtype=jnp.float64))
+
+
+def test_minimize_gibbs_cond_profile_broadcasts_single_cold_start(monkeypatch):
+    def stub_minimize_gibbs_cond(state, init, **kwargs):
+        return condmod.CondensateEquilibriumResult(
+            ln_nk=jnp.asarray(init.ln_nk),
+            ln_mk=jnp.asarray(init.ln_mk),
+            ln_ntot=jnp.asarray(init.ln_ntot),
+            diagnostics=condmod.CondensateEquilibriumDiagnostics(
+                n_iter=jnp.asarray(1, dtype=jnp.int32),
+                converged=jnp.asarray(True),
+                hit_max_iter=jnp.asarray(False),
+                final_residual=jnp.asarray(1.0e-12, dtype=jnp.float64),
+                residual_crit=jnp.asarray(kwargs["residual_crit"], dtype=jnp.float64),
+                max_iter=jnp.asarray(kwargs["max_iter"], dtype=jnp.int32),
+                epsilon=jnp.asarray(kwargs["epsilon"], dtype=jnp.float64),
+                final_step_size=jnp.asarray(1.0, dtype=jnp.float64),
+                invalid_numbers_detected=jnp.asarray(False),
+                debug_nan=jnp.asarray(kwargs["debug_nan"]),
+            ),
+        )
+
+    monkeypatch.setattr(condmod, "minimize_gibbs_cond", stub_minimize_gibbs_cond)
+
+    result = condmod.minimize_gibbs_cond_profile(
+        temperatures=jnp.asarray([1000.0, 1100.0], dtype=jnp.float64),
+        ln_normalized_pressures=jnp.asarray([-1.0, 0.0], dtype=jnp.float64),
+        element_vector=jnp.asarray([1.0], dtype=jnp.float64),
+        init=condmod.CondensateEquilibriumInit(
+            ln_nk=jnp.asarray([5.0], dtype=jnp.float64),
+            ln_mk=jnp.asarray([6.0], dtype=jnp.float64),
+            ln_ntot=jnp.asarray(7.0, dtype=jnp.float64),
+        ),
+        formula_matrix=jnp.asarray([[1.0]], dtype=jnp.float64),
+        formula_matrix_cond=jnp.asarray([[1.0]], dtype=jnp.float64),
+        hvector_func=lambda temperature: jnp.asarray([0.0], dtype=jnp.float64),
+        hvector_cond_func=lambda temperature: jnp.asarray([0.0], dtype=jnp.float64),
+        n_step=1,
+        method="vmap_cold",
+    )
+
+    assert result.ln_nk.shape == (2, 1)
+    assert result.ln_mk.shape == (2, 1)
+    assert result.ln_ntot.shape == (2,)
+    assert jnp.allclose(result.ln_nk[:, 0], 5.0)
+    assert jnp.allclose(result.ln_mk[:, 0], 6.0)
+    assert jnp.allclose(result.ln_ntot, 7.0)


### PR DESCRIPTION
 ## Summary

  Add a symmetric condensate profile hot-start mode, `method="scan_hot_from_top"`, alongside the existing:
  - `method="vmap_cold"`
  - `method="scan_hot_from_bottom"`

  This keeps the structured Phase 1/2 condensate profile API intact while enabling clean comparison of top-down vs bottom-up carry behavior under the same per-layer solver path.

  ## What Changed

  - Extended `minimize_gibbs_cond_profile(...)` to support:
    - `vmap_cold`
    - `scan_hot_from_top`
    - `scan_hot_from_bottom`
  - Reused the same structured carry path:
    - `CondensateEquilibriumResult.to_init()`
  - Kept returned outputs in the original user-facing layer order for all methods
  - Added a small shared internal helper so top/down scans use the same core logic
  - Updated the condensate profile example to make all three modes selectable
  - Added focused contract tests for:
    - top-down hot-start execution
    - stable output ordering
    - stacked diagnostics shapes
    - preservation of existing modes

  ## Intentionally Unchanged

  This PR does **not** change:
  - the RGIE/PIPM inner solver math
  - iterate update equations
  - convergence criterion
  - epsilon continuation policy within a layer
  - gas-only behavior
  - carry-reset heuristics or phase-boundary logic

  Each layer still runs its own existing epsilon continuation from `epsilon_start` to `epsilon_crit`. The only change is profile scan direction and corresponding structured carry
  direction.

  ## Why

  We want to compare condensate profile behavior across:
  - independent cold starts
  - bottom-up hot starts
  - top-down hot starts

  without forcing users to manually carry raw `ln_nk` / `ln_mk` / `ln_ntot` tuples or changing the underlying numerical method.

  ## Testing

  Ran:

  ```bash
  pytest tests/unittests/optimize/minimize_cond_api_test.py tests/unittests/optimize/minimize_cond_diagnostics_test.py
  python -m compileall src/exogibbs/optimize/minimize_cond.py documents/ipynb/pipm/rgie/fastchem_cond_prof.py
  ```

  ## Notes

  This is a comparison-enabling extension only. If top-down and bottom-up scans show materially different robustness or convergence behavior, that should be handled in a later phase
  rather than in this PR.
