### PR TITLE
optimize: add condensate continuation diagnostics

### DIFF
--- a/documents/ipynb/pipm/rgie/fastchem_cond_prof.py
+++ b/documents/ipynb/pipm/rgie/fastchem_cond_prof.py
@@ -144,8 +144,9 @@ import jax.numpy as jnp
 from jax.scipy.special import logsumexp
 
 init_setup = "gas_only"  # "zeros" or "gas_only"
-profile_method = "scan_hot_from_bottom"  # or "vmap_cold" or "scan_hot_from_top"
-
+#profile_method = "scan_hot_from_bottom"  # or "vmap_cold" or "scan_hot_from_top"
+#profile_method = "scan_hot_from_top"  # or "vmap_cold" or "scan_hot_from_top"
+profile_method = "vmap_cold"
 
 def minimize_gibbs_cond_diagnostics(
     temperature,

--- a/src/exogibbs/optimize/minimize_cond.py
+++ b/src/exogibbs/optimize/minimize_cond.py
@@ -2,21 +2,29 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Literal, Optional
+from dataclasses import dataclass, field
+from typing import Literal, Optional, Sequence
 
 import jax
 import jax.numpy as jnp
 from jax import lax, tree_util
 
 from exogibbs.api.chemistry import ThermoState
+from exogibbs.optimize.stepsize import LOG_S_MAX
 from exogibbs.optimize.pdipm_cond import minimize_gibbs_cond_core
 from exogibbs.optimize.pipm_rgie_cond import (
     minimize_gibbs_cond_with_diagnostics as _minimize_gibbs_cond_with_diagnostics_raw,
 )
 
 Array = jax.Array
-CondensateProfileMethod = Literal["vmap_cold", "scan_hot_from_top", "scan_hot_from_bottom"]
+CondensateProfileMethod = Literal[
+    "vmap_cold",
+    "scan_hot_from_top",
+    "scan_hot_from_bottom",
+    "scan_hot_from_top_final_only",
+    "scan_hot_from_bottom_final_only",
+]
+CondensateEpsilonSchedule = Literal["fixed", "adaptive_sk_guard"]
 
 
 @tree_util.register_pytree_node_class
@@ -57,6 +65,19 @@ class CondensateEquilibriumDiagnostics:
     final_step_size: Array
     invalid_numbers_detected: Array
     debug_nan: Array
+    requested_epsilon: Array = field(
+        default_factory=lambda: jnp.asarray(jnp.nan, dtype=jnp.float64)
+    )
+    actual_epsilon: Array = field(
+        default_factory=lambda: jnp.asarray(jnp.nan, dtype=jnp.float64)
+    )
+    reached_requested_epsilon: Array = field(
+        default_factory=lambda: jnp.asarray(False)
+    )
+    plateaued: Array = field(default_factory=lambda: jnp.asarray(False))
+    first_plateau_epsilon: Array = field(
+        default_factory=lambda: jnp.asarray(jnp.nan, dtype=jnp.float64)
+    )
 
     def tree_flatten(self):
         children = (
@@ -70,6 +91,11 @@ class CondensateEquilibriumDiagnostics:
             self.final_step_size,
             self.invalid_numbers_detected,
             self.debug_nan,
+            self.requested_epsilon,
+            self.actual_epsilon,
+            self.reached_requested_epsilon,
+            self.plateaued,
+            self.first_plateau_epsilon,
         )
         return children, None
 
@@ -91,6 +117,17 @@ class CondensateEquilibriumDiagnostics:
             final_step_size=diagnostics["final_step_size"],
             invalid_numbers_detected=diagnostics["invalid_numbers_detected"],
             debug_nan=diagnostics["debug_nan"],
+            requested_epsilon=diagnostics.get("requested_epsilon", diagnostics["epsilon"]),
+            actual_epsilon=diagnostics.get("actual_epsilon", diagnostics["epsilon"]),
+            reached_requested_epsilon=diagnostics.get(
+                "reached_requested_epsilon",
+                jnp.asarray(True),
+            ),
+            plateaued=diagnostics.get("plateaued", jnp.asarray(False)),
+            first_plateau_epsilon=diagnostics.get(
+                "first_plateau_epsilon",
+                jnp.asarray(jnp.nan, dtype=jnp.asarray(diagnostics["epsilon"]).dtype),
+            ),
         )
 
     def asdict(self):
@@ -105,6 +142,11 @@ class CondensateEquilibriumDiagnostics:
             "final_step_size": self.final_step_size,
             "invalid_numbers_detected": self.invalid_numbers_detected,
             "debug_nan": self.debug_nan,
+            "requested_epsilon": self.requested_epsilon,
+            "actual_epsilon": self.actual_epsilon,
+            "reached_requested_epsilon": self.reached_requested_epsilon,
+            "plateaued": self.plateaued,
+            "first_plateau_epsilon": self.first_plateau_epsilon,
         }
 
 
@@ -224,6 +266,287 @@ def _flip_condensate_profile_result(
     return tree_util.tree_map(lambda x: jnp.flip(x, axis=0), result)
 
 
+def compute_sk_feasible_epsilon_floor(
+    ln_mk: Array,
+    log_s_max: float = LOG_S_MAX,
+) -> Array:
+    """Return the lowest epsilon that keeps the current condensate state sk-feasible."""
+
+    return jnp.max(2.0 * jnp.asarray(ln_mk) - log_s_max)
+
+
+def _summarize_sk_guard_boundary(
+    ln_mk: Array,
+    *,
+    condensate_species: Optional[Sequence[str]] = None,
+    top_k: int = 5,
+):
+    ln_mk = jnp.asarray(ln_mk)
+    floor_values = 2.0 * ln_mk - LOG_S_MAX
+    ranked = jnp.argsort(-floor_values)
+    limit = min(int(ln_mk.shape[0]), top_k)
+    indices = [int(i) for i in ranked[:limit]]
+    return {
+        "epsilon_floor": float(jnp.max(floor_values)),
+        "binding_indices": indices,
+        "binding_names": None
+        if condensate_species is None
+        else [str(condensate_species[i]) for i in indices],
+        "binding_floor_values": [float(floor_values[i]) for i in indices],
+        "binding_ln_mk": [float(ln_mk[i]) for i in indices],
+    }
+
+
+def _with_schedule_summary(
+    result: CondensateEquilibriumResult,
+    *,
+    requested_epsilon: float,
+    actual_epsilon: float,
+    reached_requested_epsilon: bool,
+    plateaued: bool,
+    first_plateau_epsilon: float,
+) -> CondensateEquilibriumResult:
+    diagnostics = result.diagnostics.asdict()
+    diagnostics["requested_epsilon"] = jnp.asarray(
+        requested_epsilon, dtype=jnp.asarray(result.diagnostics.epsilon).dtype
+    )
+    diagnostics["actual_epsilon"] = jnp.asarray(
+        actual_epsilon, dtype=jnp.asarray(result.diagnostics.epsilon).dtype
+    )
+    diagnostics["reached_requested_epsilon"] = jnp.asarray(reached_requested_epsilon)
+    diagnostics["plateaued"] = jnp.asarray(plateaued)
+    diagnostics["first_plateau_epsilon"] = jnp.asarray(
+        first_plateau_epsilon, dtype=jnp.asarray(result.diagnostics.epsilon).dtype
+    )
+    return CondensateEquilibriumResult(
+        ln_nk=result.ln_nk,
+        ln_mk=result.ln_mk,
+        ln_ntot=result.ln_ntot,
+        diagnostics=CondensateEquilibriumDiagnostics.from_mapping(diagnostics),
+    )
+
+
+def _stack_profile_results(results: Sequence[CondensateEquilibriumResult]) -> CondensateEquilibriumResult:
+    return tree_util.tree_map(lambda *xs: jnp.stack(xs, axis=0), *results)
+
+
+def _plateau_result_from_init(
+    init: CondensateEquilibriumInit,
+    *,
+    actual_epsilon: float,
+    requested_epsilon: float,
+    first_plateau_epsilon: float,
+    max_iter: int,
+    debug_nan: bool,
+) -> CondensateEquilibriumResult:
+    dtype = jnp.asarray(actual_epsilon, dtype=jnp.float64).dtype
+    return CondensateEquilibriumResult(
+        ln_nk=jnp.asarray(init.ln_nk),
+        ln_mk=jnp.asarray(init.ln_mk),
+        ln_ntot=jnp.asarray(init.ln_ntot),
+        diagnostics=CondensateEquilibriumDiagnostics(
+            n_iter=jnp.asarray(0, dtype=jnp.int32),
+            converged=jnp.asarray(False),
+            hit_max_iter=jnp.asarray(False),
+            final_residual=jnp.asarray(jnp.nan, dtype=dtype),
+            residual_crit=jnp.exp(jnp.asarray(actual_epsilon, dtype=dtype)),
+            max_iter=jnp.asarray(max_iter, dtype=jnp.int32),
+            epsilon=jnp.asarray(actual_epsilon, dtype=dtype),
+            final_step_size=jnp.asarray(0.0, dtype=dtype),
+            invalid_numbers_detected=jnp.asarray(False),
+            debug_nan=jnp.asarray(debug_nan),
+            requested_epsilon=jnp.asarray(requested_epsilon, dtype=dtype),
+            actual_epsilon=jnp.asarray(actual_epsilon, dtype=dtype),
+            reached_requested_epsilon=jnp.asarray(False),
+            plateaued=jnp.asarray(True),
+            first_plateau_epsilon=jnp.asarray(first_plateau_epsilon, dtype=dtype),
+        ),
+    )
+
+
+def _run_adaptive_condensate_layer_schedule(
+    state: ThermoState,
+    init: CondensateEquilibriumInit,
+    formula_matrix: jnp.ndarray,
+    formula_matrix_cond: jnp.ndarray,
+    hvector_func,
+    hvector_cond_func,
+    *,
+    epsilon_start: float,
+    epsilon_crit: float,
+    n_step: int,
+    max_iter: int,
+    element_indices: Optional[jnp.ndarray],
+    debug_nan: bool,
+    run_full_schedule: bool,
+    epsilon_guard_margin: float,
+    min_epsilon_step: float,
+    max_adaptive_schedule_steps: Optional[int],
+    condensate_species: Optional[Sequence[str]] = None,
+    top_k: int = 5,
+):
+    """Run one layer with an sk-feasibility-aware epsilon schedule."""
+
+    current_init = _prepare_condensate_init(init)
+    proposed_epsilons = (
+        jnp.linspace(epsilon_start, epsilon_crit, n_step + 1)[1:].tolist()
+        if run_full_schedule
+        else [float(epsilon_crit)]
+    )
+    requested_epsilon = float(epsilon_crit)
+    current_epsilon = float(epsilon_start)
+    stage_limit = max_adaptive_schedule_steps
+    if stage_limit is None:
+        stage_limit = len(proposed_epsilons) + max_iter
+
+    stages = []
+    last_result = None
+    first_plateau_epsilon = float("nan")
+    reached_requested_epsilon = False
+
+    for stage_index in range(stage_limit):
+        proposed_epsilon = (
+            float(proposed_epsilons[stage_index])
+            if stage_index < len(proposed_epsilons)
+            else requested_epsilon
+        )
+        boundary = _summarize_sk_guard_boundary(
+            current_init.ln_mk,
+            condensate_species=condensate_species,
+            top_k=top_k,
+        )
+        epsilon_floor = boundary["epsilon_floor"]
+        guarded_epsilon = max(proposed_epsilon, epsilon_floor + epsilon_guard_margin)
+        pre_feasible = bool(
+            jnp.all(LOG_S_MAX + guarded_epsilon - 2.0 * jnp.asarray(current_init.ln_mk) >= 0.0)
+        )
+
+        if guarded_epsilon >= current_epsilon - min_epsilon_step:
+            first_plateau_epsilon = guarded_epsilon
+            stages.append(
+                {
+                    "stage_index": stage_index,
+                    "current_epsilon": current_epsilon,
+                    "proposed_epsilon": proposed_epsilon,
+                    "epsilon_floor": epsilon_floor,
+                    "epsilon_next": guarded_epsilon,
+                    "stage_kind": "plateau-stopped",
+                    "pre_iteration_sk_feasible": pre_feasible,
+                    **boundary,
+                }
+            )
+            break
+
+        stage_kind = (
+            "sk-guard-limited"
+            if guarded_epsilon > proposed_epsilon + 0.5 * epsilon_guard_margin
+            else "fixed-schedule-limited"
+        )
+        stages.append(
+            {
+                "stage_index": stage_index,
+                "current_epsilon": current_epsilon,
+                "proposed_epsilon": proposed_epsilon,
+                "epsilon_floor": epsilon_floor,
+                "epsilon_next": guarded_epsilon,
+                "stage_kind": stage_kind,
+                "pre_iteration_sk_feasible": pre_feasible,
+                **boundary,
+            }
+        )
+
+        last_result = minimize_gibbs_cond(
+            state,
+            init=current_init,
+            formula_matrix=formula_matrix,
+            formula_matrix_cond=formula_matrix_cond,
+            hvector_func=hvector_func,
+            hvector_cond_func=hvector_cond_func,
+            epsilon=guarded_epsilon,
+            residual_crit=jnp.exp(guarded_epsilon),
+            max_iter=max_iter,
+            element_indices=element_indices,
+            debug_nan=debug_nan,
+        )
+        current_init = last_result.to_init()
+        current_epsilon = float(guarded_epsilon)
+
+        if current_epsilon <= requested_epsilon + min_epsilon_step:
+            reached_requested_epsilon = True
+            break
+
+    if reached_requested_epsilon:
+        final_boundary = _summarize_sk_guard_boundary(
+            current_init.ln_mk,
+            condensate_species=condensate_species,
+            top_k=top_k,
+        )
+        stages.append(
+            {
+                "stage_index": len(stages),
+                "current_epsilon": current_epsilon,
+                "proposed_epsilon": requested_epsilon,
+                "epsilon_floor": final_boundary["epsilon_floor"],
+                "epsilon_next": requested_epsilon,
+                "stage_kind": "final-repeat",
+                "pre_iteration_sk_feasible": bool(
+                    jnp.all(
+                        LOG_S_MAX
+                        + requested_epsilon
+                        - 2.0 * jnp.asarray(current_init.ln_mk)
+                        >= 0.0
+                    )
+                ),
+                **final_boundary,
+            }
+        )
+        last_result = minimize_gibbs_cond(
+            state,
+            init=current_init,
+            formula_matrix=formula_matrix,
+            formula_matrix_cond=formula_matrix_cond,
+            hvector_func=hvector_func,
+            hvector_cond_func=hvector_cond_func,
+            epsilon=requested_epsilon,
+            residual_crit=jnp.exp(requested_epsilon),
+            max_iter=max_iter,
+            element_indices=element_indices,
+            debug_nan=debug_nan,
+        )
+        actual_final_epsilon = requested_epsilon
+    else:
+        actual_final_epsilon = current_epsilon
+
+    if last_result is None:
+        last_result = _plateau_result_from_init(
+            current_init,
+            actual_epsilon=actual_final_epsilon,
+            requested_epsilon=requested_epsilon,
+            first_plateau_epsilon=first_plateau_epsilon,
+            max_iter=max_iter,
+            debug_nan=debug_nan,
+        )
+    else:
+        last_result = _with_schedule_summary(
+            last_result,
+            requested_epsilon=requested_epsilon,
+            actual_epsilon=actual_final_epsilon,
+            reached_requested_epsilon=reached_requested_epsilon,
+            plateaued=not reached_requested_epsilon,
+            first_plateau_epsilon=first_plateau_epsilon,
+        )
+
+    return last_result, {
+        "epsilon_start": float(epsilon_start),
+        "requested_epsilon_crit": requested_epsilon,
+        "actual_final_epsilon": float(actual_final_epsilon),
+        "reached_requested_epsilon": bool(reached_requested_epsilon),
+        "plateaued": bool(not reached_requested_epsilon),
+        "first_plateau_epsilon": float(first_plateau_epsilon),
+        "stages": stages,
+    }
+
+
 def minimize_gibbs_cond(
     state: ThermoState,
     init: CondensateEquilibriumInit,
@@ -286,23 +609,40 @@ def minimize_gibbs_cond_profile(
     method: CondensateProfileMethod = "scan_hot_from_bottom",
     element_indices: Optional[jnp.ndarray] = None,
     debug_nan: bool = False,
+    epsilon_schedule: CondensateEpsilonSchedule = "fixed",
+    epsilon_guard_margin: float = 1.0e-6,
+    min_epsilon_step: float = 1.0e-6,
+    max_adaptive_schedule_steps: Optional[int] = None,
 ) -> CondensateEquilibriumResult:
     """Run the condensate solver over a 1D profile with cold- or hot-start execution.
 
-    The per-layer epsilon continuation schedule is intentionally unchanged from the
-    current example path: each layer steps from ``epsilon_start`` to
+    The default per-layer epsilon continuation schedule is intentionally unchanged
+    from the current example path: each layer steps from ``epsilon_start`` to
     ``epsilon_crit`` and then performs one final solve at ``epsilon_crit`` so the
     returned diagnostics correspond to the final layer solve.
 
     ``method="scan_hot_from_top"`` and ``method="scan_hot_from_bottom"`` carry
     structured :class:`CondensateEquilibriumInit` state layer-to-layer using
-    :meth:`CondensateEquilibriumResult.to_init`. ``method="vmap_cold"`` keeps the
-    existing independent-layer behavior.
+    :meth:`CondensateEquilibriumResult.to_init`. The ``*_final_only`` scan
+    variants keep the first layer continuation but skip barrier rewind on later
+    layers by solving only once at ``epsilon_crit``. ``method="vmap_cold"``
+    keeps the existing independent-layer behavior.
     """
 
     if n_step < 1:
         raise ValueError("n_step must be at least 1.")
-    valid_methods = ("vmap_cold", "scan_hot_from_top", "scan_hot_from_bottom")
+    if epsilon_schedule not in ("fixed", "adaptive_sk_guard"):
+        raise ValueError(
+            "Unknown epsilon schedule "
+            f"'{epsilon_schedule}'. Expected one of ('fixed', 'adaptive_sk_guard')."
+        )
+    valid_methods = (
+        "vmap_cold",
+        "scan_hot_from_top",
+        "scan_hot_from_bottom",
+        "scan_hot_from_top_final_only",
+        "scan_hot_from_bottom_final_only",
+    )
     if method not in valid_methods:
         raise ValueError(f"Unknown condensate profile solve method '{method}'. Expected one of {valid_methods}.")
 
@@ -314,10 +654,102 @@ def minimize_gibbs_cond_profile(
     n_layers = int(temperatures.shape[0])
     epsilons = jnp.linspace(epsilon_start, epsilon_crit, n_step + 1)[1:]
 
+    if epsilon_schedule == "adaptive_sk_guard":
+        def solve_layer_adaptive(
+            temperature: Array,
+            ln_normalized_pressure: Array,
+            layer_init: CondensateEquilibriumInit,
+            run_full_schedule: bool,
+        ) -> CondensateEquilibriumResult:
+            thermo_state = ThermoState(
+                temperature=temperature,
+                ln_normalized_pressure=ln_normalized_pressure,
+                element_vector=element_vector,
+            )
+            result, _trace = _run_adaptive_condensate_layer_schedule(
+                thermo_state,
+                init=layer_init,
+                formula_matrix=formula_matrix,
+                formula_matrix_cond=formula_matrix_cond,
+                hvector_func=hvector_func,
+                hvector_cond_func=hvector_cond_func,
+                epsilon_start=epsilon_start,
+                epsilon_crit=epsilon_crit,
+                n_step=n_step,
+                max_iter=max_iter,
+                element_indices=element_indices,
+                debug_nan=debug_nan,
+                run_full_schedule=run_full_schedule,
+                epsilon_guard_margin=epsilon_guard_margin,
+                min_epsilon_step=min_epsilon_step,
+                max_adaptive_schedule_steps=max_adaptive_schedule_steps,
+            )
+            return result
+
+        if method == "vmap_cold":
+            results = []
+            for layer_index in range(n_layers):
+                results.append(
+                    solve_layer_adaptive(
+                        temperatures[layer_index],
+                        ln_normalized_pressures[layer_index],
+                        _profile_init_at(init, n_layers, layer_index),
+                        True,
+                    )
+                )
+            return _stack_profile_results(results)
+
+        def run_scan_adaptive(
+            temperatures_scan: Array,
+            ln_pressures_scan: Array,
+            init0: CondensateEquilibriumInit,
+            *,
+            skip_rewind_after_first_layer: bool,
+            reverse_output: bool,
+        ) -> CondensateEquilibriumResult:
+            carry_init = init0
+            run_full_schedule = True
+            results = []
+            for temperature, ln_normalized_pressure in zip(
+                temperatures_scan.tolist(),
+                ln_pressures_scan.tolist(),
+            ):
+                result = solve_layer_adaptive(
+                    jnp.asarray(temperature),
+                    jnp.asarray(ln_normalized_pressure),
+                    carry_init,
+                    run_full_schedule,
+                )
+                results.append(result)
+                carry_init = result.to_init()
+                run_full_schedule = not skip_rewind_after_first_layer
+            result_seq = _stack_profile_results(results)
+            if reverse_output:
+                return _flip_condensate_profile_result(result_seq)
+            return result_seq
+
+        if method in ("scan_hot_from_top", "scan_hot_from_top_final_only"):
+            return run_scan_adaptive(
+                temperatures,
+                ln_normalized_pressures,
+                _profile_init_at(init, n_layers, 0),
+                skip_rewind_after_first_layer=(method == "scan_hot_from_top_final_only"),
+                reverse_output=False,
+            )
+
+        return run_scan_adaptive(
+            jnp.flip(temperatures, axis=0),
+            jnp.flip(ln_normalized_pressures, axis=0),
+            _profile_init_at(init, n_layers, n_layers - 1),
+            skip_rewind_after_first_layer=(method == "scan_hot_from_bottom_final_only"),
+            reverse_output=True,
+        )
+
     def solve_layer(
         temperature: Array,
         ln_normalized_pressure: Array,
         layer_init: CondensateEquilibriumInit,
+        run_full_schedule: bool,
     ) -> CondensateEquilibriumResult:
         thermo_state = ThermoState(
             temperature=temperature,
@@ -343,13 +775,15 @@ def minimize_gibbs_cond_profile(
             )
             return result.to_init()
 
-        final_init = lax.fori_loop(
-            0,
-            n_step,
-            body_fn,
-            _prepare_condensate_init(layer_init),
-        )
         final_epsilon = epsilons[-1]
+        prepared_init = _prepare_condensate_init(layer_init)
+        final_init = lax.cond(
+            run_full_schedule,
+            lambda init_state: lax.fori_loop(0, n_step, body_fn, init_state),
+            lambda init_state: init_state,
+            prepared_init,
+        )
+
         return minimize_gibbs_cond(
             thermo_state,
             init=final_init,
@@ -372,35 +806,51 @@ def minimize_gibbs_cond_profile(
                 0,
                 0,
                 CondensateEquilibriumInit(ln_nk=0, ln_mk=0, ln_ntot=0),
+                None,
             ),
+            out_axes=0,
         )(
             temperatures,
             ln_normalized_pressures,
             batched_init,
+            True,
         )
-
-    def scan_body(carry_init, layer_inputs):
-        temperature, ln_normalized_pressure = layer_inputs
-        result = solve_layer(temperature, ln_normalized_pressure, carry_init)
-        return result.to_init(), result
 
     def run_scan(
         temperatures_scan: Array,
         ln_pressures_scan: Array,
         init0: CondensateEquilibriumInit,
         *,
+        skip_rewind_after_first_layer: bool,
         reverse_output: bool,
     ) -> CondensateEquilibriumResult:
-        _, result_seq = lax.scan(scan_body, init0, (temperatures_scan, ln_pressures_scan))
+        def scan_body(carry, layer_inputs):
+            carry_init, run_full_schedule = carry
+            temperature, ln_normalized_pressure = layer_inputs
+            result = solve_layer(
+                temperature,
+                ln_normalized_pressure,
+                carry_init,
+                run_full_schedule,
+            )
+            next_run_full_schedule = jnp.asarray(not skip_rewind_after_first_layer)
+            return (result.to_init(), next_run_full_schedule), result
+
+        init_carry = (
+            init0,
+            jnp.asarray(True),
+        )
+        _, result_seq = lax.scan(scan_body, init_carry, (temperatures_scan, ln_pressures_scan))
         if reverse_output:
             return _flip_condensate_profile_result(result_seq)
         return result_seq
 
-    if method == "scan_hot_from_top":
+    if method in ("scan_hot_from_top", "scan_hot_from_top_final_only"):
         return run_scan(
             temperatures,
             ln_normalized_pressures,
             _profile_init_at(init, n_layers, 0),
+            skip_rewind_after_first_layer=(method == "scan_hot_from_top_final_only"),
             reverse_output=False,
         )
 
@@ -408,17 +858,172 @@ def minimize_gibbs_cond_profile(
         jnp.flip(temperatures, axis=0),
         jnp.flip(ln_normalized_pressures, axis=0),
         _profile_init_at(init, n_layers, n_layers - 1),
+        skip_rewind_after_first_layer=(method == "scan_hot_from_bottom_final_only"),
         reverse_output=True,
     )
+
+
+def trace_adaptive_condensate_schedule(
+    state: ThermoState,
+    init: CondensateEquilibriumInit,
+    formula_matrix: jnp.ndarray,
+    formula_matrix_cond: jnp.ndarray,
+    hvector_func,
+    hvector_cond_func,
+    *,
+    epsilon_start: float = 0.0,
+    epsilon_crit: float = -40.0,
+    n_step: int = 100,
+    max_iter: int = 100,
+    element_indices: Optional[jnp.ndarray] = None,
+    debug_nan: bool = False,
+    run_full_schedule: bool = True,
+    epsilon_guard_margin: float = 1.0e-6,
+    min_epsilon_step: float = 1.0e-6,
+    max_adaptive_schedule_steps: Optional[int] = None,
+    condensate_species: Optional[Sequence[str]] = None,
+    top_k: int = 5,
+):
+    """Trace the adaptive sk-guarded epsilon path for one layer."""
+
+    _result, trace = _run_adaptive_condensate_layer_schedule(
+        state,
+        init=init,
+        formula_matrix=formula_matrix,
+        formula_matrix_cond=formula_matrix_cond,
+        hvector_func=hvector_func,
+        hvector_cond_func=hvector_cond_func,
+        epsilon_start=epsilon_start,
+        epsilon_crit=epsilon_crit,
+        n_step=n_step,
+        max_iter=max_iter,
+        element_indices=element_indices,
+        debug_nan=debug_nan,
+        run_full_schedule=run_full_schedule,
+        epsilon_guard_margin=epsilon_guard_margin,
+        min_epsilon_step=min_epsilon_step,
+        max_adaptive_schedule_steps=max_adaptive_schedule_steps,
+        condensate_species=condensate_species,
+        top_k=top_k,
+    )
+    return trace
+
+
+def trace_condensate_sk_stage_feasibility(
+    state: ThermoState,
+    init: CondensateEquilibriumInit,
+    formula_matrix: jnp.ndarray,
+    formula_matrix_cond: jnp.ndarray,
+    hvector_func,
+    hvector_cond_func,
+    *,
+    epsilon_start: float = 0.0,
+    epsilon_crit: float = -40.0,
+    n_step: int = 100,
+    max_iter: int = 100,
+    element_indices: Optional[jnp.ndarray] = None,
+    debug_nan: bool = False,
+    condensate_species: Optional[Sequence[str]] = None,
+    top_k: int = 5,
+    include_final_repeat: bool = True,
+):
+    """Trace stage-start sk feasibility along the existing continuation schedule.
+
+    This helper is diagnostic-only. It snapshots the current condensate state
+    before each scheduled epsilon solve and reports whether the sk admissibility
+    bound used by :func:`stepsize_sk` is already violated before Newton starts.
+    """
+
+    if n_step < 1:
+        raise ValueError("n_step must be at least 1.")
+
+    prepared_init = _prepare_condensate_init(init)
+    epsilons = jnp.linspace(epsilon_start, epsilon_crit, n_step + 1)[1:]
+    stages = []
+    current_init = prepared_init
+
+    def _record_stage(epsilon, stage_index: int, is_final_repeat: bool):
+        ln_mk = jnp.asarray(current_init.ln_mk)
+        ln_sk = 2.0 * ln_mk - epsilon
+        feasibility_num = LOG_S_MAX + epsilon - 2.0 * ln_mk
+        violation_margin = -feasibility_num
+        infeasible_mask = feasibility_num < 0.0
+        infeasible_indices = jnp.where(infeasible_mask)[0]
+        infeasible_count = int(infeasible_indices.shape[0])
+
+        if infeasible_count > 0:
+            positive_margin = jnp.where(infeasible_mask, violation_margin, -jnp.inf)
+            ranked = jnp.argsort(-positive_margin)
+            worst_indices = [int(i) for i in ranked[: min(top_k, infeasible_count)]]
+        else:
+            worst_indices = []
+
+        if condensate_species is None:
+            worst_names = None
+        else:
+            worst_names = [str(condensate_species[i]) for i in worst_indices]
+
+        stages.append(
+            {
+                "stage_index": stage_index,
+                "is_final_repeat": is_final_repeat,
+                "epsilon": float(epsilon),
+                "log_s_max": float(LOG_S_MAX),
+                "ln_mk": [float(x) for x in ln_mk],
+                "ln_sk": [float(x) for x in ln_sk],
+                "feasibility_num": [float(x) for x in feasibility_num],
+                "violation_margin": [float(x) for x in violation_margin],
+                "has_pre_iteration_sk_infeasibility": bool(jnp.any(infeasible_mask)),
+                "n_pre_iteration_sk_infeasible": infeasible_count,
+                "worst_infeasible_indices": worst_indices,
+                "worst_infeasible_names": worst_names,
+                "worst_infeasible_violation_margin": [float(violation_margin[i]) for i in worst_indices],
+                "worst_infeasible_ln_mk": [float(ln_mk[i]) for i in worst_indices],
+                "worst_infeasible_ln_sk": [float(ln_sk[i]) for i in worst_indices],
+                "condition": "log_s_max + epsilon - 2*ln_mk >= 0",
+            }
+        )
+
+    for stage_index, epsilon in enumerate(epsilons.tolist()):
+        _record_stage(epsilon, stage_index, False)
+        result = minimize_gibbs_cond(
+            state,
+            init=current_init,
+            formula_matrix=formula_matrix,
+            formula_matrix_cond=formula_matrix_cond,
+            hvector_func=hvector_func,
+            hvector_cond_func=hvector_cond_func,
+            epsilon=epsilon,
+            residual_crit=jnp.exp(epsilon),
+            max_iter=max_iter,
+            element_indices=element_indices,
+            debug_nan=debug_nan,
+        )
+        current_init = result.to_init()
+
+    if include_final_repeat:
+        _record_stage(float(epsilons[-1]), int(n_step), True)
+
+    return {
+        "epsilon_start": float(epsilon_start),
+        "epsilon_crit": float(epsilon_crit),
+        "n_step": int(n_step),
+        "max_iter": int(max_iter),
+        "stages": stages,
+    }
 
 
 __all__ = [
     "CondensateEquilibriumDiagnostics",
     "CondensateEquilibriumInit",
+    "CondensateEpsilonSchedule",
     "CondensateProfileMethod",
     "CondensateEquilibriumResult",
+    "compute_sk_feasible_epsilon_floor",
     "minimize_gibbs_cond",
     "minimize_gibbs_cond_profile",
     "minimize_gibbs_cond_core",
     "minimize_gibbs_cond_with_diagnostics",
+    "trace_adaptive_condensate_schedule",
+    "trace_condensate_sk_stage_feasibility",
 ]

--- a/src/exogibbs/optimize/pipm_rgie_cond.py
+++ b/src/exogibbs/optimize/pipm_rgie_cond.py
@@ -3,7 +3,7 @@ from jax import debug as jdebug
 from jax.lax import while_loop
 from jax.lax import cond
 from jax.scipy.linalg import lu_factor, lu_solve
-from typing import Dict, Tuple, Optional
+from typing import Dict, Tuple, Optional, Sequence, Any
 
 from exogibbs.api.chemistry import ThermoState
 from exogibbs.optimize.core import _A_diagn_At
@@ -89,6 +89,53 @@ def solve_reduced_gibbs_iteration_equations_cond(
     return assemble_variable[:-1], assemble_variable[-1]
 
 
+def _solve_reduced_gibbs_iteration_equations_cond_with_metrics(
+    nk: jnp.ndarray,
+    mk: jnp.ndarray,
+    ntotk: float,
+    formula_matrix: jnp.ndarray,
+    formula_matrix_cond: jnp.ndarray,
+    b: jnp.ndarray,
+    gk: jnp.ndarray,
+    bk: jnp.ndarray,
+    hvector_cond: jnp.ndarray,
+    sk: jnp.ndarray,
+) -> Tuple[jnp.ndarray, float, Dict[str, jnp.ndarray]]:
+    """Solve the reduced system and expose scale metrics for debugging."""
+
+    resn = jnp.sum(nk) - ntotk
+    Qk = _A_diagn_At(nk, formula_matrix) + _A_diagn_At(sk, formula_matrix_cond)
+    Angk = formula_matrix @ (gk * nk)
+    ngk = jnp.dot(nk, gk)
+
+    delta_bk_hat = b - (bk + formula_matrix_cond @ mk)
+    condvec = formula_matrix_cond @ (sk * hvector_cond - mk)
+
+    assemble_mat = jnp.block([[Qk, bk[:, None]], [bk[None, :], jnp.array([[resn]])]])
+    assemble_vec = jnp.concatenate(
+        [Angk + condvec + delta_bk_hat, jnp.array([ngk - resn])]
+    )
+
+    row_scale = jnp.maximum(jnp.max(jnp.abs(assemble_mat), axis=1, keepdims=True), 1.0)
+    assemble_mat_scaled = assemble_mat / row_scale
+    assemble_vec_scaled = assemble_vec / row_scale[:, 0]
+
+    lu, piv = lu_factor(assemble_mat_scaled)
+    assemble_variable = lu_solve((lu, piv), assemble_vec_scaled)
+
+    row_scale_flat = row_scale[:, 0]
+    metrics = {
+        "reduced_resn": resn,
+        "reduced_row_scale_min": jnp.min(row_scale_flat),
+        "reduced_row_scale_max": jnp.max(row_scale_flat),
+        "reduced_row_scale_ratio": jnp.max(row_scale_flat) / jnp.maximum(jnp.min(row_scale_flat), 1.0e-300),
+        "reduced_mat_maxabs": jnp.max(jnp.abs(assemble_mat)),
+        "reduced_vec_maxabs": jnp.max(jnp.abs(assemble_vec)),
+        "reduced_qk_maxabs": jnp.max(jnp.abs(Qk)),
+    }
+    return assemble_variable[:-1], assemble_variable[-1], metrics
+
+
 
 
 def _compute_residuals(
@@ -120,6 +167,109 @@ def _compute_residuals(
     resn_squared = jnp.dot(resn, resn)
 
     return jnp.sqrt(ress_squared + resc_squared + resj_squared + resn_squared)
+
+
+def _recompute_pi_for_residual(
+    nk: jnp.ndarray,
+    mk: jnp.ndarray,
+    ntot: float,
+    formula_matrix: jnp.ndarray,
+    formula_matrix_cond: jnp.ndarray,
+    b: jnp.ndarray,
+    gk: jnp.ndarray,
+    hvector_cond: jnp.ndarray,
+    epsilon: float,
+) -> jnp.ndarray:
+    """Re-solve the reduced system on the current state for residual evaluation only.
+
+    This solve is intentionally separate from the earlier solve that produced the
+    update direction. It is not fed back into the primal update; it is only used
+    to evaluate a post-update barrier residual on a self-consistent state.
+    """
+
+    bk = formula_matrix @ nk
+    sk = mk * mk * jnp.exp(-epsilon)
+    pi_vector, _delta_ln_ntot = solve_reduced_gibbs_iteration_equations_cond(
+        nk,
+        mk,
+        ntot,
+        formula_matrix,
+        formula_matrix_cond,
+        b,
+        gk,
+        bk,
+        hvector_cond,
+        sk,
+    )
+    return pi_vector
+
+
+def _compute_iteration_step_metrics(
+    ln_nk: jnp.ndarray,
+    ln_mk: jnp.ndarray,
+    ln_ntot: float,
+    formula_matrix: jnp.ndarray,
+    formula_matrix_cond: jnp.ndarray,
+    b: jnp.ndarray,
+    gk: jnp.ndarray,
+    hvector_cond: jnp.ndarray,
+    epsilon: float,
+) -> Dict[str, jnp.ndarray]:
+    """Compute the current PIPM step components without changing the update rule."""
+
+    nk = jnp.exp(ln_nk)
+    mk = jnp.exp(ln_mk)
+    ntot = jnp.exp(ln_ntot)
+    ln_sk = 2.0 * ln_mk - epsilon
+    bk = formula_matrix @ nk
+
+    pi_vector, delta_ln_ntot, reduced_metrics = _solve_reduced_gibbs_iteration_equations_cond_with_metrics(
+        nk,
+        mk,
+        ntot,
+        formula_matrix,
+        formula_matrix_cond,
+        b,
+        gk,
+        bk,
+        hvector_cond,
+        jnp.exp(ln_sk),
+    )
+
+    delta_ln_nk = formula_matrix.T @ pi_vector + delta_ln_ntot - gk
+    factor = jnp.exp(ln_mk - epsilon)
+    raw_delta_ln_mk = factor * (formula_matrix_cond.T @ pi_vector - hvector_cond) + 1.0
+
+    max_step_m = 0.1
+    delta_ln_mk = jnp.clip(raw_delta_ln_mk, -max_step_m, max_step_m)
+
+    lam1_gas = stepsize_cea_gas(delta_ln_nk, delta_ln_ntot, ln_nk, ln_ntot)
+    lam1_cond = stepsize_cond_heurstic(delta_ln_mk)
+    lam2_cond = stepsize_sk(delta_ln_mk, ln_mk, epsilon)
+    lam = jnp.minimum(1.0, jnp.minimum(lam1_gas, jnp.minimum(lam1_cond, lam2_cond)))
+    lam = jnp.clip(lam, 0.0, 1.0)
+
+    limiter_candidates = jnp.asarray([1.0, lam1_gas, lam1_cond, lam2_cond])
+    limiting_index = jnp.argmin(limiter_candidates).astype(jnp.int32)
+
+    metrics = {
+        "pi_vector": pi_vector,
+        "delta_ln_ntot": delta_ln_ntot,
+        "delta_ln_nk": delta_ln_nk,
+        "raw_delta_ln_mk": raw_delta_ln_mk,
+        "delta_ln_mk": delta_ln_mk,
+        "lam1_gas": lam1_gas,
+        "lam1_cond": lam1_cond,
+        "lam2_cond": lam2_cond,
+        "lam": lam,
+        "limiting_index": limiting_index,
+        "pi_norm": jnp.linalg.norm(pi_vector),
+        "max_abs_delta_ln_nk": jnp.max(jnp.abs(delta_ln_nk)),
+        "max_abs_raw_delta_ln_mk": jnp.max(jnp.abs(raw_delta_ln_mk)),
+        "max_abs_clipped_delta_ln_mk": jnp.max(jnp.abs(delta_ln_mk)),
+    }
+    metrics.update(reduced_metrics)
+    return metrics
 
 
 def _debug_array(label, array, iter_count, limit=None):
@@ -183,6 +333,55 @@ def _update_all(
     iter_count,
     debug_nan=False,
 ):
+    (
+        ln_nk,
+        ln_mk,
+        ln_ntot,
+        gk,
+        An,
+        Am,
+        residual,
+        lam,
+        _metrics,
+    ) = _update_all_with_metrics(
+        ln_nk,
+        ln_mk,
+        ln_ntot,
+        formula_matrix,
+        formula_matrix_cond,
+        b,
+        T,
+        ln_normalized_pressure,
+        hvector,
+        hvector_cond,
+        gk,
+        An,
+        Am,
+        epsilon,
+        iter_count,
+        debug_nan=debug_nan,
+    )
+    return ln_nk, ln_mk, ln_ntot, gk, An, Am, residual, lam
+
+
+def _update_all_with_metrics(
+    ln_nk,
+    ln_mk,
+    ln_ntot,
+    formula_matrix,
+    formula_matrix_cond,
+    b,
+    T,
+    ln_normalized_pressure,
+    hvector,
+    hvector_cond,
+    gk,
+    An,
+    Am,
+    epsilon,
+    iter_count,
+    debug_nan=False,
+):
 
     exp_overflow_limit = 700.0
     if debug_nan:
@@ -206,20 +405,21 @@ def _update_all(
         )
         _debug_array("ln_sk_scaled pre-exp", ln_sk, iter_count, exp_overflow_limit)
 
-    pi_vector, delta_ln_ntot = solve_reduced_gibbs_iteration_equations_cond(
-        jnp.exp(ln_nk),
-        jnp.exp(ln_mk),
-        jnp.exp(ln_ntot),
+    step_metrics = _compute_iteration_step_metrics(
+        ln_nk,
+        ln_mk,
+        ln_ntot,
         formula_matrix,
         formula_matrix_cond,
         b,
         gk,
-        bk,
         hvector_cond,
-        jnp.exp(ln_sk),
+        epsilon,
     )
+    pi_vector = step_metrics["pi_vector"]
+    delta_ln_ntot = step_metrics["delta_ln_ntot"]
 
-    delta_ln_nk = formula_matrix.T @ pi_vector + delta_ln_ntot - gk
+    delta_ln_nk = step_metrics["delta_ln_nk"]
     # this breaks the results. we cannot clip here.
     # raw_delta_ln_nk = formula_matrix.T @ pi_vector + delta_ln_ntot - gk
     # MAX_STEP_N_UP = 10.0  # do not update larger than ln(n) 0.1e ~ 10%
@@ -233,25 +433,17 @@ def _update_all(
             "log_m_over_nu pre-exp", log_m_over_nu, iter_count, exp_overflow_limit
         )
 
-    factor = jnp.exp(log_m_over_nu)
-    raw_delta_ln_mk = (
-        factor * (formula_matrix_cond.T @ pi_vector - hvector_cond) + 1.0
-    )  # here we first have NaN
+    raw_delta_ln_mk = step_metrics["raw_delta_ln_mk"]
 
     MAX_STEP_M_UP = 0.1  # do not update larger than ln(m) 0.1e ~ 10%
     MAX_STEP_M_LOW = 0.1
-    delta_ln_mk = jnp.clip(raw_delta_ln_mk, -MAX_STEP_M_LOW, MAX_STEP_M_UP)
+    delta_ln_mk = step_metrics["delta_ln_mk"]
     # delta_ln_mk = jnp.exp(ln_mk - epsilon) * (formula_matrix_cond.T @ pi_vector - hvector_cond) + 1.0
 
     # relaxation and update
     # lam = 0.0001  # need to reconsider
 
-    lam1_gas = stepsize_cea_gas(delta_ln_nk, delta_ln_ntot, ln_nk, ln_ntot)
-    lam1_cond = stepsize_cond_heurstic(delta_ln_mk)
-    lam2_cond = stepsize_sk(delta_ln_mk, ln_mk, epsilon)
-    lam = jnp.minimum(1.0, jnp.minimum(lam1_gas, jnp.minimum(lam1_cond, lam2_cond)))
-    # Do not force a minimum step; allow very small values when needed.
-    lam = jnp.clip(lam, 0.0, 1.0)
+    lam = step_metrics["lam"]
 
     ln_ntot += lam * delta_ln_ntot
     ln_nk += lam * delta_ln_nk
@@ -262,7 +454,7 @@ def _update_all(
     # ln_ntot = jnp.clip(ln_ntot, LOG_MIN, LOG_MAX)
     # ln_mk = jnp.clip(ln_mk, LOG_MIN, LOG_MAX)
 
-    # computes new gk,An and residuals
+    # Rebuild the thermodynamic state after the damped primal update.
 
     nk = jnp.exp(ln_nk)
     mk = jnp.exp(ln_mk)
@@ -270,6 +462,20 @@ def _update_all(
     gk = _compute_gk(T, ln_nk, ln_ntot, hvector, ln_normalized_pressure)
     An = formula_matrix @ nk
     Am = formula_matrix_cond @ mk
+
+    # The earlier reduced solve defined the update direction. Re-solve only to
+    # evaluate the barrier residual on this updated state.
+    pi_vector_resid = _recompute_pi_for_residual(
+        nk,
+        mk,
+        ntot,
+        formula_matrix,
+        formula_matrix_cond,
+        b,
+        gk,
+        hvector_cond,
+        epsilon,
+    )
 
     residual = _compute_residuals(
         nk,
@@ -283,11 +489,13 @@ def _update_all(
         jnp.exp(epsilon),
         An,
         Am,
-        pi_vector,
+        pi_vector_resid,
     )
     if debug_nan:
         _debug_array("residual", jnp.array([residual]), iter_count)
-    return ln_nk, ln_mk, ln_ntot, gk, An, Am, residual, lam
+    trace_metrics = dict(step_metrics)
+    trace_metrics["residual"] = residual
+    return ln_nk, ln_mk, ln_ntot, gk, An, Am, residual, lam, trace_metrics
 
 
 def _contains_invalid_numbers(*arrays) -> jnp.ndarray:
@@ -524,3 +732,181 @@ def minimize_gibbs_cond_with_diagnostics(
         "debug_nan": jnp.asarray(debug_nan),
     }
     return ln_nk, ln_mk, ln_ntot, diagnostics
+
+
+def trace_minimize_gibbs_cond_iterations(
+    state: ThermoState,
+    ln_nk_init: jnp.ndarray,
+    ln_mk_init: jnp.ndarray,
+    ln_ntot_init: float,
+    formula_matrix: jnp.ndarray,
+    formula_matrix_cond: jnp.ndarray,
+    hvector_func,
+    hvector_cond_func,
+    epsilon: float,
+    residual_crit: float = 1.0e-11,
+    max_iter: int = 1000,
+    element_indices: Optional[jnp.ndarray] = None,
+    tiny_step: float = 1.0e-14,
+) -> Dict[str, Any]:
+    """Run one condensate layer with a full per-iteration trace for debugging."""
+
+    n_elements = formula_matrix.shape[0]
+    b = (
+        jnp.asarray(state.element_vector)
+        if element_indices is None
+        else jnp.asarray(state.element_vector)[jnp.asarray(element_indices)]
+    )
+    if b.shape[0] != n_elements:
+        raise ValueError(
+            "ThermoState.element_vector length does not match the number of element rows "
+            f"in the formula matrices (got {b.shape[0]}, expected {n_elements}). "
+            "Provide element_indices that map the state vector onto the reduced element set."
+        )
+
+    hvector = hvector_func(state.temperature)
+    hvector_cond = hvector_cond_func(state.temperature)
+    ln_nk = jnp.asarray(ln_nk_init)
+    ln_mk = jnp.asarray(ln_mk_init)
+    ln_ntot = jnp.asarray(ln_ntot_init)
+    gk = _compute_gk(
+        state.temperature,
+        ln_nk,
+        ln_ntot,
+        hvector,
+        state.ln_normalized_pressure,
+    )
+    An = formula_matrix @ jnp.exp(ln_nk)
+    Am = formula_matrix_cond @ jnp.exp(ln_mk)
+    residual = jnp.inf
+    history = []
+
+    for iter_count in range(max_iter):
+        if float(residual) <= float(residual_crit):
+            break
+
+        (
+            ln_nk,
+            ln_mk,
+            ln_ntot,
+            gk,
+            An,
+            Am,
+            residual,
+            lam,
+            metrics,
+        ) = _update_all_with_metrics(
+            ln_nk,
+            ln_mk,
+            ln_ntot,
+            formula_matrix,
+            formula_matrix_cond,
+            b,
+            state.temperature,
+            state.ln_normalized_pressure,
+            hvector,
+            hvector_cond,
+            gk,
+            An,
+            Am,
+            epsilon,
+            iter_count,
+            debug_nan=False,
+        )
+        record = {
+            "iter": iter_count,
+            "residual": float(residual),
+            "lam": float(metrics["lam"]),
+            "lam1_gas": float(metrics["lam1_gas"]),
+            "lam1_cond": float(metrics["lam1_cond"]),
+            "lam2_cond": float(metrics["lam2_cond"]),
+            "limiting_index": int(metrics["limiting_index"]),
+            "max_abs_delta_ln_nk": float(metrics["max_abs_delta_ln_nk"]),
+            "max_abs_raw_delta_ln_mk": float(metrics["max_abs_raw_delta_ln_mk"]),
+            "max_abs_clipped_delta_ln_mk": float(metrics["max_abs_clipped_delta_ln_mk"]),
+            "delta_ln_ntot": float(metrics["delta_ln_ntot"]),
+            "pi_norm": float(metrics["pi_norm"]),
+            "reduced_resn": float(metrics["reduced_resn"]),
+            "reduced_row_scale_min": float(metrics["reduced_row_scale_min"]),
+            "reduced_row_scale_max": float(metrics["reduced_row_scale_max"]),
+            "reduced_row_scale_ratio": float(metrics["reduced_row_scale_ratio"]),
+            "reduced_mat_maxabs": float(metrics["reduced_mat_maxabs"]),
+            "reduced_vec_maxabs": float(metrics["reduced_vec_maxabs"]),
+            "reduced_qk_maxabs": float(metrics["reduced_qk_maxabs"]),
+        }
+        history.append(record)
+        if record["lam"] <= tiny_step:
+            break
+
+    return {
+        "epsilon": float(epsilon),
+        "residual_crit": float(residual_crit),
+        "n_iter": len(history),
+        "final_residual": float(residual),
+        "converged": bool(float(residual) <= float(residual_crit)),
+        "hit_max_iter": bool(len(history) >= max_iter and float(residual) > float(residual_crit)),
+        "history": history,
+        "ln_nk": ln_nk,
+        "ln_mk": ln_mk,
+        "ln_ntot": ln_ntot,
+    }
+
+
+def trace_minimize_gibbs_cond_epsilon_sweep(
+    state: ThermoState,
+    ln_nk_init: jnp.ndarray,
+    ln_mk_init: jnp.ndarray,
+    ln_ntot_init: float,
+    formula_matrix: jnp.ndarray,
+    formula_matrix_cond: jnp.ndarray,
+    hvector_func,
+    hvector_cond_func,
+    epsilons: Sequence[float],
+    max_iter: int = 1000,
+    element_indices: Optional[jnp.ndarray] = None,
+    tiny_step: float = 1.0e-14,
+) -> Dict[str, Any]:
+    """Trace one layer over a fixed list of epsilon values and summarize stagnation."""
+
+    traces = []
+    limiter_names = {
+        0: "none_or_full_step",
+        1: "gas_step_limiter",
+        2: "condensate_step_limiter",
+        3: "sk_limiter",
+    }
+    for epsilon in epsilons:
+        trace = trace_minimize_gibbs_cond_iterations(
+            state,
+            ln_nk_init,
+            ln_mk_init,
+            ln_ntot_init,
+            formula_matrix,
+            formula_matrix_cond,
+            hvector_func,
+            hvector_cond_func,
+            epsilon=float(epsilon),
+            residual_crit=float(jnp.exp(jnp.asarray(epsilon))),
+            max_iter=max_iter,
+            element_indices=element_indices,
+            tiny_step=tiny_step,
+        )
+        history = trace["history"]
+        first_tiny = next((rec for rec in history if rec["lam"] <= tiny_step), None)
+        first_tiny_iter = None if first_tiny is None else first_tiny["iter"]
+        first_tiny_limiter = None if first_tiny is None else limiter_names.get(first_tiny["limiting_index"], "unknown")
+        residuals = [rec["residual"] for rec in history]
+        residual_decreased_before_stagnation = any(
+            curr < prev for prev, curr in zip(residuals[:-1], residuals[1:])
+        )
+        row_scale_ratio = None if first_tiny is None else first_tiny["reduced_row_scale_ratio"]
+        trace["summary"] = {
+            "made_progress": residual_decreased_before_stagnation,
+            "first_tiny_lam_iter": first_tiny_iter,
+            "first_tiny_lam_limiter": first_tiny_limiter,
+            "residual_decreased_before_stagnation": residual_decreased_before_stagnation,
+            "appears_ill_scaled": False if row_scale_ratio is None else bool(row_scale_ratio > 1.0e12),
+        }
+        traces.append(trace)
+
+    return {"epsilons": [float(eps) for eps in epsilons], "traces": traces}

--- a/tests/unittests/optimize/minimize_cond_api_test.py
+++ b/tests/unittests/optimize/minimize_cond_api_test.py
@@ -317,6 +317,98 @@ def test_minimize_gibbs_cond_profile_vmap_cold_still_available(monkeypatch):
     assert jnp.allclose(result.ln_ntot, jnp.asarray([102.0, 202.0, 302.0], dtype=jnp.float64))
 
 
+def test_minimize_gibbs_cond_profile_scan_hot_from_top_final_only_skips_rewind_after_first_layer(monkeypatch):
+    def stub_minimize_gibbs_cond(state, init, **kwargs):
+        return condmod.CondensateEquilibriumResult(
+            ln_nk=jnp.asarray(init.ln_nk) + 1.0,
+            ln_mk=jnp.asarray(init.ln_mk) + 2.0,
+            ln_ntot=jnp.asarray(init.ln_ntot) + 3.0,
+            diagnostics=condmod.CondensateEquilibriumDiagnostics(
+                n_iter=jnp.asarray(4, dtype=jnp.int32),
+                converged=jnp.asarray(True),
+                hit_max_iter=jnp.asarray(False),
+                final_residual=jnp.asarray(1.0e-12, dtype=jnp.float64),
+                residual_crit=jnp.asarray(kwargs["residual_crit"], dtype=jnp.float64),
+                max_iter=jnp.asarray(kwargs["max_iter"], dtype=jnp.int32),
+                epsilon=jnp.asarray(kwargs["epsilon"], dtype=jnp.float64),
+                final_step_size=jnp.asarray(0.5, dtype=jnp.float64),
+                invalid_numbers_detected=jnp.asarray(False),
+                debug_nan=jnp.asarray(kwargs["debug_nan"]),
+            ),
+        )
+
+    monkeypatch.setattr(condmod, "minimize_gibbs_cond", stub_minimize_gibbs_cond)
+
+    result = condmod.minimize_gibbs_cond_profile(
+        temperatures=jnp.asarray([1000.0, 1100.0, 1200.0], dtype=jnp.float64),
+        ln_normalized_pressures=jnp.asarray([-1.0, 0.0, 1.0], dtype=jnp.float64),
+        element_vector=jnp.asarray([1.0], dtype=jnp.float64),
+        init=condmod.CondensateEquilibriumInit(
+            ln_nk=jnp.asarray([[10.0], [20.0], [30.0]], dtype=jnp.float64),
+            ln_mk=jnp.asarray([[1.0], [2.0], [3.0]], dtype=jnp.float64),
+            ln_ntot=jnp.asarray([100.0, 200.0, 300.0], dtype=jnp.float64),
+        ),
+        formula_matrix=jnp.asarray([[1.0]], dtype=jnp.float64),
+        formula_matrix_cond=jnp.asarray([[1.0]], dtype=jnp.float64),
+        hvector_func=lambda temperature: jnp.asarray([0.0], dtype=jnp.float64),
+        hvector_cond_func=lambda temperature: jnp.asarray([0.0], dtype=jnp.float64),
+        n_step=1,
+        max_iter=25,
+        method="scan_hot_from_top_final_only",
+    )
+
+    assert jnp.allclose(result.ln_nk[:, 0], jnp.asarray([12.0, 13.0, 14.0], dtype=jnp.float64))
+    assert jnp.allclose(result.ln_mk[:, 0], jnp.asarray([5.0, 7.0, 9.0], dtype=jnp.float64))
+    assert jnp.allclose(result.ln_ntot, jnp.asarray([106.0, 109.0, 112.0], dtype=jnp.float64))
+    assert jnp.all(result.diagnostics.converged)
+
+
+def test_minimize_gibbs_cond_profile_scan_hot_from_bottom_final_only_skips_rewind_after_first_layer(monkeypatch):
+    def stub_minimize_gibbs_cond(state, init, **kwargs):
+        return condmod.CondensateEquilibriumResult(
+            ln_nk=jnp.asarray(init.ln_nk) + 1.0,
+            ln_mk=jnp.asarray(init.ln_mk) + 2.0,
+            ln_ntot=jnp.asarray(init.ln_ntot) + 3.0,
+            diagnostics=condmod.CondensateEquilibriumDiagnostics(
+                n_iter=jnp.asarray(4, dtype=jnp.int32),
+                converged=jnp.asarray(True),
+                hit_max_iter=jnp.asarray(False),
+                final_residual=jnp.asarray(1.0e-12, dtype=jnp.float64),
+                residual_crit=jnp.asarray(kwargs["residual_crit"], dtype=jnp.float64),
+                max_iter=jnp.asarray(kwargs["max_iter"], dtype=jnp.int32),
+                epsilon=jnp.asarray(kwargs["epsilon"], dtype=jnp.float64),
+                final_step_size=jnp.asarray(0.5, dtype=jnp.float64),
+                invalid_numbers_detected=jnp.asarray(False),
+                debug_nan=jnp.asarray(kwargs["debug_nan"]),
+            ),
+        )
+
+    monkeypatch.setattr(condmod, "minimize_gibbs_cond", stub_minimize_gibbs_cond)
+
+    result = condmod.minimize_gibbs_cond_profile(
+        temperatures=jnp.asarray([1000.0, 1100.0, 1200.0], dtype=jnp.float64),
+        ln_normalized_pressures=jnp.asarray([-1.0, 0.0, 1.0], dtype=jnp.float64),
+        element_vector=jnp.asarray([1.0], dtype=jnp.float64),
+        init=condmod.CondensateEquilibriumInit(
+            ln_nk=jnp.asarray([[10.0], [20.0], [30.0]], dtype=jnp.float64),
+            ln_mk=jnp.asarray([[1.0], [2.0], [3.0]], dtype=jnp.float64),
+            ln_ntot=jnp.asarray([100.0, 200.0, 300.0], dtype=jnp.float64),
+        ),
+        formula_matrix=jnp.asarray([[1.0]], dtype=jnp.float64),
+        formula_matrix_cond=jnp.asarray([[1.0]], dtype=jnp.float64),
+        hvector_func=lambda temperature: jnp.asarray([0.0], dtype=jnp.float64),
+        hvector_cond_func=lambda temperature: jnp.asarray([0.0], dtype=jnp.float64),
+        n_step=1,
+        max_iter=25,
+        method="scan_hot_from_bottom_final_only",
+    )
+
+    assert jnp.allclose(result.ln_nk[:, 0], jnp.asarray([34.0, 33.0, 32.0], dtype=jnp.float64))
+    assert jnp.allclose(result.ln_mk[:, 0], jnp.asarray([11.0, 9.0, 7.0], dtype=jnp.float64))
+    assert jnp.allclose(result.ln_ntot, jnp.asarray([312.0, 309.0, 306.0], dtype=jnp.float64))
+    assert jnp.all(result.diagnostics.converged)
+
+
 def test_minimize_gibbs_cond_profile_broadcasts_single_cold_start(monkeypatch):
     def stub_minimize_gibbs_cond(state, init, **kwargs):
         return condmod.CondensateEquilibriumResult(
@@ -362,3 +454,103 @@ def test_minimize_gibbs_cond_profile_broadcasts_single_cold_start(monkeypatch):
     assert jnp.allclose(result.ln_nk[:, 0], 5.0)
     assert jnp.allclose(result.ln_mk[:, 0], 6.0)
     assert jnp.allclose(result.ln_ntot, 7.0)
+
+
+def test_trace_adaptive_condensate_schedule_reports_guard_and_plateau(monkeypatch):
+    def stub_minimize_gibbs_cond(state, init, **kwargs):
+        return condmod.CondensateEquilibriumResult(
+            ln_nk=jnp.asarray(init.ln_nk),
+            ln_mk=jnp.asarray(init.ln_mk),
+            ln_ntot=jnp.asarray(init.ln_ntot),
+            diagnostics=condmod.CondensateEquilibriumDiagnostics(
+                n_iter=jnp.asarray(1, dtype=jnp.int32),
+                converged=jnp.asarray(False),
+                hit_max_iter=jnp.asarray(False),
+                final_residual=jnp.asarray(1.0, dtype=jnp.float64),
+                residual_crit=jnp.asarray(kwargs["residual_crit"], dtype=jnp.float64),
+                max_iter=jnp.asarray(kwargs["max_iter"], dtype=jnp.int32),
+                epsilon=jnp.asarray(kwargs["epsilon"], dtype=jnp.float64),
+                final_step_size=jnp.asarray(0.1, dtype=jnp.float64),
+                invalid_numbers_detected=jnp.asarray(False),
+                debug_nan=jnp.asarray(kwargs["debug_nan"]),
+            ),
+        )
+
+    monkeypatch.setattr(condmod, "minimize_gibbs_cond", stub_minimize_gibbs_cond)
+
+    state = ThermoState(
+        temperature=jnp.asarray(1000.0, dtype=jnp.float64),
+        ln_normalized_pressure=jnp.asarray(0.0, dtype=jnp.float64),
+        element_vector=jnp.asarray([1.0], dtype=jnp.float64),
+    )
+    trace = condmod.trace_adaptive_condensate_schedule(
+        state,
+        init=condmod.CondensateEquilibriumInit(
+            ln_nk=jnp.asarray([0.0], dtype=jnp.float64),
+            ln_mk=jnp.asarray([6.8], dtype=jnp.float64),
+            ln_ntot=jnp.asarray(0.0, dtype=jnp.float64),
+        ),
+        formula_matrix=jnp.asarray([[1.0]], dtype=jnp.float64),
+        formula_matrix_cond=jnp.asarray([[1.0]], dtype=jnp.float64),
+        hvector_func=lambda temperature: jnp.asarray([0.0], dtype=jnp.float64),
+        hvector_cond_func=lambda temperature: jnp.asarray([0.0], dtype=jnp.float64),
+        epsilon_start=0.0,
+        epsilon_crit=-1.0,
+        n_step=1,
+        max_iter=1,
+        condensate_species=["guarded_cond"],
+    )
+
+    assert trace["stages"][0]["stage_kind"] == "sk-guard-limited"
+    assert trace["stages"][1]["stage_kind"] == "plateau-stopped"
+    assert not trace["reached_requested_epsilon"]
+    assert trace["plateaued"]
+
+
+def test_minimize_gibbs_cond_profile_adaptive_reports_actual_epsilon(monkeypatch):
+    def stub_minimize_gibbs_cond(state, init, **kwargs):
+        return condmod.CondensateEquilibriumResult(
+            ln_nk=jnp.asarray(init.ln_nk),
+            ln_mk=jnp.asarray(init.ln_mk),
+            ln_ntot=jnp.asarray(init.ln_ntot),
+            diagnostics=condmod.CondensateEquilibriumDiagnostics(
+                n_iter=jnp.asarray(1, dtype=jnp.int32),
+                converged=jnp.asarray(False),
+                hit_max_iter=jnp.asarray(False),
+                final_residual=jnp.asarray(1.0, dtype=jnp.float64),
+                residual_crit=jnp.asarray(kwargs["residual_crit"], dtype=jnp.float64),
+                max_iter=jnp.asarray(kwargs["max_iter"], dtype=jnp.int32),
+                epsilon=jnp.asarray(kwargs["epsilon"], dtype=jnp.float64),
+                final_step_size=jnp.asarray(0.1, dtype=jnp.float64),
+                invalid_numbers_detected=jnp.asarray(False),
+                debug_nan=jnp.asarray(kwargs["debug_nan"]),
+            ),
+        )
+
+    monkeypatch.setattr(condmod, "minimize_gibbs_cond", stub_minimize_gibbs_cond)
+
+    result = condmod.minimize_gibbs_cond_profile(
+        temperatures=jnp.asarray([1000.0], dtype=jnp.float64),
+        ln_normalized_pressures=jnp.asarray([0.0], dtype=jnp.float64),
+        element_vector=jnp.asarray([1.0], dtype=jnp.float64),
+        init=condmod.CondensateEquilibriumInit(
+            ln_nk=jnp.asarray([[0.0]], dtype=jnp.float64),
+            ln_mk=jnp.asarray([[6.8]], dtype=jnp.float64),
+            ln_ntot=jnp.asarray([0.0], dtype=jnp.float64),
+        ),
+        formula_matrix=jnp.asarray([[1.0]], dtype=jnp.float64),
+        formula_matrix_cond=jnp.asarray([[1.0]], dtype=jnp.float64),
+        hvector_func=lambda temperature: jnp.asarray([0.0], dtype=jnp.float64),
+        hvector_cond_func=lambda temperature: jnp.asarray([0.0], dtype=jnp.float64),
+        epsilon_start=0.0,
+        epsilon_crit=-1.0,
+        n_step=1,
+        max_iter=1,
+        method="vmap_cold",
+        epsilon_schedule="adaptive_sk_guard",
+    )
+
+    assert bool(result.diagnostics.plateaued[0])
+    assert not bool(result.diagnostics.reached_requested_epsilon[0])
+    assert float(result.diagnostics.actual_epsilon[0]) > -1.0
+    assert float(result.diagnostics.requested_epsilon[0]) == -1.0

--- a/tests/unittests/optimize/minimize_cond_diagnostics_test.py
+++ b/tests/unittests/optimize/minimize_cond_diagnostics_test.py
@@ -4,7 +4,15 @@ from jax import config
 config.update("jax_enable_x64", True)
 
 from exogibbs.api.chemistry import ThermoState
+from exogibbs.optimize.minimize_cond import CondensateEquilibriumInit
+from exogibbs.optimize.minimize_cond import trace_condensate_sk_stage_feasibility
+from exogibbs.optimize.core import _compute_gk
+from exogibbs.optimize.pipm_rgie_cond import _compute_residuals
+from exogibbs.optimize.pipm_rgie_cond import _recompute_pi_for_residual
+from exogibbs.optimize.pipm_rgie_cond import _update_all
 from exogibbs.optimize.pipm_rgie_cond import minimize_gibbs_cond_with_diagnostics
+from exogibbs.optimize.pipm_rgie_cond import solve_reduced_gibbs_iteration_equations_cond
+from exogibbs.optimize.pipm_rgie_cond import trace_minimize_gibbs_cond_epsilon_sweep
 
 
 def test_minimize_gibbs_cond_with_diagnostics_smoke():
@@ -62,3 +70,182 @@ def test_minimize_gibbs_cond_with_diagnostics_smoke():
     assert not bool(diagnostics["invalid_numbers_detected"])
     assert not bool(diagnostics["debug_nan"])
     assert not (bool(diagnostics["converged"]) and bool(diagnostics["hit_max_iter"]))
+
+
+def test_update_all_reports_post_update_residual_with_fresh_pi():
+    formula_matrix = jnp.array([[1.0, 1.0], [0.0, 1.0]], dtype=jnp.float64)
+    formula_matrix_cond = jnp.array([[1.0], [0.0]], dtype=jnp.float64)
+    epsilon = jnp.asarray(-3.0, dtype=jnp.float64)
+    temperature = jnp.asarray(1000.0, dtype=jnp.float64)
+    ln_normalized_pressure = jnp.asarray(0.0, dtype=jnp.float64)
+    b = jnp.array([1.5, 0.5], dtype=jnp.float64)
+    hvector = jnp.array([0.0, 0.1], dtype=jnp.float64)
+    hvector_cond = jnp.array([-0.3], dtype=jnp.float64)
+
+    ln_nk0 = jnp.array([0.0, 0.0], dtype=jnp.float64)
+    ln_mk0 = jnp.array([0.5], dtype=jnp.float64)
+    ln_ntot0 = jnp.asarray(0.1, dtype=jnp.float64)
+    gk0 = _compute_gk(temperature, ln_nk0, ln_ntot0, hvector, ln_normalized_pressure)
+    An0 = formula_matrix @ jnp.exp(ln_nk0)
+    Am0 = formula_matrix_cond @ jnp.exp(ln_mk0)
+
+    ln_nk1, ln_mk1, ln_ntot1, gk1, An1, Am1, residual1, _lam = _update_all(
+        ln_nk0,
+        ln_mk0,
+        ln_ntot0,
+        formula_matrix,
+        formula_matrix_cond,
+        b,
+        temperature,
+        ln_normalized_pressure,
+        hvector,
+        hvector_cond,
+        gk0,
+        An0,
+        Am0,
+        epsilon,
+        iter_count=0,
+        debug_nan=False,
+    )
+
+    nk1 = jnp.exp(ln_nk1)
+    mk1 = jnp.exp(ln_mk1)
+    ntot1 = jnp.exp(ln_ntot1)
+    pi_resid = _recompute_pi_for_residual(
+        nk1,
+        mk1,
+        ntot1,
+        formula_matrix,
+        formula_matrix_cond,
+        b,
+        gk1,
+        hvector_cond,
+        epsilon,
+    )
+    expected_residual = _compute_residuals(
+        nk1,
+        mk1,
+        ntot1,
+        formula_matrix,
+        formula_matrix_cond,
+        b,
+        gk1,
+        hvector_cond,
+        jnp.exp(epsilon),
+        An1,
+        Am1,
+        pi_resid,
+    )
+
+    bk0 = formula_matrix @ jnp.exp(ln_nk0)
+    sk0 = jnp.exp(2.0 * ln_mk0 - epsilon)
+    pi_stale, _delta_ln_ntot0 = solve_reduced_gibbs_iteration_equations_cond(
+        jnp.exp(ln_nk0),
+        jnp.exp(ln_mk0),
+        jnp.exp(ln_ntot0),
+        formula_matrix,
+        formula_matrix_cond,
+        b,
+        gk0,
+        bk0,
+        hvector_cond,
+        sk0,
+    )
+    stale_residual = _compute_residuals(
+        nk1,
+        mk1,
+        ntot1,
+        formula_matrix,
+        formula_matrix_cond,
+        b,
+        gk1,
+        hvector_cond,
+        jnp.exp(epsilon),
+        An1,
+        Am1,
+        pi_stale,
+    )
+
+    assert jnp.isclose(residual1, expected_residual, rtol=1.0e-12, atol=1.0e-12)
+    assert not jnp.isclose(residual1, stale_residual, rtol=1.0e-6, atol=1.0e-6)
+
+
+def test_trace_minimize_gibbs_cond_epsilon_sweep_smoke():
+    formula_matrix = jnp.array([[1.0]], dtype=jnp.float64)
+    formula_matrix_cond = jnp.array([[1.0]], dtype=jnp.float64)
+    state = ThermoState(
+        temperature=jnp.asarray(1000.0, dtype=jnp.float64),
+        ln_normalized_pressure=jnp.asarray(0.0, dtype=jnp.float64),
+        element_vector=jnp.array([1.0], dtype=jnp.float64),
+    )
+
+    trace = trace_minimize_gibbs_cond_epsilon_sweep(
+        state,
+        ln_nk_init=jnp.array([0.0], dtype=jnp.float64),
+        ln_mk_init=jnp.array([0.0], dtype=jnp.float64),
+        ln_ntot_init=jnp.asarray(0.0, dtype=jnp.float64),
+        formula_matrix=formula_matrix,
+        formula_matrix_cond=formula_matrix_cond,
+        hvector_func=lambda temperature: jnp.array([0.0], dtype=jnp.float64),
+        hvector_cond_func=lambda temperature: jnp.array([2.0], dtype=jnp.float64),
+        epsilons=[-5.0],
+        max_iter=2,
+    )
+
+    assert trace["epsilons"] == [-5.0]
+    assert len(trace["traces"]) == 1
+    first = trace["traces"][0]
+    assert "history" in first
+    assert len(first["history"]) >= 1
+    record = first["history"][0]
+    expected_fields = {
+        "residual",
+        "lam",
+        "lam1_gas",
+        "lam1_cond",
+        "lam2_cond",
+        "max_abs_delta_ln_nk",
+        "max_abs_raw_delta_ln_mk",
+        "max_abs_clipped_delta_ln_mk",
+        "delta_ln_ntot",
+        "pi_norm",
+        "reduced_row_scale_min",
+        "reduced_row_scale_max",
+        "reduced_row_scale_ratio",
+    }
+    assert expected_fields.issubset(record.keys())
+
+
+def test_trace_condensate_sk_stage_feasibility_reports_pre_iteration_violation():
+    formula_matrix = jnp.array([[1.0]], dtype=jnp.float64)
+    formula_matrix_cond = jnp.array([[1.0]], dtype=jnp.float64)
+    state = ThermoState(
+        temperature=jnp.asarray(1000.0, dtype=jnp.float64),
+        ln_normalized_pressure=jnp.asarray(0.0, dtype=jnp.float64),
+        element_vector=jnp.array([1.0], dtype=jnp.float64),
+    )
+
+    trace = trace_condensate_sk_stage_feasibility(
+        state,
+        init=CondensateEquilibriumInit(
+            ln_nk=jnp.array([0.0], dtype=jnp.float64),
+            ln_mk=jnp.array([10.0], dtype=jnp.float64),
+            ln_ntot=jnp.asarray(0.0, dtype=jnp.float64),
+        ),
+        formula_matrix=formula_matrix,
+        formula_matrix_cond=formula_matrix_cond,
+        hvector_func=lambda temperature: jnp.array([0.0], dtype=jnp.float64),
+        hvector_cond_func=lambda temperature: jnp.array([2.0], dtype=jnp.float64),
+        epsilon_start=0.0,
+        epsilon_crit=-1.0,
+        n_step=1,
+        max_iter=0,
+        condensate_species=["test_cond"],
+    )
+
+    assert len(trace["stages"]) == 2
+    first = trace["stages"][0]
+    assert first["has_pre_iteration_sk_infeasibility"]
+    assert first["worst_infeasible_indices"] == [0]
+    assert first["worst_infeasible_names"] == ["test_cond"]
+    assert first["condition"] == "log_s_max + epsilon - 2*ln_mk >= 0"


### PR DESCRIPTION
## Summary

  This PR adds diagnostic and continuation-scheduling support for the condensate PIPM profile solver, while preserving
  the existing default behavior.

  The main changes are:

  - fix condensate inner-solver residual evaluation so convergence checks use a fresh reduced solve on the updated
  primal state
  - add optional profile methods that hot-start from neighboring layers without rewinding the full epsilon continuation
  after the first layer
  - add inner-solver tracing utilities for diagnosing step-size collapse and reduced-system scaling
  - add stage-start `sk` feasibility tracing for continuation schedules
  - add an opt-in adaptive epsilon schedule that guards against entering stage-start `sk`-infeasible states
  - extend diagnostics so profile solves can report requested vs actual final epsilon, plateau detection, and adaptive
  schedule state

  Default fixed-schedule behavior remains unchanged unless the new adaptive mode is explicitly selected.

  ## Motivation

  Recent profiling showed two distinct failure regimes in the condensate solver:

  1. at moderate epsilon values, the gas-step limiter drives very small but nonzero steps
  2. at sufficiently negative epsilon, the `sk` limiter can become negative before the first Newton iteration of a
  stage, causing the assembled step size to clip to exactly zero

  This PR adds the instrumentation needed to identify those failure modes and introduces an optional schedule guard so
  continuation does not silently step into a stage that is already `sk`-infeasible.

  ## Key Changes

  ### Residual consistency
  - recompute the reduced-system multipliers on the post-update state before evaluating the stopping residual
  - use that refreshed residual for convergence checks and final diagnostics
  - keep the primal update rule unchanged

  ### Hot-start profile policy
  - keep existing methods unchanged
  - add optional `scan_hot_from_top_final_only` and `scan_hot_from_bottom_final_only`
  - first layer still runs the full continuation
  - subsequent layers can reuse the previous layer state and solve only at the final epsilon

  ### Inner-solver diagnostics
  - add per-iteration tracing for:
    - residual
    - `lam`, `lam1_gas`, `lam1_cond`, `lam2_cond`
    - `delta_ln_ntot`
    - update magnitudes for `ln_nk` and `ln_mk`
    - `||pi||`
    - reduced-system scaling summaries
  - add epsilon-sweep helpers for single-layer diagnosis

  ### Continuation feasibility tracing
  - add stage-start tracing for the `sk` admissibility condition
  - report the first stage where the carried condensate state becomes infeasible for the next epsilon
  - identify the condensate species binding that guard

  ### Adaptive epsilon schedule
  - add opt-in `epsilon_schedule="adaptive_sk_guard"`
  - guard each proposed `epsilon_next` using the same admissibility condition as `stepsize_sk(...)`
  - detect plateau when the schedule can no longer move downward by a meaningful amount
  - do not force an infeasible final solve at `epsilon_crit`
  - record:
    - actual epsilon path
    - stage type (`fixed-schedule-limited`, `sk-guard-limited`, `plateau-stopped`)
    - first plateau epsilon
    - requested vs actual final epsilon
    - whether the layer truly reached `epsilon_crit`

  ## Validation

  Focused tests:
  - `pytest tests/unittests/optimize/minimize_cond_api_test.py tests/unittests/optimize/
  minimize_cond_diagnostics_test.py`

  Result:
  - `16 passed`

  Representative-layer diagnostics under production-like settings (`epsilon_start=0.0`, `epsilon_crit=-40.0`,
  `n_step=100`, `max_iter=100`) showed:

  - fixed continuation can enter stage-start `sk`-infeasible states before Newton begins
  - adaptive scheduling avoids those infeasible jumps on the tested layers
  - after removing the infeasible jump, the dominant limiter remains gas-step-limited crawling
  - some layers plateau above `epsilon_crit`, and that is now reported explicitly instead of forcing an infeasible final
  stage

  ## Notes

  - this PR does **not** change the inner PIPM equations, damping heuristics, clipping rules, or residual definition
  beyond the stale-residual consistency fix
  - this PR does **not** change the default profile scheduling behavior
  - full adaptive-profile benchmarking remains more expensive than the fixed path and may be sensitive to local JAX
  compilation/runtime limits

