### PR TITLE
removes interpax dependency because of jaxtyping mismatch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,7 @@ classifiers = [
 ]
 
 dependencies = [
-  "interpax",
-  "jax >=0.4.30",  # interpax
+  "jax >=0.4.30",
   "tqdm",
   "pandas",
   "xarray",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 
 dependencies = [
   "interpax",
-  "jax >=0.4.30, <0.7",  # interpax
+  "jax >=0.4.30",  # interpax
   "tqdm",
   "pandas",
   "xarray",

--- a/src/exogibbs/api/equilibrium_grid.py
+++ b/src/exogibbs/api/equilibrium_grid.py
@@ -10,13 +10,12 @@ import jax
 import jax.numpy as jnp
 from jax import core
 import numpy as np
-from interpax import Interpolator3D
-
 from exogibbs.api.chemistry import ChemicalSetup
 from exogibbs.api.chemistry import update_element_vector
 from exogibbs.api.equilibrium import EquilibriumOptions, equilibrium
 from exogibbs.api.equilibrium import EquilibriumInit
 from exogibbs.io.load_data import get_data_filepath
+from exogibbs.utils.interpolation import Interpolator3D
 from exogibbs.utils.elements import element_mass
 from exogibbs.utils.nameparser import strip_trailing_one
 
@@ -381,7 +380,7 @@ def _interpolate_grid_field(
     interpolator_kwargs = dict(options.interpolator_kwargs or {})
     if "period" in interpolator_kwargs:
         raise NotImplementedError(
-            "EquilibriumGrid interpolation does not expose interpax periodic interpolation yet."
+            "EquilibriumGrid interpolation does not expose periodic interpolation yet."
         )
     interpolator = Interpolator3D(
         grid.temperature_axis,

--- a/src/exogibbs/equilibrium/gibbs.py
+++ b/src/exogibbs/equilibrium/gibbs.py
@@ -5,7 +5,7 @@ from typing import Dict
 import jax
 import jax.numpy as jnp
 from jax import custom_jvp
-from interpax import interp1d
+from exogibbs.utils.interpolation import interp1d
 
 from exogibbs.utils.constants import R_gas_constant_si
 
@@ -93,19 +93,10 @@ def interpolate_hvector_one(T_target, T_vec, mu_vec, method="linear"):
         T_target (scalar or array): target temperature(s) (K)
         T_vec (1D array): temeprature grid（Lmax)
         mu_vec (1D array): chemical potential grid（Lmax)
-        method (str):  method of interpolation used in interpax.interp1d
-            'nearest': nearest neighbor interpolation
-            'linear': linear interpolation
-            'cubic': C1 cubic splines (aka local splines)
-            'cubic2': C2 cubic splines (aka natural splines)
-            'catmull-rom': C1 cubic centripetal “tension” splines
-            'cardinal': C1 cubic general tension splines. If used, can also pass keyword parameter c in float[0,1] to specify tension
-            'monotonic': C1 cubic splines that attempt to preserve monotonicity in the data, and will not introduce new extrema in the interpolated points
-            'monotonic-0': same as 'monotonic' but with 0 first derivatives at both endpoints
-            'akima': C1 cubic splines that appear smooth and natural
+        method (str): interpolation method; currently supports "linear" and "nearest"
 
     """
-    RT = R_gas_constant_si * T_vec
+    RT = jnp.where(T_vec != 0.0, R_gas_constant_si * T_vec, jnp.nan)
     return interp1d(T_target, T_vec, mu_vec / RT, method=method)
 
 

--- a/src/exogibbs/thermo/gibbs.py
+++ b/src/exogibbs/thermo/gibbs.py
@@ -5,7 +5,7 @@ from typing import Dict
 import jax
 import jax.numpy as jnp
 from jax import custom_jvp
-from interpax import interp1d
+from exogibbs.utils.interpolation import interp1d
 
 from exogibbs.utils.constants import R_gas_constant_si
 
@@ -93,19 +93,10 @@ def interpolate_hvector_one(T_target, T_vec, mu_vec, method="linear"):
         T_target (scalar or array): target temperature(s) (K)
         T_vec (1D array): temeprature grid（Lmax)
         mu_vec (1D array): chemical potential grid（Lmax)
-        method (str):  method of interpolation used in interpax.interp1d
-            'nearest': nearest neighbor interpolation
-            'linear': linear interpolation
-            'cubic': C1 cubic splines (aka local splines)
-            'cubic2': C2 cubic splines (aka natural splines)
-            'catmull-rom': C1 cubic centripetal “tension” splines
-            'cardinal': C1 cubic general tension splines. If used, can also pass keyword parameter c in float[0,1] to specify tension
-            'monotonic': C1 cubic splines that attempt to preserve monotonicity in the data, and will not introduce new extrema in the interpolated points
-            'monotonic-0': same as 'monotonic' but with 0 first derivatives at both endpoints
-            'akima': C1 cubic splines that appear smooth and natural
+        method (str): interpolation method; currently supports "linear" and "nearest"
 
     """
-    RT = R_gas_constant_si * T_vec
+    RT = jnp.where(T_vec != 0.0, R_gas_constant_si * T_vec, jnp.nan)
     return interp1d(T_target, T_vec, mu_vec / RT, method=method)
 
 

--- a/src/exogibbs/utils/interpolation.py
+++ b/src/exogibbs/utils/interpolation.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import Tuple, Union
+
+import jax.numpy as jnp
+
+Array = jnp.ndarray
+
+
+def interp1d(xq: Array, x: Array, y: Array, method: str = "linear") -> Array:
+    """JAX-compatible 1D interpolation for scalar or array queries."""
+    xq = jnp.asarray(xq)
+    x = jnp.asarray(x)
+    y = jnp.asarray(y)
+    if method == "linear":
+        return jnp.interp(xq, x, y)
+    if method == "nearest":
+        idx = jnp.argmin(jnp.abs(x - xq[..., None]), axis=-1)
+        return y[idx]
+    raise NotImplementedError(f"Unsupported interpolation method: {method!r}")
+
+
+def _bracket(axis: Array, query: Array, extrap: Union[bool, float, Tuple[object, ...]]):
+    axis = jnp.asarray(axis)
+    query = jnp.asarray(query)
+    upper = jnp.searchsorted(axis, query, side="right")
+    upper = jnp.clip(upper, 1, axis.shape[0] - 1)
+    lower = upper - 1
+    x0 = axis[lower]
+    x1 = axis[upper]
+    weight = (query - x0) / jnp.clip(x1 - x0, 1e-300)
+    if extrap is False:
+        outside = (query < axis[0]) | (query > axis[-1])
+    else:
+        outside = jnp.asarray(False)
+        weight = jnp.clip(weight, 0.0, 1.0)
+    return lower, upper, weight, outside
+
+
+class Interpolator3D:
+    """Minimal trilinear interpolator for scalar equilibrium grid lookups."""
+
+    def __init__(
+        self,
+        x: Array,
+        y: Array,
+        z: Array,
+        f: Array,
+        method: str = "linear",
+        extrap: Union[bool, float, Tuple[object, ...]] = False,
+        **kwargs: object,
+    ) -> None:
+        if kwargs:
+            raise NotImplementedError(f"Unsupported interpolation options: {sorted(kwargs)}")
+        if method not in {"linear", "nearest"}:
+            raise NotImplementedError(f"Unsupported interpolation method: {method!r}")
+        self.x = jnp.asarray(x)
+        self.y = jnp.asarray(y)
+        self.z = jnp.asarray(z)
+        self.f = jnp.asarray(f)
+        self.method = method
+        self.extrap = extrap
+
+    def __call__(self, xq: Array, yq: Array, zq: Array, dx: int = 0, dy: int = 0, dz: int = 0) -> Array:
+        if dx or dy or dz:
+            raise NotImplementedError("Derivative interpolation is not implemented.")
+        if self.method == "nearest":
+            ix = jnp.argmin(jnp.abs(self.x - xq))
+            iy = jnp.argmin(jnp.abs(self.y - yq))
+            iz = jnp.argmin(jnp.abs(self.z - zq))
+            return self.f[ix, iy, iz]
+        return self._linear(xq, yq, zq)
+
+    def _linear(self, xq: Array, yq: Array, zq: Array) -> Array:
+        ix0, ix1, wx, ox = _bracket(self.x, xq, self.extrap)
+        iy0, iy1, wy, oy = _bracket(self.y, yq, self.extrap)
+        iz0, iz1, wz, oz = _bracket(self.z, zq, self.extrap)
+
+        c000 = self.f[ix0, iy0, iz0]
+        c001 = self.f[ix0, iy0, iz1]
+        c010 = self.f[ix0, iy1, iz0]
+        c011 = self.f[ix0, iy1, iz1]
+        c100 = self.f[ix1, iy0, iz0]
+        c101 = self.f[ix1, iy0, iz1]
+        c110 = self.f[ix1, iy1, iz0]
+        c111 = self.f[ix1, iy1, iz1]
+
+        c00 = c000 * (1.0 - wx) + c100 * wx
+        c01 = c001 * (1.0 - wx) + c101 * wx
+        c10 = c010 * (1.0 - wx) + c110 * wx
+        c11 = c011 * (1.0 - wx) + c111 * wx
+        c0 = c00 * (1.0 - wy) + c10 * wy
+        c1 = c01 * (1.0 - wy) + c11 * wy
+        out = c0 * (1.0 - wz) + c1 * wz
+
+        outside = ox | oy | oz
+        return jnp.where(outside, jnp.full_like(out, jnp.nan), out)


### PR DESCRIPTION
## Summary

  - Remove the runtime dependency on `interpax`.
  - Add a small JAX-based interpolation helper for 1D interpolation and scalar 3D grid lookups.
  - Switch Gibbs h-vector interpolation and equilibrium grid interpolation to the local helper.
  - Keep the public interpolation behavior used by the tests: `linear`, `nearest`, scalar grid queries, and out-of-
  bounds rejection by default.

  ## Motivation

  Recent JAX updates exposed compatibility issues in the `interpax -> equinox -> jaxtyping` import chain. The test suite
  failed during collection before exogibbs code could run.

  Since exogibbs only uses a narrow subset of interpolation behavior, this PR replaces that dependency path with a local
  implementation and avoids importing `interpax` entirely.

  ## Testing

  ```bash
  pytest tests/unittests

  Result:

  94 passed, 1 warning

  The remaining warning is the existing unregistered pytest.mark.smoke warning.
