### PR TITLE
condensates: promote head route v1.7

### DIFF
--- a/head_route.md
+++ b/head_route.md
@@ -2,7 +2,7 @@
 
 この文書は、ExoGibbs の凝縮あり計算で現在の基準経路として扱う **HEAD route** を定義する。HEAD route の内容を変更した場合は、この文書を更新する。
 
-現在の実装版は **HEAD route v1.6** である。v1.6 は v1.5 の support-closure retry gate を維持したまま、support outer loop の support 更新規則を修正した固定版である。non-fallback accepted result から次 round の support を grow するとき、solver に渡した広い support ではなく、solver が実際に保持した support を existing support として扱う。これにより、solver が落とした species が final gas state で再び activity-positive なら、既存の activity-driven support outer loop の通常規則で再追加される。
+現在の実装版は **HEAD route v1.7** である。v1.7 は v1.6 の solver route と support 更新規則を維持したまま、公開 diagnostics の inactive condensate driving を温度有効性つきで読めるようにするマイナー更新である。legacy の all-condensate metric は残しつつ、HEAD support selection と同じ `temperature_validity_upper` metadata に基づく temperature-valid subset を併記する。
 
 ## 一言でいうと
 
@@ -18,9 +18,24 @@
 6. v1.4 では、返却直前に gas と full condensate vector から元素 budget を再構成し、element-wise relative residual が許容値を超える accepted row を relative joint budget-correction retry、budget-preserving seed retry、empty-support strict gas retry で直す。retry 後も許容値を超える row だけを `not_converged` に降格する。
 7. v1.5 では、support-cap retry と support-growth staging retry の候補を採用する前に、候補の gas state から inactive condensate driving を再評価し、positive inactive driving が許容値を超える候補を採用しない。
 8. v1.6 では、support outer loop の次 round を作るとき、前 round で試した support ではなく、accepted result の実 support indices を既存 support として使う。実 support から落ちた species がまだ positive inactive なら、通常の support-growth で再追加する。
-9. 最後に selected route（採用経路）と acceptance tier（成功品質ランク）を返す。
+9. v1.7 では、`return_diagnostics=True` の result に `inactive_condensate_driving` report を追加し、all-condensate と temperature-valid の inactive-driving summary を分ける。
+10. 最後に selected route（採用経路）と acceptance tier（成功品質ランク）を返す。
 
 これは FastChem4 exact replay（FastChem4 の分岐を完全再現すること）ではない。FastChem4 public/runtime/trace values（公開出力・実行時出力・内部 trace 値）は、ExoGibbs の constructor input（初期値や構成入力）として使わない。
+
+## HEAD route v1.7 固定内容
+
+HEAD route v1.7 は、v1.6 の route selection、support outer loop、solver acceptance を変えない diagnostics 更新である。主目的は、highT gas-only boundary で温度範囲外の condensate が legacy all-condensate inactive-driving metric を支配し、実際の support miss のように見える問題を切り分けることである。
+
+| promoted item | 目的 | 適用範囲 |
+|---|---|---|
+| validity-aware inactive-driving diagnostics | `return_diagnostics=True` の result に `inactive_condensate_driving` report を追加し、all-condensate summary と temperature-valid summary を併記する。 | public condensate API diagnostics |
+| support-selection validity alignment | temperature-valid subset は HEAD support selection と同じ `temperature_validity_upper` metadata を使う。 | diagnostics only |
+| gas-only route comparability | empty positive support route と通常の gas-only equilibrium solver を、同じ validity-aware inactive-driving 指標で比較できるようにする。 | diagnostics only |
+
+この更新は solver route、support update、public convergence、budget gate を変更しない。FastChem4 output は比較対象としてのみ使い、constructor input には使わない。
+
+v1.7 audit では、`solar_highT_no_condensate_gas_regression` の legacy all-condensate inactive driving は HEAD empty-support route と direct gas-only solver の両方で約 772 と一致する一方、temperature-valid inactive driving は HEAD 側で 0 である。したがって highT gas-only hotspot は温度範囲外 condensate を legacy metric が数えた diagnostic artifact であり、温度有効な condensate support miss ではない。
 
 ## HEAD route v1.6 固定内容
 
@@ -128,10 +143,10 @@ v1.3 default fresh API support-free route selection evidence は次の通りで�
   - `condensate_equilibrium`
 
 `condensate_equilibrium()` が返す `CondensateEquilibriumResult` から、現在の固定版は
-`result.head_route_version == "v1.6"` および
-`result.head_route_name == "head_route_v1_6_actual_support_outer_loop_growth"` として読み出せる。
+`result.head_route_version == "v1.7"` および
+`result.head_route_name == "head_route_v1_7_validity_aware_inactive_driving_diagnostics"` として読み出せる。
 `return_diagnostics=True` の場合は diagnostics にも同じ `head_route_version` と
-`head_route_name` を残す。
+`head_route_name` を残し、さらに `inactive_condensate_driving` report を残す。
 
 通常の gas-only API（凝縮なし API）は変更しない。HEAD route は凝縮あり専用入口から使う。
 
@@ -456,8 +471,8 @@ HEAD route は凝縮あり初版標準経路として進めてよいが、以下
 
 - gas-only `equilibrium()` の挙動を変えない。
 - 既存の production result fields の意味を変えない。
-- gas-only API の defaults を変更しない。凝縮あり API の fixed default は HEAD route v1.6 として扱う。
-- 現在の凝縮あり API の fixed default は `result.head_route_version == "v1.6"` として公開する。
+- gas-only API の defaults を変更しない。凝縮あり API の fixed default は HEAD route v1.7 として扱う。
+- 現在の凝縮あり API の fixed default は `result.head_route_version == "v1.7"` として公開する。
 - FastChem4 public/runtime/trace values を constructor input にしない。
 - FastChem4 exact branch replay を acceptance target にしない。
 - case、species、element を落として成功扱いにしない。

--- a/score.json
+++ b/score.json
@@ -1121,6 +1121,67 @@
       "verdict": "Algorithmic improvement: preserves public convergence and route counts, removes all >1000 inactive-driving rows by growing from actual accepted support, improves water gas-ratio outliers, and slightly improves FastChem4-scaled Gibbs counts."
     }
   ],
+  "diagnostic_trials": [
+    {
+      "trial": "v1.7",
+      "title": "validity-aware inactive-driving diagnostics",
+      "description": "Expose diagnostics that separate all-condensate inactive driving from temperature-valid inactive driving and compare HEAD empty-support rows against the direct gas-only equilibrium solver.",
+      "implementation": {
+        "new_helper": "exogibbs.condensates.inactive_driving.evaluate_inactive_condensate_driving",
+        "api_result_head_route_version": "v1.7",
+        "api_result_head_route_name": "head_route_v1_7_validity_aware_inactive_driving_diagnostics",
+        "diagnostics_key": "inactive_condensate_driving",
+        "diagnostic_only": true,
+        "production_behavior_change": false,
+        "fastchem4_constructor_inputs_used": false,
+        "fastchem4_exact_replay_target": false
+      },
+      "artifacts": [
+        "volatiles_artifacts/highT_gas_only_head_route_audit.json",
+        "volatiles_artifacts/head_route_v13_fastchem4_deep_comparison.json"
+      ],
+      "highT_gas_only_route_comparison": {
+        "family": "solar_highT_no_condensate_gas_regression",
+        "rows": 18,
+        "head_route_counts": {
+          "head_v1_empty_positive_support_gas_only": 17,
+          "m4310_full_promoted_policy_route": 1
+        },
+        "head_status_counts": {
+          "converged": 18
+        },
+        "strict_gas_only_budget_retry_rows": 2,
+        "head_max_all_condensate_inactive_driving": 771.6906072420092,
+        "direct_gas_default_max_all_condensate_inactive_driving": 772.0161366679351,
+        "head_max_temperature_valid_inactive_driving": 0.0,
+        "rows_with_final_temperature_valid_inactive_support": 0,
+        "interpretation": "The highT hotspot is caused by temperature-invalid condensates counted by the legacy all-condensate diagnostic, not by missing temperature-valid support."
+      },
+      "full_profile_validity_aware_fastchem4_comparison": {
+        "rows": 99,
+        "public_status_counts": {
+          "converged": 99
+        },
+        "route_counts": {
+          "m4310_full_promoted_policy_route": 82,
+          "head_v1_empty_positive_support_gas_only": 17
+        },
+        "exogibbs_all_condensate_max_inactive_driving": 771.6906072420092,
+        "exogibbs_temperature_valid_max_inactive_driving": 487.0636431073906,
+        "exogibbs_temperature_valid_rows_gt_500": 0,
+        "exogibbs_temperature_valid_rows_gt_1000": 0,
+        "fastchem4_scaled_temperature_valid_max_inactive_driving": 21.578063671135624,
+        "exogibbs_state_lower_g_over_rt": 19,
+        "fastchem4_scaled_state_lower_g_over_rt": 80,
+        "max_abs_delta_g_over_rt": 0.0007951733639472991
+      },
+      "next_support_closure_targets": [
+        "carbon_rich_CaS_MgS_AlN_window",
+        "lowT_strong_condensation_budget_stress",
+        "SiO_s_condensate_window"
+      ]
+    }
+  ],
   "next_trial_candidates": [
     {
       "candidate": "A",

--- a/score.md
+++ b/score.md
@@ -376,26 +376,110 @@ public convergence and route counts.
 
 ## Current verdict
 
-v1.6 is a good algorithmic improvement over v1.5.1:
+v1.7 keeps the v1.6 algorithmic surface and adds a validity-aware diagnostic
+readout for inactive condensate driving. The solver route score remains the
+v1.6 score:
 
 - It preserves public convergence and budget-gate behavior.
 - It removes the remaining `>1000` inactive-driving rows without adding a new ad hoc retry.
 - It fixes the water layer 8 and layer 2 support-closure hotspots using the normal outer loop.
 - It reduces the water FastChem4 gas-ratio outlier from 121 to 23.3.
 - It improves the FastChem4-scaled Gibbs score from 17/82 to 19/80 and lowers max `|dG/RT|`.
+- It separates temperature-invalid highT gas-only diagnostic artifacts from
+  temperature-valid inactive-driving support misses.
 
 It is not yet a complete support-closure or FastChem4 agreement improvement:
 
 - Active condensate Jaccard remains low for most condensation families.
-- highT gas-only boundary rows still show large inactive-driving diagnostics.
+- all-condensate inactive-driving diagnostics still show highT gas-only rows,
+  but the v1.7 validity-aware audit below shows these are temperature-invalid
+  condensates rather than temperature-valid support misses.
 - FastChem4-scaled states still have lower ExoGibbs-native `G/RT` in 80/99 layers.
+
+## Trial v1.7: validity-aware inactive-driving diagnostics
+
+v1.7 checks whether the remaining highT gas-only inactive-driving rows are real
+missing condensates or diagnostic artifacts near the no-condensate boundary.
+The implementation adds a diagnostic-only
+`evaluate_inactive_condensate_driving()` helper that reports both the legacy
+all-condensate inactive-driving metric and a temperature-valid subset using the
+same `temperature_validity_upper` metadata as HEAD support selection.
+
+API exposure:
+
+```text
+result.head_route_version = "v1.7"
+result.head_route_name = "head_route_v1_7_validity_aware_inactive_driving_diagnostics"
+diagnostics["inactive_condensate_driving"] = {
+    "all_condensates": ...,
+    "temperature_valid_condensates": ...,
+}
+```
+
+This is a diagnostics-only HEAD route update. It does not change route
+selection, support growth, solver acceptance, gas-only API defaults, or
+FastChem4 constructor inputs.
+
+Artifacts:
+
+| artifact | purpose |
+|---|---|
+| `volatiles_artifacts/highT_gas_only_head_route_audit.json` | direct gas-only solver vs HEAD empty-support route comparison |
+| `volatiles_artifacts/head_route_v13_fastchem4_deep_comparison.json` | full-profile FastChem4 output comparison with validity-aware inactive-driving fields |
+
+highT gas-only route comparison over `solar_highT_no_condensate_gas_regression`:
+
+| metric | value |
+|---|---:|
+| rows | 18 |
+| HEAD route counts | 17 gas-only, 1 primary |
+| HEAD status counts | 18 converged |
+| strict gas-only budget retry rows | 2 |
+| max all-condensate inactive driving, HEAD | 771.7 |
+| max all-condensate inactive driving, direct gas-only default | 772.0 |
+| max temperature-valid inactive driving, HEAD | 0 |
+| rows with final temperature-valid inactive support | 0 |
+
+Interpretation: the highT hotspot is not evidence that the HEAD route is
+missing temperature-valid condensates. The largest all-condensate inactive
+driving species are `H2S(s,l)`, `CH4(s,l)`, `CO2(s,l)`, and `N2(s,l)`, all of
+which are above their condensate temperature-validity range at 2200 K. The
+direct gas-only solver and the HEAD empty-support route show the same
+all-condensate driving surface; HEAD support selection correctly excludes those
+species through the standard temperature-validity gate.
+
+Full-profile FastChem4 comparison after adding v1.7 validity-aware diagnostics:
+
+| metric | value |
+|---|---:|
+| rows | 99 |
+| public status | 99 converged |
+| route counts | 82 primary, 17 gas-only |
+| Exo all-condensate max inactive driving | 771.7 |
+| Exo temperature-valid max inactive driving | 487.1 |
+| Exo rows with temperature-valid inactive driving >500 | 0 |
+| Exo rows with temperature-valid inactive driving >1000 | 0 |
+| FastChem4-scaled temperature-valid max inactive driving | 21.6 |
+| ExoGibbs lower `G/RT` vs FastChem4-scaled | 19/99 |
+| FastChem4-scaled lower `G/RT` | 80/99 |
+| max `|dG/RT|` | 7.952e-4 |
+
+The next real support-closure targets are no longer the highT gas-only rows.
+By temperature-valid inactive-driving, the largest remaining ExoGibbs rows are
+in `carbon_rich_CaS_MgS_AlN_window`, `lowT_strong_condensation_budget_stress`,
+and `SiO_s_condensate_window`, with top species such as `Cr23C6(s)` and
+`Ti4O7(s,l)`. Those should be investigated as support/amount/complementarity
+issues, not as gas-only boundary problems.
 
 ## Next trial candidates
 
 ### Candidate A: highT gas-only boundary closure
 
-Goal: decide whether the remaining highT gas-only inactive-driving rows are a real
-condensation-support miss or a diagnostic artifact near the no-condensate boundary.
+Status: investigated. The highT gas-only rows are diagnostic artifacts under
+the legacy all-condensate metric; temperature-valid inactive-driving is zero.
+
+Goal: keep the validity-aware metric in future score runs so highT
+temperature-invalid condensates do not dominate the support-closure queue.
 
 Required score checks:
 

--- a/src/exogibbs/api/condensate_equilibrium.py
+++ b/src/exogibbs/api/condensate_equilibrium.py
@@ -36,8 +36,8 @@ CondensateSeedInitializationPolicy = Literal[
     "capacity_fraction",
     "max_density",
 ]
-CONDENSATE_HEAD_ROUTE_VERSION = "v1.6"
-CONDENSATE_HEAD_ROUTE_NAME = "head_route_v1_6_actual_support_outer_loop_growth"
+CONDENSATE_HEAD_ROUTE_VERSION = "v1.7"
+CONDENSATE_HEAD_ROUTE_NAME = "head_route_v1_7_validity_aware_inactive_driving_diagnostics"
 HEAD_ROUTE_SOFT_RESTORATION_COMPONENT_WEIGHTS = {
     "budget": 1.0,
     "total_density": 1.0,
@@ -1844,6 +1844,47 @@ def _with_support_budget_preserving_seed_retry_diagnostics(
     return replace(result, diagnostics=diagnostics)
 
 
+def _with_inactive_condensate_driving_diagnostics(
+    *,
+    result: CondensateEquilibriumResult,
+    setup: CondensateChemicalSetup,
+    T: float,
+    P: float,
+    Pref: float,
+    options: CondensateEquilibriumOptions,
+) -> CondensateEquilibriumResult:
+    if not options.return_diagnostics:
+        return result
+    from exogibbs.condensates.inactive_driving import (
+        evaluate_inactive_condensate_driving,
+    )
+
+    gas_stationarity_source = setup.gas_setup.hvector_func(float(T)) + (
+        _ln_normalized_pressure(P, Pref)
+    )
+    element_potential = _least_squares_element_potential(
+        formula_matrix=setup.formula_matrix,
+        gas_ln_n=result.gas_ln_n,
+        gas_stationarity_source=gas_stationarity_source,
+    )
+    report = evaluate_inactive_condensate_driving(
+        formula_matrix_cond=setup.formula_matrix_cond,
+        condensate_species_order=setup.condensate_species,
+        condensate_amounts=result.condensate_amounts,
+        hvector_cond=setup.condensate_setup.hvector_func(float(T)),
+        element_potential=element_potential,
+        temperature=float(T),
+        condensate_temperature_validity_upper=setup.condensate_setup.metadata.get(
+            "temperature_validity_upper"
+        ),
+        active_floor=1.0e-50,
+        activity_threshold=options.support_activity_threshold,
+    )
+    diagnostics = dict(result.diagnostics or {})
+    diagnostics["inactive_condensate_driving"] = report.as_dict()
+    return replace(result, diagnostics=diagnostics)
+
+
 def _run_activity_driven_support_outer_loop(
     *,
     setup: CondensateChemicalSetup,
@@ -2420,11 +2461,18 @@ def condensate_equilibrium(
     validate_condensate_chemical_setup(setup)
     _validate_options(opts)
     if support_indices is None and opts.enable_support_outer_loop:
-        return _run_activity_driven_support_outer_loop(
+        return _with_inactive_condensate_driving_diagnostics(
+            result=_run_activity_driven_support_outer_loop(
+                setup=setup,
+                T=T,
+                P=P,
+                b=b,
+                Pref=Pref,
+                options=opts,
+            ),
             setup=setup,
             T=T,
             P=P,
-            b=b,
             Pref=Pref,
             options=opts,
         )
@@ -2517,17 +2565,24 @@ def condensate_equilibrium(
             return_diagnostics=False,
         )
         diagnostics = {"support_selection": support_selection_report} if opts.return_diagnostics else None
-        return _build_empty_support_gas_result(
+        return _with_inactive_condensate_driving_diagnostics(
+            result=_build_empty_support_gas_result(
+                setup=setup,
+                gas_ln_n=gas_result.ln_n,
+                diagnostics=diagnostics,
+                element_inventory_target=b,
+                enable_full_condensate_budget_residual_gate=(
+                    opts.enable_full_condensate_budget_residual_gate
+                ),
+                full_condensate_budget_relative_tolerance=(
+                    opts.full_condensate_budget_relative_tolerance
+                ),
+            ),
             setup=setup,
-            gas_ln_n=gas_result.ln_n,
-            diagnostics=diagnostics,
-            element_inventory_target=b,
-            enable_full_condensate_budget_residual_gate=(
-                opts.enable_full_condensate_budget_residual_gate
-            ),
-            full_condensate_budget_relative_tolerance=(
-                opts.full_condensate_budget_relative_tolerance
-            ),
+            T=T,
+            P=P,
+            Pref=Pref,
+            options=opts,
         )
     solve_kwargs: dict[str, Any] = {}
     if opts.max_inner_iterations is not None:
@@ -3230,27 +3285,34 @@ def condensate_equilibrium(
             and selected_warm_start_candidate_object is not None
             and selected_warm_start_candidate_object.finite_solver_inputs
         ):
-            return _build_native_seed_fallback_result(
+            return _with_inactive_condensate_driving_diagnostics(
+                result=_build_native_seed_fallback_result(
+                    setup=setup,
+                    T=T,
+                    P=P,
+                    b=b,
+                    Pref=Pref,
+                    candidate=selected_warm_start_candidate_object,
+                    support_selection_report=support_selection_report,
+                    warm_start_report=warm_start_report,
+                    solver_attempts=solver_attempts,
+                    selected_warm_start_candidate=selected_warm_start_candidate,
+                    lifecycle_payload=lifecycle_payload,
+                    allow_caveat_tiers=opts.allow_caveat_tiers,
+                    return_diagnostics=opts.return_diagnostics,
+                    enable_full_condensate_budget_residual_gate=(
+                        opts.enable_full_condensate_budget_residual_gate
+                    ),
+                    full_condensate_budget_relative_tolerance=(
+                        opts.full_condensate_budget_relative_tolerance
+                    ),
+                    restricted_solver_success=False,
+                ),
                 setup=setup,
                 T=T,
                 P=P,
-                b=b,
                 Pref=Pref,
-                candidate=selected_warm_start_candidate_object,
-                support_selection_report=support_selection_report,
-                warm_start_report=warm_start_report,
-                solver_attempts=solver_attempts,
-                selected_warm_start_candidate=selected_warm_start_candidate,
-                lifecycle_payload=lifecycle_payload,
-                allow_caveat_tiers=opts.allow_caveat_tiers,
-                return_diagnostics=opts.return_diagnostics,
-                enable_full_condensate_budget_residual_gate=(
-                    opts.enable_full_condensate_budget_residual_gate
-                ),
-                full_condensate_budget_relative_tolerance=(
-                    opts.full_condensate_budget_relative_tolerance
-                ),
-                restricted_solver_success=False,
+                options=opts,
             )
     if (
         lifecycle_converged
@@ -3303,28 +3365,35 @@ def condensate_equilibrium(
         and selected_warm_start_candidate_object is not None
         and selected_warm_start_candidate_object.finite_solver_inputs
     ):
-        return _build_native_seed_fallback_result(
+        return _with_inactive_condensate_driving_diagnostics(
+            result=_build_native_seed_fallback_result(
+                setup=setup,
+                T=T,
+                P=P,
+                b=b,
+                Pref=Pref,
+                candidate=selected_warm_start_candidate_object,
+                support_selection_report=support_selection_report,
+                warm_start_report=warm_start_report,
+                solver_attempts=solver_attempts,
+                selected_warm_start_candidate=selected_warm_start_candidate,
+                lifecycle_payload=lifecycle_payload,
+                allow_caveat_tiers=opts.allow_caveat_tiers,
+                return_diagnostics=opts.return_diagnostics,
+                enable_full_condensate_budget_residual_gate=(
+                    opts.enable_full_condensate_budget_residual_gate
+                ),
+                full_condensate_budget_relative_tolerance=(
+                    opts.full_condensate_budget_relative_tolerance
+                ),
+                restricted_solver_success=restricted_solver_success,
+                restricted_solver_payload=solver if restricted_solver_success else None,
+            ),
             setup=setup,
             T=T,
             P=P,
-            b=b,
             Pref=Pref,
-            candidate=selected_warm_start_candidate_object,
-            support_selection_report=support_selection_report,
-            warm_start_report=warm_start_report,
-            solver_attempts=solver_attempts,
-            selected_warm_start_candidate=selected_warm_start_candidate,
-            lifecycle_payload=lifecycle_payload,
-            allow_caveat_tiers=opts.allow_caveat_tiers,
-            return_diagnostics=opts.return_diagnostics,
-            enable_full_condensate_budget_residual_gate=(
-                opts.enable_full_condensate_budget_residual_gate
-            ),
-            full_condensate_budget_relative_tolerance=(
-                opts.full_condensate_budget_relative_tolerance
-            ),
-            restricted_solver_success=restricted_solver_success,
-            restricted_solver_payload=solver if restricted_solver_success else None,
+            options=opts,
         )
     diagnostics_payload: Optional[Mapping[str, Any]]
     if opts.return_diagnostics:
@@ -3362,24 +3431,31 @@ def condensate_equilibrium(
             )
     else:
         diagnostics_payload = None
-    return build_condensate_equilibrium_result_from_solver_payload(
+    return _with_inactive_condensate_driving_diagnostics(
+        result=build_condensate_equilibrium_result_from_solver_payload(
+            setup=setup,
+            gas_ln_n=result_ln_nk,
+            support_indices=result_support_indices,
+            support_amounts=result_support_amounts,
+            external_condensate_amounts=result_external_condensate_amounts,
+            selected_route=lifecycle_selected_route,
+            metric_status=lifecycle_metric_status,
+            solver_success=bool(lifecycle_converged),
+            allow_caveat_tiers=opts.allow_caveat_tiers,
+            diagnostics=diagnostics_payload,
+            element_inventory_target=b,
+            enable_full_condensate_budget_residual_gate=(
+                opts.enable_full_condensate_budget_residual_gate
+            ),
+            full_condensate_budget_relative_tolerance=(
+                opts.full_condensate_budget_relative_tolerance
+            ),
+        ),
         setup=setup,
-        gas_ln_n=result_ln_nk,
-        support_indices=result_support_indices,
-        support_amounts=result_support_amounts,
-        external_condensate_amounts=result_external_condensate_amounts,
-        selected_route=lifecycle_selected_route,
-        metric_status=lifecycle_metric_status,
-        solver_success=bool(lifecycle_converged),
-        allow_caveat_tiers=opts.allow_caveat_tiers,
-        diagnostics=diagnostics_payload,
-        element_inventory_target=b,
-        enable_full_condensate_budget_residual_gate=(
-            opts.enable_full_condensate_budget_residual_gate
-        ),
-        full_condensate_budget_relative_tolerance=(
-            opts.full_condensate_budget_relative_tolerance
-        ),
+        T=T,
+        P=P,
+        Pref=Pref,
+        options=opts,
     )
 
 

--- a/src/exogibbs/condensates/inactive_driving.py
+++ b/src/exogibbs/condensates/inactive_driving.py
@@ -1,0 +1,185 @@
+"""Inactive condensate driving diagnostics.
+
+These helpers evaluate condensate activity driving for an already-computed gas
+and condensate state.  They are diagnostic-only and do not change solver state.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Mapping, Optional, Sequence
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class InactiveDrivingSummary:
+    """Positive inactive-driving summary for one condensate subset."""
+
+    max_positive_inactive_driving: float
+    positive_inactive_count: int
+    top_positive_inactive: tuple[Mapping[str, object], ...]
+
+
+@dataclass(frozen=True)
+class InactiveDrivingReport:
+    """Diagnostic report for inactive condensate driving."""
+
+    report_schema: str
+    diagnostic_only: bool
+    default_off: bool
+    production_behavior_change: bool
+    temperature: Optional[float]
+    activity_threshold: float
+    active_floor: float
+    all_condensates: InactiveDrivingSummary
+    temperature_valid_condensates: InactiveDrivingSummary
+    temperature_invalid_positive_inactive_count: int
+    temperature_invalid_max_positive_inactive_driving: float
+    candidate_temperature_valid: Mapping[str, bool]
+    fastchem4_trace_public_runtime_constructor_inputs_used: bool
+
+    def as_dict(self) -> dict:
+        payload = asdict(self)
+        payload["all_condensates"] = asdict(self.all_condensates)
+        payload["temperature_valid_condensates"] = asdict(
+            self.temperature_valid_condensates
+        )
+        return payload
+
+
+def _as_vector(
+    values: Sequence[float],
+    name: str,
+    expected: Optional[int] = None,
+) -> np.ndarray:
+    array = np.asarray(values, dtype=np.float64)
+    if array.ndim != 1:
+        raise ValueError(f"{name} must be a one-dimensional vector.")
+    if expected is not None and array.shape[0] != expected:
+        raise ValueError(
+            f"{name} length mismatch: got {array.shape[0]}, expected {expected}."
+        )
+    if not np.all(np.isfinite(array)):
+        raise ValueError(f"{name} must contain finite values.")
+    return array
+
+
+def _as_matrix(values: Sequence[Sequence[float]], name: str) -> np.ndarray:
+    array = np.asarray(values, dtype=np.float64)
+    if array.ndim != 2:
+        raise ValueError(f"{name} must be a two-dimensional matrix.")
+    if not np.all(np.isfinite(array)):
+        raise ValueError(f"{name} must contain finite values.")
+    return array
+
+
+def _positive_inactive_summary(
+    *,
+    indices: np.ndarray,
+    condensate_species_order: tuple[str, ...],
+    driving: np.ndarray,
+    amounts: np.ndarray,
+) -> InactiveDrivingSummary:
+    top = sorted(
+        (
+            {
+                "index": int(index),
+                "species": condensate_species_order[int(index)],
+                "driving": float(driving[int(index)]),
+                "amount": float(amounts[int(index)]),
+            }
+            for index in indices
+        ),
+        key=lambda row: float(row["driving"]),
+        reverse=True,
+    )
+    return InactiveDrivingSummary(
+        max_positive_inactive_driving=float(top[0]["driving"]) if top else 0.0,
+        positive_inactive_count=len(top),
+        top_positive_inactive=tuple(top[:20]),
+    )
+
+
+def evaluate_inactive_condensate_driving(
+    *,
+    formula_matrix_cond: Sequence[Sequence[float]],
+    condensate_species_order: Sequence[str],
+    condensate_amounts: Sequence[float],
+    hvector_cond: Sequence[float],
+    element_potential: Sequence[float],
+    temperature: Optional[float] = None,
+    condensate_temperature_validity_upper: Optional[Sequence[float]] = None,
+    active_floor: float = 1.0e-50,
+    activity_threshold: float = 0.0,
+) -> InactiveDrivingReport:
+    """Evaluate inactive positive condensate driving with validity bookkeeping."""
+
+    ac = _as_matrix(formula_matrix_cond, "formula_matrix_cond")
+    ncond = ac.shape[1]
+    species = tuple(str(item) for item in condensate_species_order)
+    if len(species) != ncond:
+        raise ValueError(
+            "condensate_species_order length must match formula_matrix_cond columns."
+        )
+    amounts = _as_vector(condensate_amounts, "condensate_amounts", ncond)
+    hcond = _as_vector(hvector_cond, "hvector_cond", ncond)
+    potential = _as_vector(element_potential, "element_potential", ac.shape[0])
+    if condensate_temperature_validity_upper is None:
+        validity_upper = np.full((ncond,), np.inf, dtype=np.float64)
+    else:
+        validity_upper = _as_vector(
+            condensate_temperature_validity_upper,
+            "condensate_temperature_validity_upper",
+            ncond,
+        )
+    temp_value = None if temperature is None else float(temperature)
+    temperature_valid_mask = (
+        np.ones((ncond,), dtype=bool)
+        if temp_value is None
+        else temp_value <= validity_upper
+    )
+    driving = ac.T @ potential - hcond
+    active = amounts > float(active_floor)
+    inactive_positive = (~active) & (driving > float(activity_threshold))
+    all_indices = np.where(inactive_positive)[0]
+    valid_indices = np.where(inactive_positive & temperature_valid_mask)[0]
+    invalid_indices = np.where(inactive_positive & (~temperature_valid_mask))[0]
+    invalid_summary = _positive_inactive_summary(
+        indices=invalid_indices,
+        condensate_species_order=species,
+        driving=driving,
+        amounts=amounts,
+    )
+    return InactiveDrivingReport(
+        report_schema="exogibbs_inactive_condensate_driving_report_v1",
+        diagnostic_only=True,
+        default_off=True,
+        production_behavior_change=False,
+        temperature=temp_value,
+        activity_threshold=float(activity_threshold),
+        active_floor=float(active_floor),
+        all_condensates=_positive_inactive_summary(
+            indices=all_indices,
+            condensate_species_order=species,
+            driving=driving,
+            amounts=amounts,
+        ),
+        temperature_valid_condensates=_positive_inactive_summary(
+            indices=valid_indices,
+            condensate_species_order=species,
+            driving=driving,
+            amounts=amounts,
+        ),
+        temperature_invalid_positive_inactive_count=(
+            invalid_summary.positive_inactive_count
+        ),
+        temperature_invalid_max_positive_inactive_driving=(
+            invalid_summary.max_positive_inactive_driving
+        ),
+        candidate_temperature_valid={
+            species[index]: bool(temperature_valid_mask[index])
+            for index in range(ncond)
+        },
+        fastchem4_trace_public_runtime_constructor_inputs_used=False,
+    )

--- a/tests/unittests/api/condensate_equilibrium_test.py
+++ b/tests/unittests/api/condensate_equilibrium_test.py
@@ -357,9 +357,15 @@ def test_condensate_equilibrium_auto_selects_positive_support_and_calls_solver(m
         ]
         == "number_density_divided_by_initial_gas_phase_total_element_density"
     )
+    inactive_driving = result.diagnostics["inactive_condensate_driving"]
+    assert inactive_driving["report_schema"] == (
+        "exogibbs_inactive_condensate_driving_report_v1"
+    )
+    assert inactive_driving["diagnostic_only"] is True
+    assert inactive_driving["production_behavior_change"] is False
 
 
-def test_condensate_equilibrium_options_default_to_head_route_v1_6() -> None:
+def test_condensate_equilibrium_options_default_to_head_route_v1_7() -> None:
     options = CondensateEquilibriumOptions()
 
     assert options.max_positive_support_count is None
@@ -1870,6 +1876,13 @@ def test_condensate_equilibrium_empty_positive_support_uses_gas_only_path(monkey
     assert result.diagnostics["head_route_version"] == CONDENSATE_HEAD_ROUTE_VERSION
     assert result.diagnostics["head_route_name"] == CONDENSATE_HEAD_ROUTE_NAME
     assert result.diagnostics["support_selection"]["solver_inputs"]["empty_positive_support"] is True
+    inactive_driving = result.diagnostics["inactive_condensate_driving"]
+    assert inactive_driving["all_condensates"]["positive_inactive_count"] == 0
+    assert inactive_driving["temperature_valid_condensates"]["positive_inactive_count"] == 0
+    assert (
+        inactive_driving["fastchem4_trace_public_runtime_constructor_inputs_used"]
+        is False
+    )
 
 
 def test_condensate_equilibrium_rejects_invalid_positive_support_options() -> None:

--- a/tests/unittests/condensates/inactive_driving_test.py
+++ b/tests/unittests/condensates/inactive_driving_test.py
@@ -1,0 +1,53 @@
+"""Tests for inactive condensate driving diagnostics."""
+
+from __future__ import annotations
+
+import pytest
+
+from exogibbs.condensates.inactive_driving import (
+    evaluate_inactive_condensate_driving,
+)
+
+
+def test_inactive_driving_reports_all_and_temperature_valid_subsets() -> None:
+    report = evaluate_inactive_condensate_driving(
+        formula_matrix_cond=[[1.0, 1.0, 1.0]],
+        condensate_species_order=("cold_s", "hot_s", "active_s"),
+        condensate_amounts=[0.0, 0.0, 1.0e-10],
+        hvector_cond=[-10.0, -2.0, -100.0],
+        element_potential=[0.0],
+        temperature=500.0,
+        condensate_temperature_validity_upper=[300.0, 1000.0, 1000.0],
+    )
+
+    payload = report.as_dict()
+    assert payload["all_condensates"]["positive_inactive_count"] == 2
+    assert payload["all_condensates"]["max_positive_inactive_driving"] == pytest.approx(10.0)
+    assert payload["all_condensates"]["top_positive_inactive"][0]["species"] == "cold_s"
+    assert payload["temperature_valid_condensates"]["positive_inactive_count"] == 1
+    assert payload["temperature_valid_condensates"]["max_positive_inactive_driving"] == pytest.approx(2.0)
+    assert payload["temperature_valid_condensates"]["top_positive_inactive"][0]["species"] == "hot_s"
+    assert payload["temperature_invalid_positive_inactive_count"] == 1
+    assert payload["temperature_invalid_max_positive_inactive_driving"] == pytest.approx(10.0)
+    assert payload["candidate_temperature_valid"] == {
+        "cold_s": False,
+        "hot_s": True,
+        "active_s": True,
+    }
+    assert payload["fastchem4_trace_public_runtime_constructor_inputs_used"] is False
+
+
+def test_inactive_driving_without_validity_metadata_treats_all_species_as_valid() -> None:
+    report = evaluate_inactive_condensate_driving(
+        formula_matrix_cond=[[1.0, 1.0]],
+        condensate_species_order=("a_s", "b_s"),
+        condensate_amounts=[0.0, 0.0],
+        hvector_cond=[-3.0, 1.0],
+        element_potential=[0.0],
+        temperature=2000.0,
+    )
+
+    payload = report.as_dict()
+    assert payload["all_condensates"]["positive_inactive_count"] == 1
+    assert payload["temperature_valid_condensates"]["positive_inactive_count"] == 1
+    assert payload["temperature_invalid_positive_inactive_count"] == 0


### PR DESCRIPTION
## Summary

  Promote condensates HEAD route to v1.7.

  This is a diagnostics-only update on top of v1.6. It keeps the v1.6 solver route, support outer loop growth rule,
  route acceptance, gas-only API defaults, and FastChem4 comparison policy unchanged, while adding validity-aware
  inactive condensate driving diagnostics.

  ## Changes

  - Bump public HEAD route metadata:
      - head_route_version = "v1.7"
      - head_route_name = "head_route_v1_7_validity_aware_inactive_driving_diagnostics"

  - Add inactive_condensate_driving diagnostics when return_diagnostics=True.
  - Report inactive-driving in two views:
      - all_condensates: legacy all-candidate view
      - temperature_valid_condensates: filtered using the same temperature_validity_upper metadata as HEAD support
        selection

  - Add unit coverage for the new diagnostics helper and API diagnostics exposure.
  - Update head_route.md, score.md, and score.json with v1.7 results and interpretation.

  ## Interpretation

  The remaining highT gas-only inactive-driving hotspot is not a temperature-valid support miss.

  The legacy all-condensate diagnostic still reports large inactive-driving values around 772, and the direct gas-only
  solver shows the same surface. However, when filtered to temperature-valid condensates, the HEAD route reports zero
  inactive support for the highT gas-only rows.

  This means the highT hotspot was caused by temperature-invalid condensates being counted by the legacy diagnostic, not
  by the HEAD route missing valid condensates.

