### PR TITLE
condensates: promote head route v1.8

### DIFF
--- a/head_route.md
+++ b/head_route.md
@@ -2,7 +2,7 @@
 
 この文書は、ExoGibbs の凝縮あり計算で現在の基準経路として扱う **HEAD route** を定義する。HEAD route の内容を変更した場合は、この文書を更新する。
 
-現在の実装版は **HEAD route v1.7** である。v1.7 は v1.6 の solver route と support 更新規則を維持したまま、公開 diagnostics の inactive condensate driving を温度有効性つきで読めるようにするマイナー更新である。legacy の all-condensate metric は残しつつ、HEAD support selection と同じ `temperature_validity_upper` metadata に基づく temperature-valid subset を併記する。
+現在の実装版は **HEAD route v1.8** である。v1.8 は v1.7 の validity-aware diagnostics を維持しつつ、support-cap retry / staged support-growth retry の採用を「最初に gate を通った候補」ではなく、ExoGibbs-native inactive support closure score が最も良い converged 候補で選ぶ更新である。FastChem4 output は比較対象としてのみ使い、constructor input には使わない。
 
 ## 一言でいうと
 
@@ -19,9 +19,22 @@
 7. v1.5 では、support-cap retry と support-growth staging retry の候補を採用する前に、候補の gas state から inactive condensate driving を再評価し、positive inactive driving が許容値を超える候補を採用しない。
 8. v1.6 では、support outer loop の次 round を作るとき、前 round で試した support ではなく、accepted result の実 support indices を既存 support として使う。実 support から落ちた species がまだ positive inactive なら、通常の support-growth で再追加する。
 9. v1.7 では、`return_diagnostics=True` の result に `inactive_condensate_driving` report を追加し、all-condensate と temperature-valid の inactive-driving summary を分ける。
-10. 最後に selected route（採用経路）と acceptance tier（成功品質ランク）を返す。
+10. v1.8 では、support-cap retry と staged support-growth retry の候補を全て評価し、converged かつ support-closure gate を通る候補の中から `(positive_inactive_count, max_positive_inactive_driving, support_count)` が最小の候補を採用する。
+11. 最後に selected route（採用経路）と acceptance tier（成功品質ランク）を返す。
 
 これは FastChem4 exact replay（FastChem4 の分岐を完全再現すること）ではない。FastChem4 public/runtime/trace values（公開出力・実行時出力・内部 trace 値）は、ExoGibbs の constructor input（初期値や構成入力）として使わない。
+
+## HEAD route v1.8 固定内容
+
+HEAD route v1.8 は、v1.7 の public diagnostics と highT gas-only 解釈を維持したまま、fallback-only retry の採用規則を強化する固定版である。v1.7 では support-cap retry が最初に `max_positive_inactive_driving <= 500` を満たした候補を採用したため、`SiO_s_condensate_window` layer 4 で max driving は 470 と閾値内でも temperature-valid inactive condensates が 77 種残る candidate を採用していた。v1.8 では retry candidate を最初の合格で止めず、全 configured cap / staging candidate を比較して closure score が最も良い converged candidate を採用する。
+
+| promoted item | 目的 | 適用範囲 |
+|---|---|---|
+| best support-closure retry candidate selection | support-cap retry / staged support-growth retry で、最初の合格候補ではなく inactive count、max driving、support count の lexicographic score が最良の converged candidate を採用する。 | support-free fallback-only retry |
+| inactive-count-aware gate diagnostics | gate report に `positive_inactive_count_tolerance` と count/max それぞれの accepted flag を残す。default では count を hard reject には使わず、candidate ranking に使う。 | retry diagnostics |
+| configured cap retry coverage | current broad support より大きい configured cap も retry candidate として評価し、large cap で solver が実 support を落として closure する path を見逃さない。 | support-cap retry |
+
+v1.8 audit では、v1.7 の最大 Gibbs 差だった `SiO_s_condensate_window` layer 4 が cap 34 ではなく cap 128 retry を採用し、temperature-valid inactive driving は 470.8 / 77 種から 0 / 0 種へ下がる。同 row の FastChem4-scaled comparison は `dG/RT Exo-FC = 7.952e-4` から `5.905e-6` へ改善する。99-layer full-profile comparison では public status は `99 converged`、route counts は `82 primary, 17 gas-only` を維持し、max `|dG/RT|` は `9.973e-5` になる。
 
 ## HEAD route v1.7 固定内容
 
@@ -143,8 +156,8 @@ v1.3 default fresh API support-free route selection evidence は次の通りで�
   - `condensate_equilibrium`
 
 `condensate_equilibrium()` が返す `CondensateEquilibriumResult` から、現在の固定版は
-`result.head_route_version == "v1.7"` および
-`result.head_route_name == "head_route_v1_7_validity_aware_inactive_driving_diagnostics"` として読み出せる。
+`result.head_route_version == "v1.8"` および
+`result.head_route_name == "head_route_v1_8_best_support_closure_retry_candidate"` として読み出せる。
 `return_diagnostics=True` の場合は diagnostics にも同じ `head_route_version` と
 `head_route_name` を残し、さらに `inactive_condensate_driving` report を残す。
 
@@ -471,8 +484,8 @@ HEAD route は凝縮あり初版標準経路として進めてよいが、以下
 
 - gas-only `equilibrium()` の挙動を変えない。
 - 既存の production result fields の意味を変えない。
-- gas-only API の defaults を変更しない。凝縮あり API の fixed default は HEAD route v1.7 として扱う。
-- 現在の凝縮あり API の fixed default は `result.head_route_version == "v1.7"` として公開する。
+- gas-only API の defaults を変更しない。凝縮あり API の fixed default は HEAD route v1.8 として扱う。
+- 現在の凝縮あり API の fixed default は `result.head_route_version == "v1.8"` として公開する。
 - FastChem4 public/runtime/trace values を constructor input にしない。
 - FastChem4 exact branch replay を acceptance target にしない。
 - case、species、element を落として成功扱いにしない。

--- a/score.json
+++ b/score.json
@@ -1,6 +1,21 @@
 {
   "schema": "exogibbs_condensate_head_route_scorecard_v1",
   "policy": {
+    "case_by_case_trial_deltas_required": true,
+    "case_by_case_trial_deltas_required_fields": [
+      "rows",
+      "status_counts",
+      "route_counts",
+      "max_abs_delta_g_over_rt_before",
+      "max_abs_delta_g_over_rt_after",
+      "max_abs_delta_g_over_rt_delta",
+      "temperature_valid_max_inactive_driving_before",
+      "temperature_valid_max_inactive_driving_after",
+      "temperature_valid_max_inactive_driving_delta",
+      "temperature_valid_positive_inactive_count_summary",
+      "active_support_count_summary",
+      "top_changed_layers"
+    ],
     "fastchem4_is_comparison_target_only": true,
     "fastchem4_constructor_inputs_used": false,
     "fastchem4_exact_replay_target": false,
@@ -41,6 +56,11 @@
       "metric": "route_support_churn",
       "purpose": "Confirm whether a trial changes only intended rows.",
       "improvement_direction": "Keep route/support changes localized and justified by G/RT or residual improvements."
+    },
+    {
+      "metric": "case_by_case_delta_tracking",
+      "purpose": "Preserve family-level before/after scores so later runs can identify which curated cases changed.",
+      "improvement_direction": "Every new trial records case-by-case deltas in both score.md and score.json."
     },
     {
       "metric": "global_inactive_driving_distribution",
@@ -1119,6 +1139,70 @@
         }
       ],
       "verdict": "Algorithmic improvement: preserves public convergence and route counts, removes all >1000 inactive-driving rows by growing from actual accepted support, improves water gas-ratio outliers, and slightly improves FastChem4-scaled Gibbs counts."
+    },
+    {
+      "description": "Evaluate all configured support-cap and staged support-growth retry candidates, then select the converged candidate with the best ExoGibbs-native support-closure score instead of the first acceptable retry.",
+      "case_by_case_delta": {
+        "available": false,
+        "reason": "The v1.8 scorecard preserves full-profile summary and targeted SiO_s_condensate_window layer 4 before/after values, but the v1.7 family-level artifact was not preserved before the v1.8 artifact was generated. Future trials must store family-level before/after deltas directly in this scorecard.",
+        "targeted_delta_available": true
+      },
+      "full_profile_fastchem4_comparison": {
+        "exogibbs_state_lower_g_over_rt": 19,
+        "exogibbs_temperature_valid_max_inactive_driving": 224.3156799185349,
+        "exogibbs_temperature_valid_rows_gt_0": 16,
+        "exogibbs_temperature_valid_rows_gt_500": 0,
+        "fastchem4_scaled_state_lower_g_over_rt": 80,
+        "max_abs_delta_g_over_rt": 9.972649253597865e-05,
+        "max_abs_delta_g_over_rt_row": {
+          "delta_gibbs_exogibbs_minus_fastchem4": 9.972649253597865e-05,
+          "family": "solar_metal_sulfide_or_Fe_Ni_S_region",
+          "layer_index": 5,
+          "pressure": 0.31622776601683794,
+          "temperature": 693.75
+        },
+        "public_converged": 99,
+        "route_counts": {
+          "gas_only": 17,
+          "primary": 82
+        },
+        "rows": 99
+      },
+      "implementation": {
+        "fastchem4_constructor_inputs_used": false,
+        "support_cap_retry_selection_policy": "best_support_closure_score",
+        "support_closure_max_positive_inactive_count_default": null,
+        "support_closure_max_positive_inactive_driving": 500.0,
+        "support_closure_score_fields": [
+          "positive_inactive_count",
+          "max_positive_inactive_driving",
+          "support_count"
+        ],
+        "support_growth_staging_retry_selection_policy": "best_support_closure_score"
+      },
+      "targeted_before_after": {
+        "after": {
+          "delta_gibbs_exogibbs_minus_fastchem4": 5.905147119733556e-06,
+          "selected_retry": "support_cap_128",
+          "support_count": 72,
+          "temperature_valid_max_positive_inactive_driving": 0.0,
+          "temperature_valid_positive_inactive_count": 0
+        },
+        "before": {
+          "delta_gibbs_exogibbs_minus_fastchem4": 0.0007951733639472991,
+          "selected_retry": "support_cap_34",
+          "support_count": 5,
+          "temperature_valid_max_positive_inactive_driving": 470.8494885802095,
+          "temperature_valid_positive_inactive_count": 77
+        },
+        "family": "SiO_s_condensate_window",
+        "layer_index": 4,
+        "pressure": 0.31622776601683794,
+        "temperature": 900.0
+      },
+      "title": "best support-closure retry candidate",
+      "trial": "v1.8",
+      "verdict": "Improves the largest v1.7 Gibbs gap and support-closure hotspot while preserving 99/99 public convergence and route counts. Runtime increases on fallback-heavy curated tests because all configured retry candidates are evaluated."
     }
   ],
   "diagnostic_trials": [

--- a/score.md
+++ b/score.md
@@ -20,6 +20,28 @@
 
 優先順位は、まず public convergence と budget consistency を壊さないこと、次に ExoGibbs-native `G/RT` と inactive driving を改善すること、その後 FastChem4 gas/Jaccard 差を詰めることとする。
 
+## Score 記録ルール
+
+今後の trial では、全体 summary だけでなく case-by-case delta を
+`score.md` と `score.json` の両方に保存する。`volatiles_artifacts/` は
+scratch artifact なので、後から上書きされても scorecard だけで「どの
+curated case がどう変わったか」を追跡できる状態にする。
+
+各 trial の case-by-case delta には、少なくとも次を family ごとに残す。
+
+| field | 内容 |
+|---|---|
+| rows / status counts / route counts | public route surface が case 単位で変わったか。 |
+| max `|dG/RT|` before/after/delta | FastChem4-scaled comparison の Gibbs gap がどの case で改善・悪化したか。 |
+| Exo temperature-valid max inactive driving before/after/delta | support closure が case 単位で閉じたか。 |
+| temperature-valid inactive count / rows above thresholds | max だけでなく残存数と threshold exceedance を追う。 |
+| active support count summary | support が過剰に膨らんでいないか。 |
+| top changed layers | case 内の代表 layer と、その layer の before/after metrics。 |
+
+`score.json` では各 trial に `case_by_case_delta` block を置く。過去 trial で
+before 側の case-by-case artifact が保存されていない場合は、推測で埋めず、
+`case_by_case_delta_available: false` と理由を明記する。
+
 ## Baseline: HEAD route v1.4
 
 v1.4 は public full condensate budget consistency を主目的にした固定版である。
@@ -470,6 +492,53 @@ in `carbon_rich_CaS_MgS_AlN_window`, `lowT_strong_condensation_budget_stress`,
 and `SiO_s_condensate_window`, with top species such as `Cr23C6(s)` and
 `Ti4O7(s,l)`. Those should be investigated as support/amount/complementarity
 issues, not as gas-only boundary problems.
+
+## Trial v1.8: best support-closure retry candidate
+
+v1.8 changes fallback-only retry adoption from "first acceptable retry" to
+"best inactive-closure retry". Support-cap retry and staged support-growth
+retry now evaluate all configured candidates and select the converged candidate
+with the lowest `(positive_inactive_count, max_positive_inactive_driving,
+support_count)` score. The existing max-driving threshold remains a feasibility
+filter. The positive-inactive count is recorded in the gate and may be used as
+an explicit hard tolerance, but the default uses it as the primary ranking
+metric rather than as a convergence-breaking hard reject.
+
+Motivation: in v1.7, `SiO_s_condensate_window` layer 4 accepted the cap-34 retry
+because its max inactive driving was 470.8, below the 500 gate. That candidate
+still left 77 temperature-valid inactive condensates and produced the largest
+FastChem4-scaled Gibbs gap. The cap-128 candidate converges, closes
+temperature-valid inactive driving, and is selected by v1.8.
+
+Target row score:
+
+| metric | v1.7 cap-34 candidate | v1.8 selected cap-128 candidate |
+|---|---:|---:|
+| row | `SiO_s_condensate_window` layer 4 | same |
+| support count | 5 | 72 |
+| temperature-valid max inactive driving | 470.8 | 0 |
+| temperature-valid inactive count | 77 | 0 |
+| `dG/RT` Exo-FC | 7.952e-4 | 5.905e-6 |
+
+Full-profile FastChem4 comparison after v1.8:
+
+| metric | v1.7 | v1.8 |
+|---|---:|---:|
+| rows | 99 | 99 |
+| public status | 99 converged | 99 converged |
+| route counts | 82 primary, 17 gas-only | 82 primary, 17 gas-only |
+| Exo temperature-valid max inactive driving | 487.1 | 224.3 |
+| Exo rows with temperature-valid inactive driving >500 | 0 | 0 |
+| ExoGibbs lower `G/RT` vs FastChem4-scaled | 19/99 | 19/99 |
+| FastChem4-scaled lower `G/RT` | 80/99 | 80/99 |
+| max `|dG/RT|` | 7.952e-4 | 9.973e-5 |
+
+The largest remaining Gibbs gap after v1.8 is
+`solar_metal_sulfide_or_Fe_Ni_S_region` layer 5 with
+`dG/RT Exo-FC = 9.972649e-5`. The largest remaining temperature-valid inactive
+driving is in `carbon_rich_CaS_MgS_AlN_window` with max 224.3. This keeps the
+next investigation focused on real condensation-family support/amount closure,
+not on highT gas-only artifacts.
 
 ## Next trial candidates
 

--- a/src/exogibbs/api/condensate_equilibrium.py
+++ b/src/exogibbs/api/condensate_equilibrium.py
@@ -36,8 +36,8 @@ CondensateSeedInitializationPolicy = Literal[
     "capacity_fraction",
     "max_density",
 ]
-CONDENSATE_HEAD_ROUTE_VERSION = "v1.7"
-CONDENSATE_HEAD_ROUTE_NAME = "head_route_v1_7_validity_aware_inactive_driving_diagnostics"
+CONDENSATE_HEAD_ROUTE_VERSION = "v1.8"
+CONDENSATE_HEAD_ROUTE_NAME = "head_route_v1_8_best_support_closure_retry_candidate"
 HEAD_ROUTE_SOFT_RESTORATION_COMPONENT_WEIGHTS = {
     "budget": 1.0,
     "total_density": 1.0,
@@ -132,6 +132,7 @@ class CondensateEquilibriumOptions:
     support_growth_staging_retry_add_per_rounds: Optional[Sequence[int]] = (64, 32, 16, 8)
     enable_support_closure_retry_gate: bool = True
     support_closure_max_positive_inactive_driving: float = 5.0e2
+    support_closure_max_positive_inactive_count: Optional[int] = None
     enable_native_seed_fallback: bool = True
     enable_full_condensate_budget_residual_gate: bool = True
     full_condensate_budget_relative_tolerance: float = 1.0e-3
@@ -459,6 +460,13 @@ def _validate_options(options: CondensateEquilibriumOptions) -> None:
     ):
         raise ValueError(
             "support_closure_max_positive_inactive_driving must be finite and non-negative."
+        )
+    if (
+        options.support_closure_max_positive_inactive_count is not None
+        and int(options.support_closure_max_positive_inactive_count) < 0
+    ):
+        raise ValueError(
+            "support_closure_max_positive_inactive_count must be non-negative or None."
         )
     if not isinstance(options.enable_full_condensate_budget_residual_gate, bool):
         raise TypeError("enable_full_condensate_budget_residual_gate must be a bool.")
@@ -1625,7 +1633,10 @@ def _support_closure_retry_gate_report(
             "enabled": False,
             "accepted": True,
             "max_positive_inactive_driving": 0.0,
+            "max_positive_inactive_driving_accepted": True,
             "positive_inactive_count": 0,
+            "positive_inactive_count_tolerance": None,
+            "positive_inactive_count_accepted": True,
             "fastchem4_trace_public_runtime_constructor_inputs_used": False,
         }
     try:
@@ -1648,7 +1659,14 @@ def _support_closure_retry_gate_report(
             "accepted": False,
             "error": f"{type(exc).__name__}: {exc}",
             "max_positive_inactive_driving": float("inf"),
+            "max_positive_inactive_driving_accepted": False,
             "positive_inactive_count": -1,
+            "positive_inactive_count_tolerance": (
+                None
+                if options.support_closure_max_positive_inactive_count is None
+                else int(options.support_closure_max_positive_inactive_count)
+            ),
+            "positive_inactive_count_accepted": False,
             "fastchem4_trace_public_runtime_constructor_inputs_used": False,
         }
     inactive = tuple(int(index) for index in report.get("inactive_positive_indices", ()))
@@ -1667,16 +1685,53 @@ def _support_closure_retry_gate_report(
     )
     max_driving = float(top_rows[0]["driving"]) if top_rows else 0.0
     tolerance = float(options.support_closure_max_positive_inactive_driving)
+    count_tolerance = (
+        None
+        if options.support_closure_max_positive_inactive_count is None
+        else int(options.support_closure_max_positive_inactive_count)
+    )
+    driving_accepted = bool(max_driving <= tolerance)
+    count_accepted = bool(
+        count_tolerance is None or len(inactive) <= count_tolerance
+    )
     return {
         "gate_schema": "exogibbs_support_closure_retry_gate_v1",
         "enabled": True,
-        "accepted": bool(max_driving <= tolerance),
+        "accepted": bool(driving_accepted and count_accepted),
         "max_positive_inactive_driving": max_driving,
         "max_positive_inactive_driving_tolerance": tolerance,
+        "max_positive_inactive_driving_accepted": driving_accepted,
         "positive_inactive_count": len(inactive),
+        "positive_inactive_count_tolerance": count_tolerance,
+        "positive_inactive_count_accepted": count_accepted,
         "top_positive_inactive": tuple(top_rows[:20]),
         "fastchem4_trace_public_runtime_constructor_inputs_used": False,
     }
+
+
+def _support_closure_retry_candidate_score(
+    support_closure_gate: Mapping[str, Any],
+    *,
+    support_count: int,
+) -> tuple[float, float, int]:
+    """Return a sortable closure score for retry candidates.
+
+    Lower is better.  The gate remains a feasibility filter; this score prevents
+    the retry path from stopping at the first barely acceptable cap when a later
+    cap closes more inactive support.
+    """
+
+    positive_count = support_closure_gate.get("positive_inactive_count", math.inf)
+    max_driving = support_closure_gate.get("max_positive_inactive_driving", math.inf)
+    try:
+        count_value = float(positive_count)
+    except (TypeError, ValueError):
+        count_value = math.inf
+    try:
+        driving_value = float(max_driving)
+    except (TypeError, ValueError):
+        driving_value = math.inf
+    return (count_value, driving_value, int(support_count))
 
 
 def _budget_seed_for_support(
@@ -2179,11 +2234,7 @@ def _run_activity_driven_support_outer_loop(
         terminated_reason=terminated_reason,
         outer_iterations=outer_iterations,
     )
-    retry_caps = tuple(
-        cap
-        for cap in _support_cap_retry_sequence(options)
-        if cap < len(tuple(current_support))
-    )
+    retry_caps = _support_cap_retry_sequence(options)
     if (
         options.enable_support_cap_retry
         and options.max_positive_support_count is None
@@ -2191,6 +2242,10 @@ def _run_activity_driven_support_outer_loop(
         and retry_caps
     ):
         retry_attempts = []
+        best_retry_result: CondensateEquilibriumResult | None = None
+        best_retry_gate: Mapping[str, Any] | None = None
+        best_retry_attempt: Mapping[str, Any] | None = None
+        best_retry_score: tuple[float, float, int] | None = None
         for retry_cap in retry_caps:
             retry_options = replace(
                 options,
@@ -2251,32 +2306,45 @@ def _run_activity_driven_support_outer_loop(
                 "support_closure_accepted": retry_support_closure_accepted,
             }
             retry_attempts.append(retry_attempt)
-            if retry_route_promoted and retry_support_closure_accepted:
-                retry_report = {
-                    "retry_schema": "exogibbs_support_free_support_cap_retry_v1",
-                    "triggered": True,
-                    "accepted": bool(retry_accepted and retry_support_closure_accepted),
-                    "route_promoted": True,
-                    "support_closure_accepted": True,
-                    "support_cap": int(retry_cap),
-                    "support_cap_sequence": tuple(int(cap) for cap in retry_caps),
-                    "attempts": tuple(retry_attempts),
-                    "initial_selected_route": last_result.selected_route,
-                    "initial_status": last_result.status,
-                    "initial_support_count": len(tuple(current_support)),
-                    "retry_selected_route": retry_result.selected_route,
-                    "retry_status": retry_result.status,
-                    "retry_support_count": len(
-                        tuple(retry_result.condensate_support_names)
-                    ),
-                    "retry_support_closure_gate": support_closure_gate,
-                    "fastchem4_trace_public_runtime_constructor_inputs_used": False,
-                }
-                return _with_support_cap_retry_diagnostics(
-                    result=retry_result,
-                    retry_report=retry_report,
-                    return_diagnostics=options.return_diagnostics,
+            if retry_route_promoted and retry_accepted and retry_support_closure_accepted:
+                score = _support_closure_retry_candidate_score(
+                    support_closure_gate,
+                    support_count=len(tuple(retry_result.condensate_support_names)),
                 )
+                if best_retry_score is None or score < best_retry_score:
+                    best_retry_score = score
+                    best_retry_result = retry_result
+                    best_retry_gate = support_closure_gate
+                    best_retry_attempt = retry_attempt
+        if best_retry_result is not None and best_retry_gate is not None:
+            selected_attempt = dict(best_retry_attempt or {})
+            retry_report = {
+                "retry_schema": "exogibbs_support_free_support_cap_retry_v1",
+                "triggered": True,
+                "accepted": True,
+                "route_promoted": True,
+                "support_closure_accepted": True,
+                "selection_policy": "best_support_closure_score",
+                "support_closure_score": best_retry_score,
+                "support_cap": int(selected_attempt.get("support_cap", 0)),
+                "support_cap_sequence": tuple(int(cap) for cap in retry_caps),
+                "attempts": tuple(retry_attempts),
+                "initial_selected_route": last_result.selected_route,
+                "initial_status": last_result.status,
+                "initial_support_count": len(tuple(current_support)),
+                "retry_selected_route": best_retry_result.selected_route,
+                "retry_status": best_retry_result.status,
+                "retry_support_count": len(
+                    tuple(best_retry_result.condensate_support_names)
+                ),
+                "retry_support_closure_gate": best_retry_gate,
+                "fastchem4_trace_public_runtime_constructor_inputs_used": False,
+            }
+            return _with_support_cap_retry_diagnostics(
+                result=best_retry_result,
+                retry_report=retry_report,
+                return_diagnostics=options.return_diagnostics,
+            )
     staged_retry_counts = _support_growth_staging_retry_sequence(options)
     if (
         options.enable_support_growth_staging_retry
@@ -2286,6 +2354,10 @@ def _run_activity_driven_support_outer_loop(
         and staged_retry_counts
     ):
         retry_attempts = []
+        best_retry_result = None
+        best_retry_gate = None
+        best_retry_attempt = None
+        best_retry_score = None
         for add_per_round in staged_retry_counts:
             retry_options = replace(
                 options,
@@ -2352,35 +2424,50 @@ def _run_activity_driven_support_outer_loop(
                 "support_closure_accepted": retry_support_closure_accepted,
             }
             retry_attempts.append(retry_attempt)
-            if retry_route_promoted and retry_support_closure_accepted:
-                retry_report = {
-                    "retry_schema": "exogibbs_support_free_support_growth_staging_retry_v1",
-                    "triggered": True,
-                    "accepted": bool(retry_accepted and retry_support_closure_accepted),
-                    "route_promoted": True,
-                    "support_closure_accepted": True,
-                    "max_support_add_per_round": int(add_per_round),
-                    "max_support_add_per_round_sequence": tuple(
-                        int(count) for count in staged_retry_counts
-                    ),
-                    "attempts": tuple(retry_attempts),
-                    "initial_selected_route": last_result.selected_route,
-                    "initial_status": last_result.status,
-                    "initial_support_count": len(tuple(current_support)),
-                    "initial_support_outer_terminated_reason": terminated_reason,
-                    "retry_selected_route": retry_result.selected_route,
-                    "retry_status": retry_result.status,
-                    "retry_support_count": len(
-                        tuple(retry_result.condensate_support_names)
-                    ),
-                    "retry_support_closure_gate": support_closure_gate,
-                    "fastchem4_trace_public_runtime_constructor_inputs_used": False,
-                }
-                return _with_support_growth_staging_retry_diagnostics(
-                    result=retry_result,
-                    retry_report=retry_report,
-                    return_diagnostics=options.return_diagnostics,
+            if retry_route_promoted and retry_accepted and retry_support_closure_accepted:
+                score = _support_closure_retry_candidate_score(
+                    support_closure_gate,
+                    support_count=len(tuple(retry_result.condensate_support_names)),
                 )
+                if best_retry_score is None or score < best_retry_score:
+                    best_retry_score = score
+                    best_retry_result = retry_result
+                    best_retry_gate = support_closure_gate
+                    best_retry_attempt = retry_attempt
+        if best_retry_result is not None and best_retry_gate is not None:
+            selected_attempt = dict(best_retry_attempt or {})
+            retry_report = {
+                "retry_schema": "exogibbs_support_free_support_growth_staging_retry_v1",
+                "triggered": True,
+                "accepted": True,
+                "route_promoted": True,
+                "support_closure_accepted": True,
+                "selection_policy": "best_support_closure_score",
+                "support_closure_score": best_retry_score,
+                "max_support_add_per_round": int(
+                    selected_attempt.get("max_support_add_per_round", 0)
+                ),
+                "max_support_add_per_round_sequence": tuple(
+                    int(count) for count in staged_retry_counts
+                ),
+                "attempts": tuple(retry_attempts),
+                "initial_selected_route": last_result.selected_route,
+                "initial_status": last_result.status,
+                "initial_support_count": len(tuple(current_support)),
+                "initial_support_outer_terminated_reason": terminated_reason,
+                "retry_selected_route": best_retry_result.selected_route,
+                "retry_status": best_retry_result.status,
+                "retry_support_count": len(
+                    tuple(best_retry_result.condensate_support_names)
+                ),
+                "retry_support_closure_gate": best_retry_gate,
+                "fastchem4_trace_public_runtime_constructor_inputs_used": False,
+            }
+            return _with_support_growth_staging_retry_diagnostics(
+                result=best_retry_result,
+                retry_report=retry_report,
+                return_diagnostics=options.return_diagnostics,
+            )
     if (
         options.seed_initialization_policy != "budget_preserving_fraction"
         and last_result.selected_route == "native_budget_seed_fallback_budget_tradeoff"

--- a/tests/unittests/api/condensate_equilibrium_test.py
+++ b/tests/unittests/api/condensate_equilibrium_test.py
@@ -365,7 +365,7 @@ def test_condensate_equilibrium_auto_selects_positive_support_and_calls_solver(m
     assert inactive_driving["production_behavior_change"] is False
 
 
-def test_condensate_equilibrium_options_default_to_head_route_v1_7() -> None:
+def test_condensate_equilibrium_options_default_to_head_route_v1_8() -> None:
     options = CondensateEquilibriumOptions()
 
     assert options.max_positive_support_count is None
@@ -378,6 +378,7 @@ def test_condensate_equilibrium_options_default_to_head_route_v1_7() -> None:
     assert options.enable_head_route_ipopt_h_type_retry is False
     assert options.enable_head_route_condensate_budget_correction_retry is True
     assert options.enable_support_closure_retry_gate is True
+    assert options.support_closure_max_positive_inactive_count is None
     assert options.enable_full_condensate_budget_residual_gate is True
     assert options.full_condensate_budget_relative_tolerance == pytest.approx(1.0e-3)
 
@@ -438,6 +439,7 @@ def test_support_outer_loop_does_not_grow_from_native_seed_fallback(
             allow_caveat_tiers=True,
             max_positive_support_count=None,
             max_support_add_per_round=None,
+            enable_support_cap_retry=False,
             enable_support_growth_staging_retry=False,
         ),
     )
@@ -881,6 +883,62 @@ def test_support_cap_retry_skips_promoted_candidate_when_closure_gate_fails(
     ]
 
 
+def test_support_closure_gate_rejects_residual_inactive_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    setup = _setup_pair_with_two_condensates()
+
+    def fake_activity_report(**kwargs):
+        return {
+            "inactive_positive_indices": (1,),
+            "candidate_driving": {
+                "H2O_s": -1.0,
+                "HO_s": 10.0,
+            },
+        }
+
+    import exogibbs.api.condensate_equilibrium as condensate_api
+
+    monkeypatch.setattr(
+        condensate_api,
+        "_activity_driven_support_report",
+        fake_activity_report,
+    )
+    result = condensate_api.CondensateEquilibriumResult(
+        gas_ln_n=jnp.asarray([0.0, -1.0], dtype=jnp.float64),
+        gas_n=jnp.asarray([1.0, 0.1], dtype=jnp.float64),
+        gas_x=jnp.asarray([0.9, 0.1], dtype=jnp.float64),
+        gas_ntot=jnp.asarray(1.1, dtype=jnp.float64),
+        condensate_amounts=jnp.asarray([0.1, 0.0], dtype=jnp.float64),
+        condensate_support_indices=jnp.asarray([0], dtype=jnp.int32),
+        condensate_support_names=("H2O_s",),
+        acceptance_tier="tier_1_tight_residual_production_adjacent_candidate",
+        selected_route="m4310_full_promoted_policy_route",
+        status=CONVERGED,
+        converged=True,
+        diagnostics={},
+    )
+
+    gate = condensate_api._support_closure_retry_gate_report(
+        setup=setup,
+        T=300.0,
+        P=1.0,
+        b=jnp.asarray([1.0, 1.0]),
+        Pref=1.0,
+        result=result,
+        options=CondensateEquilibriumOptions(
+            support_closure_max_positive_inactive_driving=500.0,
+            support_closure_max_positive_inactive_count=0,
+        ),
+    )
+
+    assert gate["accepted"] is False
+    assert gate["max_positive_inactive_driving_accepted"] is True
+    assert gate["positive_inactive_count"] == 1
+    assert gate["positive_inactive_count_tolerance"] == 0
+    assert gate["positive_inactive_count_accepted"] is False
+
+
 def test_support_outer_loop_tries_staged_support_growth_retry(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -960,7 +1018,7 @@ def test_support_outer_loop_tries_staged_support_growth_retry(
         ),
     )
 
-    assert calls == [(None, True), (2, False)]
+    assert calls == [(None, True), (2, False), (1, False)]
     assert result.selected_route == "m4310_full_promoted_policy_route"
     assert result.diagnostics is not None
     retry = result.diagnostics["support_growth_staging_retry"]
@@ -969,6 +1027,7 @@ def test_support_outer_loop_tries_staged_support_growth_retry(
     assert retry["route_promoted"] is True
     assert retry["max_support_add_per_round"] == 2
     assert retry["max_support_add_per_round_sequence"] == (2, 1)
+    assert retry["selection_policy"] == "best_support_closure_score"
     assert retry["initial_selected_route"] == "native_budget_seed_fallback_budget_tradeoff"
     assert retry["retry_selected_route"] == "m4310_full_promoted_policy_route"
     assert retry["attempts"][0]["support_outer_terminated_reason"] == (
@@ -2136,6 +2195,16 @@ def test_condensate_equilibrium_rejects_invalid_positive_support_options() -> No
             jnp.asarray([1.0, 1.0]),
             options=CondensateEquilibriumOptions(
                 support_growth_staging_retry_add_per_rounds=(64, 0),
+            ),
+        )
+    with pytest.raises(ValueError, match="support_closure_max_positive_inactive_count"):
+        condensate_equilibrium(
+            setup,
+            300.0,
+            1.0,
+            jnp.asarray([1.0, 1.0]),
+            options=CondensateEquilibriumOptions(
+                support_closure_max_positive_inactive_count=-1,
             ),
         )
 


### PR DESCRIPTION
## Summary

Promote condensates HEAD route to v1.8.

v1.8 keeps the v1.7 validity-aware inactive-driving diagnostics, but changes fallback retry adoption from "first acceptable candidate" to "best support-closure candidate". Support-cap retry and staged support-growth retry now evaluate all configured candidates and select the converged candidate with the best ExoGibbs-native closure score:

```text
(positive_inactive_count, max_positive_inactive_driving, support_count)
```

FastChem4 remains a comparison target only. FastChem4 public/runtime/trace values are not used as ExoGibbs constructor inputs.

## Motivation

v1.7 accepted retry candidates using a max inactive-driving feasibility threshold. In `SiO_s_condensate_window` layer 4, v1.7 selected support cap 34 because max inactive driving was below 500, but that candidate still left 77 temperature-valid inactive condensates and produced the largest FastChem4-scaled Gibbs gap.

v1.8 evaluates all retry candidates and selects the one with the best support closure instead of stopping at the first acceptable cap.

## Changes

- Promote public condensate HEAD route metadata:
  - `result.head_route_version == "v1.8"`
  - `result.head_route_name == "head_route_v1_8_best_support_closure_retry_candidate"`
- Add inactive-count-aware support-closure gate diagnostics.
- Add optional `support_closure_max_positive_inactive_count`, defaulting to `None`.
- Change support-cap retry and staged support-growth retry to best-candidate selection.
- Update `head_route.md`, `score.md`, and `score.json`.
- Add a future scorecard rule requiring case-by-case deltas in both `score.md` and `score.json`.

## Target Row Result

| Metric | v1.7 Selected Candidate | v1.8 Selected Candidate |
| --- | --- | --- |
| Row | `SiO_s_condensate_window` layer 4 | `SiO_s_condensate_window` layer 4 |
| Selected retry | support cap 34 | support cap 128 |
| Support count | 5 | 72 |
| Temperature-valid max inactive driving | 470.8 | 0 |
| Temperature-valid inactive count | 77 | 0 |
| `dG/RT` Exo - FastChem4-scaled | `7.952e-4` | `5.905e-6` |

## Full Profile FastChem4 Comparison

| Metric | v1.7 | v1.8 |
| --- | --- | --- |
| Rows | 99 | 99 |
| Public status | 99 converged | 99 converged |
| Route counts | 82 primary, 17 gas-only | 82 primary, 17 gas-only |
| Exo temperature-valid max inactive driving | 487.1 | 224.3 |
| Exo rows with temperature-valid inactive driving > 500 | 0 | 0 |
| ExoGibbs lower `G/RT` vs FastChem4-scaled | 19 / 99 | 19 / 99 |
| FastChem4-scaled lower `G/RT` | 80 / 99 | 80 / 99 |
| max `abs(dG/RT)` | `7.952e-4` | `9.973e-5` |

## Remaining Known Gaps

Largest remaining Gibbs gap:

| Family | Layer | T | P | `dG/RT` Exo - FastChem4-scaled |
| --- | --- | --- | --- | --- |
| `solar_metal_sulfide_or_Fe_Ni_S_region` | 5 | 693.75 | 0.31622776601683794 | `9.972649e-5` |

Largest remaining temperature-valid inactive driving:

| Family | Max temperature-valid inactive driving |
| --- | --- |
| `carbon_rich_CaS_MgS_AlN_window` | 224.3 |

## Verification

```text
python -m py_compile src/exogibbs/api/condensate_equilibrium.py tests/unittests/api/condensate_equilibrium_test.py
python -m json.tool score.json
git diff --check
pytest -q tests/unittests/api/condensate_equilibrium_test.py
pytest -q tests/endtoend/curated_cases
pytest -q tests/unittests
python volatiles_code/deep_compare_head_route_v13_fastchem4.py
```

| Check | Result |
| --- | --- |
| API unit tests | 34 passed |
| Curated end-to-end tests | 8 passed |
| Full unit tests | 328 passed, 1 skipped |
| FastChem4 deep comparison | completed |

Known warnings are unchanged from the existing environment: JAX CUDA no-device fallback, PDIPM overflow/invalid warnings, and DLASCL warnings.

