### PR TITLE
equilibrium: add fixed-support condensate VJP

### DIFF
--- a/documents/equilibrium_solvers.rst
+++ b/documents/equilibrium_solvers.rst
@@ -148,6 +148,42 @@ raw species requiring a depleted element are not carried into it. A failed
 warm solve is retried cold at the same abundance scale, and no condensate
 support is carried between layers.
 
+Fixed-support reverse mode
+--------------------------
+
+The accepted zero-barrier equations have a JAX-compatible custom VJP once the
+positive condensate support is fixed.  The numerical kernel is available as
+``exogibbs.equilibrium.condensate.fixed_support.minimize_gibbs_fixed_support``.
+It returns gas log amounts and physical amounts for the supplied active
+condensate columns.  Temperature, normalized log pressure, and the elemental
+target are differentiable; formula matrices, support, and initial values are
+held fixed.  Before differentiating, run
+``minimize_gibbs_fixed_support_with_diagnostics`` once and check
+``diagnostics.converged``, ``diagnostics.residual_norm``, and
+``diagnostics.iterations``.  This audit route is separate from the custom-VJP
+result so that diagnostic booleans and counters do not become differentiation
+targets; its returned physical state is for certification, not reverse-mode
+AD.  Differentiate the ordinary ``minimize_gibbs_fixed_support`` result.  The
+requested residual tolerance is floored at ten machine epsilons, so the default
+is also usable when JAX runs in float32 mode.
+The condensate formula matrix, initial amounts, and thermochemical source
+callable must all be restricted to the same support and use the same order;
+slice a full-catalog ``condensate_setup.hvector_func(T)`` before passing it to
+the kernel.
+
+This is a local, piecewise-smooth contract.  Active amounts must remain
+positive, inactive condensate driving forces must remain strictly positive,
+and the reduced zero-barrier KKT matrix must remain nonsingular.  A support or
+temperature-validity change is generally nondifferentiable.  The host-side
+support discovery, support expansion, acceptance gates, and rainout inventory
+propagation are therefore not included in this VJP.  A failed zero-barrier
+solve reports ``diagnostics.converged=False`` on the audit route, while the
+custom VJP returns non-finite source cotangents rather than differentiating an
+uncertified iterate.  Primal convergence alone does not certify a derivative
+when the reduced KKT matrix is singular.  This is a first-order reverse-mode
+contract; forward-mode ``jvp`` and higher-order derivatives are not supported
+by the custom-VJP route.
+
 Execution and JAX Contracts
 ---------------------------
 
@@ -174,7 +210,8 @@ Execution and JAX Contracts
    * - Differentiation
      - Custom VJP supports reverse-mode derivatives; forward-mode ``jvp`` is
        intentionally unsupported
-     - The complete lifecycle is not a differentiable or JIT-compatible
+     - The zero-barrier fixed-support kernel has a custom reverse-mode VJP;
+       the complete lifecycle is not a differentiable or JIT-compatible
        public contract
    * - Diagnostics
      - Optional numerical diagnostics use a distinct solver route

--- a/src/exogibbs/equilibrium/condensate/fixed_support/__init__.py
+++ b/src/exogibbs/equilibrium/condensate/fixed_support/__init__.py
@@ -1,1 +1,58 @@
-"""Fixed-support PD-IPM implementation for condensate equilibrium."""
+"""Fixed-support numerical kernels for condensate equilibrium."""
+
+from importlib import import_module
+from typing import Any
+
+
+_EXPORTS = {
+    "DifferentiableFixedSupportResult": (
+        ".types",
+        "DifferentiableFixedSupportResult",
+    ),
+    "FixedSupportSourceCotangents": (
+        ".types",
+        "FixedSupportSourceCotangents",
+    ),
+    "FixedSupportSolveDiagnostics": (
+        ".types",
+        "FixedSupportSolveDiagnostics",
+    ),
+    "fixed_support_source_vjp": (".autodiff", "fixed_support_source_vjp"),
+    "minimize_gibbs_fixed_support": (
+        ".autodiff",
+        "minimize_gibbs_fixed_support",
+    ),
+    "minimize_gibbs_fixed_support_with_diagnostics": (
+        ".autodiff",
+        "minimize_gibbs_fixed_support_with_diagnostics",
+    ),
+}
+
+
+__all__ = (
+    "DifferentiableFixedSupportResult",
+    "FixedSupportSolveDiagnostics",
+    "FixedSupportSourceCotangents",
+    "fixed_support_source_vjp",
+    "minimize_gibbs_fixed_support",
+    "minimize_gibbs_fixed_support_with_diagnostics",
+)
+
+
+def __getattr__(name: str) -> Any:
+    """Load optional fixed-support autodiff objects only when requested."""
+
+    export = _EXPORTS.get(name)
+    if export is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module_name, attribute_name = export
+    module = import_module(module_name, __name__)
+    value = getattr(module, attribute_name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    """Return stable exported names without importing numerical kernels."""
+
+    return sorted(set(globals()) | set(__all__))

--- a/src/exogibbs/equilibrium/condensate/fixed_support/autodiff.py
+++ b/src/exogibbs/equilibrium/condensate/fixed_support/autodiff.py
@@ -1,0 +1,807 @@
+"""Implicit reverse-mode sensitivities on a fixed condensate support.
+
+The production condensate lifecycle discovers support on the host and then
+polishes accepted states at zero barrier.  Support discovery is discrete, so
+this module deliberately owns only the smooth local problem obtained after a
+strictly positive support has been fixed.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, NamedTuple
+
+import jax
+import jax.numpy as jnp
+from jax import custom_vjp
+from jax.lax import stop_gradient
+
+from exogibbs.equilibrium.condensate.fixed_support.linear_solver import (
+    solve_symmetric_reduced_system,
+)
+from exogibbs.equilibrium.condensate.fixed_support.types import (
+    DifferentiableFixedSupportResult,
+    FixedSupportSolveDiagnostics,
+    FixedSupportSourceCotangents,
+    LinearSolverConfig,
+)
+from exogibbs.equilibrium.gas.types import ThermoState
+
+
+_FRACTION_TO_BOUNDARY = 0.995
+_LINE_SEARCH_TRIALS = 20
+_BACKTRACKING_FACTOR = 0.5
+
+
+class _ZeroBarrierState(NamedTuple):
+    gas_log_amounts: Any
+    condensate_amounts: Any
+    element_potential: Any
+    total_gas_log_amount: Any
+
+
+class _ZeroBarrierResiduals(NamedTuple):
+    gas_stationarity: Any
+    condensate_stationarity: Any
+    budget: Any
+    total_density: Any
+
+
+class _NewtonCarry(NamedTuple):
+    state: _ZeroBarrierState
+    residual_norm: Any
+    iteration: Any
+    progressing: Any
+
+
+def _effective_residual_tolerance(residual_crit, dtype):
+    requested = jnp.asarray(residual_crit, dtype=dtype)
+    roundoff_floor = jnp.asarray(10.0 * jnp.finfo(dtype).eps, dtype=dtype)
+    return jnp.maximum(requested, roundoff_floor)
+
+
+def zero_barrier_residuals(
+    target_inventory: Any,
+    gas_source: Any,
+    condensate_standard_source: Any,
+    state: _ZeroBarrierState,
+    gas_formula_matrix: Any,
+    condensate_formula_matrix: Any,
+) -> _ZeroBarrierResiduals:
+    """Evaluate the physical fixed-support KKT residual at zero barrier."""
+
+    q = jnp.asarray(state.gas_log_amounts)
+    dtype = q.dtype
+    m = jnp.asarray(state.condensate_amounts, dtype=dtype)
+    element_potential = jnp.asarray(state.element_potential, dtype=dtype)
+    qtot = jnp.asarray(state.total_gas_log_amount, dtype=dtype)
+    target = jnp.asarray(target_inventory, dtype=dtype)
+    gamma = jnp.asarray(gas_source, dtype=dtype)
+    hcond = jnp.asarray(condensate_standard_source, dtype=dtype)
+    ag = jnp.asarray(gas_formula_matrix, dtype=dtype)
+    ac = jnp.asarray(condensate_formula_matrix, dtype=dtype)
+    gas_amounts = jnp.exp(q)
+    total_gas = jnp.exp(qtot)
+
+    return _ZeroBarrierResiduals(
+        gas_stationarity=(
+            q + gamma - qtot - ag.T @ element_potential
+        ),
+        condensate_stationarity=hcond - ac.T @ element_potential,
+        budget=ag @ gas_amounts + ac @ m - target,
+        total_density=jnp.sum(gas_amounts) - total_gas,
+    )
+
+
+def zero_barrier_residual_vector(
+    target_inventory: Any,
+    gas_source: Any,
+    condensate_standard_source: Any,
+    gas_log_amounts: Any,
+    condensate_amounts: Any,
+    element_potential: Any,
+    total_gas_log_amount: Any,
+    gas_formula_matrix: Any,
+    condensate_formula_matrix: Any,
+) -> Any:
+    """Return the zero-barrier residual in canonical block order."""
+
+    residual = zero_barrier_residuals(
+        target_inventory,
+        gas_source,
+        condensate_standard_source,
+        _ZeroBarrierState(
+            gas_log_amounts=gas_log_amounts,
+            condensate_amounts=condensate_amounts,
+            element_potential=element_potential,
+            total_gas_log_amount=total_gas_log_amount,
+        ),
+        gas_formula_matrix,
+        condensate_formula_matrix,
+    )
+    return jnp.concatenate(
+        [
+            jnp.ravel(residual.gas_stationarity),
+            jnp.ravel(residual.condensate_stationarity),
+            jnp.ravel(residual.budget),
+            jnp.ravel(residual.total_density),
+        ]
+    )
+
+
+def _scaled_residual_norm(residual, target_inventory, total_gas_log_amount):
+    dtype = jnp.asarray(residual.gas_stationarity).dtype
+    target = jnp.asarray(target_inventory, dtype=dtype)
+    target_magnitude = jnp.abs(target)
+    budget_scale = 1.0 / jnp.where(
+        target_magnitude > 0.0,
+        target_magnitude,
+        jnp.ones_like(target_magnitude),
+    )
+    tiny = jnp.asarray(jnp.finfo(dtype).tiny, dtype=dtype)
+    total_scale = 1.0 / jnp.maximum(
+        jnp.exp(jnp.asarray(total_gas_log_amount, dtype=dtype)), tiny
+    )
+
+    def max_abs(value):
+        return jnp.max(jnp.abs(jnp.asarray(value)), initial=0.0)
+
+    return jnp.max(
+        jnp.asarray(
+            [
+                max_abs(residual.gas_stationarity),
+                max_abs(residual.condensate_stationarity),
+                max_abs(budget_scale * residual.budget),
+                jnp.abs(total_scale * residual.total_density),
+            ],
+            dtype=dtype,
+        )
+    )
+
+
+def _zero_barrier_reduced_matrix(
+    gas_log_amounts,
+    total_gas_log_amount,
+    gas_formula_matrix,
+    condensate_formula_matrix,
+):
+    q = jnp.asarray(gas_log_amounts)
+    dtype = q.dtype
+    qtot = jnp.asarray(total_gas_log_amount, dtype=dtype)
+    ag = jnp.asarray(gas_formula_matrix, dtype=dtype)
+    ac = jnp.asarray(condensate_formula_matrix, dtype=dtype)
+    gas_amounts = jnp.exp(q)
+    total_gas = jnp.exp(qtot)
+    gas_inventory = ag @ gas_amounts
+    qgas = ag @ (gas_amounts[:, None] * ag.T)
+    condensate_count = ac.shape[1]
+    return jnp.block(
+        [
+            [qgas, ac, gas_inventory[:, None]],
+            [
+                ac.T,
+                jnp.zeros(
+                    (condensate_count, condensate_count), dtype=dtype
+                ),
+                jnp.zeros((condensate_count, 1), dtype=dtype),
+            ],
+            [
+                gas_inventory[None, :],
+                jnp.zeros((1, condensate_count), dtype=dtype),
+                (jnp.sum(gas_amounts) - total_gas).reshape((1, 1)),
+            ],
+        ]
+    )
+
+
+def _zero_barrier_newton_direction(
+    target_inventory,
+    gas_source,
+    condensate_standard_source,
+    state,
+    gas_formula_matrix,
+    condensate_formula_matrix,
+):
+    residual = zero_barrier_residuals(
+        target_inventory,
+        gas_source,
+        condensate_standard_source,
+        state,
+        gas_formula_matrix,
+        condensate_formula_matrix,
+    )
+    q = jnp.asarray(state.gas_log_amounts)
+    dtype = q.dtype
+    ag = jnp.asarray(gas_formula_matrix, dtype=dtype)
+    gas_amounts = jnp.exp(q)
+    matrix = _zero_barrier_reduced_matrix(
+        q,
+        state.total_gas_log_amount,
+        ag,
+        condensate_formula_matrix,
+    )
+    rhs = jnp.concatenate(
+        [
+            -residual.budget
+            + ag @ (gas_amounts * residual.gas_stationarity),
+            residual.condensate_stationarity,
+            jnp.asarray(
+                [
+                    -residual.total_density
+                    + jnp.dot(gas_amounts, residual.gas_stationarity)
+                ],
+                dtype=dtype,
+            ),
+        ]
+    )
+    solution = solve_symmetric_reduced_system(
+        matrix, rhs, LinearSolverConfig()
+    )
+    element_count = ag.shape[0]
+    condensate_count = jnp.asarray(
+        condensate_formula_matrix
+    ).shape[1]
+    delta_element_potential = solution[:element_count]
+    delta_condensate = solution[
+        element_count : element_count + condensate_count
+    ]
+    delta_qtot = solution[-1]
+    delta_q = (
+        ag.T @ delta_element_potential
+        + delta_qtot
+        - residual.gas_stationarity
+    )
+    return _ZeroBarrierState(
+        gas_log_amounts=delta_q,
+        condensate_amounts=delta_condensate,
+        element_potential=delta_element_potential,
+        total_gas_log_amount=delta_qtot,
+    )
+
+
+def _zero_barrier_solve_core(
+    target_inventory,
+    gas_source,
+    condensate_standard_source,
+    gas_log_amounts_init,
+    condensate_amounts_init,
+    element_potential_init,
+    total_gas_log_amount_init,
+    gas_formula_matrix,
+    condensate_formula_matrix,
+    residual_crit,
+    max_iter,
+):
+    q0 = jnp.asarray(gas_log_amounts_init)
+    dtype = q0.dtype
+    tiny = jnp.asarray(jnp.finfo(dtype).tiny, dtype=dtype)
+    initial_state = _ZeroBarrierState(
+        gas_log_amounts=q0,
+        condensate_amounts=jnp.maximum(
+            jnp.asarray(condensate_amounts_init, dtype=dtype), tiny
+        ),
+        element_potential=jnp.asarray(element_potential_init, dtype=dtype),
+        total_gas_log_amount=jnp.asarray(
+            total_gas_log_amount_init, dtype=dtype
+        ),
+    )
+    initial_residual = zero_barrier_residuals(
+        target_inventory,
+        gas_source,
+        condensate_standard_source,
+        initial_state,
+        gas_formula_matrix,
+        condensate_formula_matrix,
+    )
+    initial_norm = _scaled_residual_norm(
+        initial_residual,
+        target_inventory,
+        initial_state.total_gas_log_amount,
+    )
+    initial = _NewtonCarry(
+        state=initial_state,
+        residual_norm=initial_norm,
+        iteration=jnp.asarray(0, dtype=jnp.int32),
+        progressing=jnp.asarray(True),
+    )
+    tolerance = _effective_residual_tolerance(residual_crit, dtype)
+
+    def cond_fun(carry):
+        return (
+            (carry.residual_norm > tolerance)
+            & (carry.iteration < max_iter)
+            & carry.progressing
+            & jnp.isfinite(carry.residual_norm)
+        )
+
+    def body_fun(carry):
+        direction = _zero_barrier_newton_direction(
+            target_inventory,
+            gas_source,
+            condensate_standard_source,
+            carry.state,
+            gas_formula_matrix,
+            condensate_formula_matrix,
+        )
+        m = carry.state.condensate_amounts
+        dm = direction.condensate_amounts
+        boundary_ratios = jnp.where(dm < 0.0, -m / dm, jnp.inf)
+        alpha_max = jnp.minimum(
+            jnp.asarray(1.0, dtype=dtype),
+            _FRACTION_TO_BOUNDARY * jnp.min(boundary_ratios),
+        )
+        alphas = alpha_max * _BACKTRACKING_FACTOR ** jnp.arange(
+            _LINE_SEARCH_TRIALS, dtype=dtype
+        )
+
+        def evaluate(alpha):
+            candidate = jax.tree_util.tree_map(
+                lambda current, delta: current + alpha * delta,
+                carry.state,
+                direction,
+            )
+            residual = zero_barrier_residuals(
+                target_inventory,
+                gas_source,
+                condensate_standard_source,
+                candidate,
+                gas_formula_matrix,
+                condensate_formula_matrix,
+            )
+            norm = _scaled_residual_norm(
+                residual,
+                target_inventory,
+                candidate.total_gas_log_amount,
+            )
+            values = jnp.concatenate(
+                [
+                    candidate.gas_log_amounts,
+                    candidate.condensate_amounts,
+                    candidate.element_potential,
+                    candidate.total_gas_log_amount.reshape((1,)),
+                ]
+            )
+            finite_and_positive = (
+                jnp.all(jnp.isfinite(values))
+                & jnp.isfinite(norm)
+                & jnp.all(candidate.condensate_amounts > 0.0)
+            )
+            return candidate, norm, finite_and_positive
+
+        candidates, norms, finite_and_positive = jax.vmap(evaluate)(alphas)
+        acceptable = finite_and_positive & (norms < carry.residual_norm)
+        accepted = jnp.any(acceptable)
+        selected_index = jnp.argmax(acceptable.astype(jnp.int32))
+        selected_state = jax.tree_util.tree_map(
+            lambda values, fallback: jnp.where(
+                accepted, values[selected_index], fallback
+            ),
+            candidates,
+            carry.state,
+        )
+        selected_norm = jnp.where(
+            accepted, norms[selected_index], carry.residual_norm
+        )
+        return _NewtonCarry(
+            state=selected_state,
+            residual_norm=selected_norm,
+            iteration=carry.iteration + 1,
+            progressing=accepted,
+        )
+
+    return jax.lax.while_loop(cond_fun, body_fun, initial)
+
+
+def fixed_support_source_vjp(
+    gas_cotangent: Any,
+    condensate_cotangent: Any,
+    gas_log_amounts: Any,
+    condensate_amounts: Any,
+    total_gas_log_amount: Any,
+    gas_formula_matrix: Any,
+    condensate_formula_matrix: Any,
+) -> FixedSupportSourceCotangents:
+    """Return source cotangents from the zero-barrier reduced adjoint.
+
+    The caller supplies cotangents for ``(log(n_gas), m_active)``.  The
+    returned fields correspond to ``(b, gamma, h_cond_active)``.  Formula
+    matrices and support indices are treated as fixed mathematical structure.
+    The supplied state must be a converged physical root with strictly
+    positive active amounts and a nonsingular reduced KKT matrix.
+    """
+
+    q = jnp.asarray(gas_log_amounts)
+    dtype = q.dtype
+    m = jnp.asarray(condensate_amounts, dtype=dtype)
+    gq = jnp.asarray(gas_cotangent, dtype=dtype)
+    gm = jnp.asarray(condensate_cotangent, dtype=dtype)
+    ag = jnp.asarray(gas_formula_matrix, dtype=dtype)
+    ac = jnp.asarray(condensate_formula_matrix, dtype=dtype)
+    if gq.shape != q.shape:
+        raise ValueError("gas_cotangent must match gas_log_amounts.")
+    if gm.shape != m.shape or m.shape != (ac.shape[1],):
+        raise ValueError(
+            "condensate cotangent, amounts, and formula columns must match."
+        )
+    matrix = _zero_barrier_reduced_matrix(
+        q, total_gas_log_amount, ag, ac
+    )
+    rhs = jnp.concatenate([ag @ gq, gm, jnp.sum(gq).reshape((1,))])
+    solution = solve_symmetric_reduced_system(
+        matrix, rhs, LinearSolverConfig()
+    )
+    element_count = ag.shape[0]
+    condensate_count = ac.shape[1]
+    alpha = solution[:element_count]
+    chi = solution[element_count : element_count + condensate_count]
+    tau = solution[-1]
+    gas_amounts = jnp.exp(q)
+    gas_source_cotangent = (
+        gas_amounts * (ag.T @ alpha + tau) - gq
+    )
+    return FixedSupportSourceCotangents(
+        target_inventory=alpha,
+        gas_source=gas_source_cotangent,
+        condensate_standard_source=chi,
+    )
+
+
+def _solve_zero_barrier_sources_impl(
+    target_inventory,
+    gas_source,
+    condensate_standard_source,
+    gas_log_amounts_init,
+    condensate_amounts_init,
+    element_potential_init,
+    total_gas_log_amount_init,
+    gas_formula_matrix,
+    condensate_formula_matrix,
+    residual_crit,
+    max_iter,
+):
+    solved = _zero_barrier_solve_core(
+        target_inventory,
+        gas_source,
+        condensate_standard_source,
+        gas_log_amounts_init,
+        condensate_amounts_init,
+        element_potential_init,
+        total_gas_log_amount_init,
+        gas_formula_matrix,
+        condensate_formula_matrix,
+        residual_crit,
+        max_iter,
+    )
+    final = solved.state
+    return DifferentiableFixedSupportResult(
+        gas_log_amounts=final.gas_log_amounts,
+        condensate_amounts=final.condensate_amounts,
+    )
+
+
+@custom_vjp
+def _solve_zero_barrier_sources(
+    target_inventory,
+    gas_source,
+    condensate_standard_source,
+    gas_log_amounts_init,
+    condensate_amounts_init,
+    element_potential_init,
+    total_gas_log_amount_init,
+    gas_formula_matrix,
+    condensate_formula_matrix,
+    residual_crit,
+    max_iter,
+):
+    return _solve_zero_barrier_sources_impl(
+        target_inventory,
+        gas_source,
+        condensate_standard_source,
+        gas_log_amounts_init,
+        condensate_amounts_init,
+        element_potential_init,
+        total_gas_log_amount_init,
+        gas_formula_matrix,
+        condensate_formula_matrix,
+        residual_crit,
+        max_iter,
+    )
+
+
+def _solve_zero_barrier_sources_fwd(
+    target_inventory,
+    gas_source,
+    condensate_standard_source,
+    gas_log_amounts_init,
+    condensate_amounts_init,
+    element_potential_init,
+    total_gas_log_amount_init,
+    gas_formula_matrix,
+    condensate_formula_matrix,
+    residual_crit,
+    max_iter,
+):
+    solved = _zero_barrier_solve_core(
+        target_inventory,
+        gas_source,
+        condensate_standard_source,
+        gas_log_amounts_init,
+        condensate_amounts_init,
+        element_potential_init,
+        total_gas_log_amount_init,
+        gas_formula_matrix,
+        condensate_formula_matrix,
+        residual_crit,
+        max_iter,
+    )
+    final = solved.state
+    result = DifferentiableFixedSupportResult(
+        gas_log_amounts=final.gas_log_amounts,
+        condensate_amounts=final.condensate_amounts,
+    )
+    tolerance = _effective_residual_tolerance(
+        residual_crit, solved.residual_norm.dtype
+    )
+    residuals = (
+        final.gas_log_amounts,
+        final.condensate_amounts,
+        final.total_gas_log_amount,
+        jnp.isfinite(solved.residual_norm)
+        & (solved.residual_norm <= tolerance),
+        gas_formula_matrix,
+        condensate_formula_matrix,
+    )
+    return result, residuals
+
+
+def _solve_zero_barrier_sources_bwd(
+    residuals,
+    cotangent,
+):
+    q, m, qtot, converged, ag, ac = residuals
+    source_cotangents = fixed_support_source_vjp(
+        cotangent.gas_log_amounts,
+        cotangent.condensate_amounts,
+        q,
+        m,
+        qtot,
+        ag,
+        ac,
+    )
+
+    def require_converged(value):
+        value = jnp.asarray(value)
+        return jnp.where(converged, value, jnp.full_like(value, jnp.nan))
+
+    # Initialization, formula matrices, and support are not differentiated.
+    # A failed primal has no certified implicit root, so its source cotangents
+    # fail closed instead of reporting derivatives of an arbitrary iterate.
+    return (
+        require_converged(source_cotangents.target_inventory),
+        require_converged(source_cotangents.gas_source),
+        require_converged(source_cotangents.condensate_standard_source),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+
+
+_solve_zero_barrier_sources.defvjp(
+    _solve_zero_barrier_sources_fwd,
+    _solve_zero_barrier_sources_bwd,
+)
+
+
+def _prepare_fixed_support_inputs(
+    state: ThermoState,
+    gas_log_amounts_init,
+    condensate_amounts_init,
+    total_gas_log_amount_init,
+    gas_formula_matrix,
+    condensate_formula_matrix,
+    gas_hvector_func: Callable[[Any], Any],
+    condensate_hvector_func: Callable[[Any], Any],
+    *,
+    element_potential_init=None,
+):
+    """Validate and normalize one fixed-support zero-barrier solve."""
+
+    q_input = jnp.asarray(gas_log_amounts_init)
+    m_input = jnp.asarray(condensate_amounts_init)
+    target_input = jnp.asarray(state.element_vector)
+    gas_source_input = jnp.asarray(gas_hvector_func(state.temperature))
+    condensate_source_input = jnp.asarray(
+        condensate_hvector_func(state.temperature)
+    )
+    dtype = jnp.result_type(
+        q_input,
+        m_input,
+        target_input,
+        gas_source_input,
+        condensate_source_input,
+        state.temperature,
+        state.ln_normalized_pressure,
+        jnp.float32,
+    )
+    ag = jnp.asarray(gas_formula_matrix, dtype=dtype)
+    ac = jnp.asarray(condensate_formula_matrix, dtype=dtype)
+    q0 = jnp.asarray(q_input, dtype=dtype)
+    m0 = jnp.asarray(m_input, dtype=dtype)
+    qtot0 = jnp.asarray(total_gas_log_amount_init, dtype=dtype)
+    target = jnp.asarray(target_input, dtype=dtype)
+    if ag.ndim != 2 or ac.ndim != 2:
+        raise ValueError("gas and condensate formula matrices must be 2D.")
+    if ag.shape[0] != ac.shape[0]:
+        raise ValueError("gas and condensate element dimensions must match.")
+    if ac.shape[1] == 0:
+        raise ValueError(
+            "fixed-support differentiation requires a nonempty support."
+        )
+    if q0.shape != (ag.shape[1],):
+        raise ValueError("gas_log_amounts_init must have one value per gas species.")
+    if m0.shape != (ac.shape[1],):
+        raise ValueError(
+            "condensate_amounts_init must have one value per support species."
+        )
+    if qtot0.ndim != 0:
+        raise ValueError("total_gas_log_amount_init must be scalar.")
+    if target.shape != (ag.shape[0],):
+        raise ValueError("state.element_vector must have one value per element.")
+
+    gas_standard_source = jnp.asarray(
+        gas_source_input, dtype=dtype
+    )
+    condensate_standard_source = jnp.asarray(
+        condensate_source_input, dtype=dtype
+    )
+    if gas_standard_source.shape != (ag.shape[1],):
+        raise ValueError("gas_hvector_func must return one value per gas species.")
+    if condensate_standard_source.shape != (ac.shape[1],):
+        raise ValueError(
+            "condensate_hvector_func must return one value per support species."
+        )
+    gas_source = gas_standard_source + jnp.asarray(
+        state.ln_normalized_pressure, dtype=dtype
+    )
+    if element_potential_init is None:
+        initial_stationarity_rhs = q0 + gas_source - qtot0
+        element_potential0 = jnp.linalg.lstsq(
+            ag.T, initial_stationarity_rhs, rcond=None
+        )[0]
+    else:
+        element_potential0 = jnp.asarray(
+            element_potential_init, dtype=dtype
+        )
+        if element_potential0.shape != (ag.shape[0],):
+            raise ValueError(
+                "element_potential_init must have one value per element."
+            )
+
+    return (
+        target,
+        gas_source,
+        condensate_standard_source,
+        stop_gradient(q0),
+        stop_gradient(m0),
+        stop_gradient(element_potential0),
+        stop_gradient(qtot0),
+        ag,
+        ac,
+    )
+
+
+def minimize_gibbs_fixed_support(
+    state: ThermoState,
+    gas_log_amounts_init: Any,
+    condensate_amounts_init: Any,
+    total_gas_log_amount_init: Any,
+    gas_formula_matrix: Any,
+    condensate_formula_matrix: Any,
+    gas_hvector_func: Callable[[Any], Any],
+    condensate_hvector_func: Callable[[Any], Any],
+    *,
+    element_potential_init: Any = None,
+    residual_crit: float = 1.0e-10,
+    max_iter: int = 100,
+) -> DifferentiableFixedSupportResult:
+    """Solve and differentiate a zero-barrier equilibrium on fixed support.
+
+    ``condensate_formula_matrix`` must contain exactly the caller-selected
+    positive support, and ``condensate_amounts_init`` uses the same column
+    order.  ``condensate_hvector_func`` must likewise return only that support
+    in the same order; a full-catalog setup function should be sliced by the
+    caller.  The support, formula matrices, and all initialization values are
+    non-differentiable.  Reverse-mode derivatives are provided with respect
+    to temperature, normalized log pressure, and target elemental inventory
+    via ``state``.  The host-side support lifecycle and rainout propagation
+    are not part of this local differentiability contract.
+
+    The convergence threshold is never set below ten machine epsilons for the
+    numerical dtype.  Thus the default remains ``1e-10`` in float64 and is
+    automatically relaxed to a representable tolerance in float32.  Use
+    :func:`minimize_gibbs_fixed_support_with_diagnostics` to certify a primal
+    solve before consuming it.
+    """
+
+    prepared = _prepare_fixed_support_inputs(
+        state,
+        gas_log_amounts_init,
+        condensate_amounts_init,
+        total_gas_log_amount_init,
+        gas_formula_matrix,
+        condensate_formula_matrix,
+        gas_hvector_func,
+        condensate_hvector_func,
+        element_potential_init=element_potential_init,
+    )
+    return _solve_zero_barrier_sources(
+        *prepared,
+        residual_crit,
+        max_iter,
+    )
+
+
+def minimize_gibbs_fixed_support_with_diagnostics(
+    state: ThermoState,
+    gas_log_amounts_init: Any,
+    condensate_amounts_init: Any,
+    total_gas_log_amount_init: Any,
+    gas_formula_matrix: Any,
+    condensate_formula_matrix: Any,
+    gas_hvector_func: Callable[[Any], Any],
+    condensate_hvector_func: Callable[[Any], Any],
+    *,
+    element_potential_init: Any = None,
+    residual_crit: float = 1.0e-10,
+    max_iter: int = 100,
+) -> tuple[DifferentiableFixedSupportResult, FixedSupportSolveDiagnostics]:
+    """Run the zero-barrier kernel and return non-differentiable diagnostics.
+
+    This audit entry point executes the same primal iteration but intentionally
+    bypasses the custom VJP.  Use :func:`minimize_gibbs_fixed_support` for
+    reverse-mode derivatives after this report certifies convergence.
+    """
+
+    prepared = _prepare_fixed_support_inputs(
+        state,
+        gas_log_amounts_init,
+        condensate_amounts_init,
+        total_gas_log_amount_init,
+        gas_formula_matrix,
+        condensate_formula_matrix,
+        gas_hvector_func,
+        condensate_hvector_func,
+        element_potential_init=element_potential_init,
+    )
+    solved = _zero_barrier_solve_core(
+        *prepared,
+        residual_crit,
+        max_iter,
+    )
+    final = solved.state
+    tolerance = _effective_residual_tolerance(
+        residual_crit, solved.residual_norm.dtype
+    )
+    result = DifferentiableFixedSupportResult(
+        gas_log_amounts=final.gas_log_amounts,
+        condensate_amounts=final.condensate_amounts,
+    )
+    diagnostics = FixedSupportSolveDiagnostics(
+        converged=jnp.isfinite(solved.residual_norm)
+        & (solved.residual_norm <= tolerance),
+        residual_norm=solved.residual_norm,
+        iterations=solved.iteration,
+    )
+    return result, diagnostics
+
+
+__all__ = [
+    "fixed_support_source_vjp",
+    "minimize_gibbs_fixed_support",
+    "minimize_gibbs_fixed_support_with_diagnostics",
+    "zero_barrier_residual_vector",
+]

--- a/src/exogibbs/equilibrium/condensate/fixed_support/linear_solver.py
+++ b/src/exogibbs/equilibrium/condensate/fixed_support/linear_solver.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import jax.numpy as jnp
 
 from exogibbs.equilibrium.condensate.fixed_support.problem import physical_amounts
@@ -39,6 +41,34 @@ def _symmetric_ruiz_equilibration(
 def _scaled_solve(scaled_matrix, scaled_rhs, total_scale):
     scaled_solution = jnp.linalg.solve(scaled_matrix, scaled_rhs)
     return total_scale * scaled_solution
+
+
+def solve_symmetric_reduced_system(
+    matrix: Any,
+    rhs: Any,
+    config: LinearSolverConfig = LinearSolverConfig(),
+) -> Any:
+    """Solve one symmetric reduced system with the canonical scaling policy.
+
+    Both the finite-barrier R-GIE direction and the zero-barrier implicit VJP
+    use symmetric, generally indefinite, reduced systems.  Keeping their Ruiz
+    equilibration and iterative-refinement policy in one helper prevents the
+    forward and adjoint paths from silently acquiring different numerics.
+    """
+
+    scaled_matrix, scaled_rhs, total_scale = _symmetric_ruiz_equilibration(
+        matrix, rhs, config.ruiz_iterations
+    )
+    solution = _scaled_solve(scaled_matrix, scaled_rhs, total_scale)
+    for _ in range(config.iterative_refinement_steps):
+        unscaled_residual = rhs - matrix @ solution
+        correction = _scaled_solve(
+            scaled_matrix,
+            total_scale * unscaled_residual,
+            total_scale,
+        )
+        solution = solution + correction
+    return solution
 
 
 def reduced_direction_from_rhs(
@@ -90,18 +120,7 @@ def reduced_direction_from_rhs(
     rhs = jnp.concatenate(
         [reduced_budget_rhs, reduced_total_rhs.reshape((1,))]
     )
-    scaled_matrix, scaled_rhs, total_scale = _symmetric_ruiz_equilibration(
-        matrix, rhs, config.ruiz_iterations
-    )
-    solution = _scaled_solve(scaled_matrix, scaled_rhs, total_scale)
-    for _ in range(config.iterative_refinement_steps):
-        unscaled_residual = rhs - matrix @ solution
-        correction = _scaled_solve(
-            scaled_matrix,
-            total_scale * unscaled_residual,
-            total_scale,
-        )
-        solution = solution + correction
+    solution = solve_symmetric_reduced_system(matrix, rhs, config)
 
     delta_lambda = solution[:-1]
     delta_qtot = solution[-1]
@@ -186,4 +205,8 @@ def normal_reduced_direction(
     )
 
 
-__all__ = ["normal_reduced_direction", "reduced_direction_from_rhs"]
+__all__ = [
+    "normal_reduced_direction",
+    "reduced_direction_from_rhs",
+    "solve_symmetric_reduced_system",
+]

--- a/src/exogibbs/equilibrium/condensate/fixed_support/types.py
+++ b/src/exogibbs/equilibrium/condensate/fixed_support/types.py
@@ -214,6 +214,34 @@ class PhysicalAmounts(NamedTuple):
     total_gas: Array
 
 
+class DifferentiableFixedSupportResult(NamedTuple):
+    """Physical zero-barrier solution on one caller-selected support.
+
+    The condensate vector contains only the active columns supplied to the
+    fixed-support kernel.  Catalog support discovery remains a separate,
+    discrete lifecycle operation.
+    """
+
+    gas_log_amounts: Array
+    condensate_amounts: Array
+
+
+class FixedSupportSolveDiagnostics(NamedTuple):
+    """Non-differentiable convergence report for a zero-barrier solve."""
+
+    converged: Array
+    residual_norm: Array
+    iterations: Array
+
+
+class FixedSupportSourceCotangents(NamedTuple):
+    """Cotangents of the zero-barrier thermochemical source arrays."""
+
+    target_inventory: Array
+    gas_source: Array
+    condensate_standard_source: Array
+
+
 class ResidualComponents(NamedTuple):
     """Canonical KKT residual blocks in mathematical equation order."""
 
@@ -531,6 +559,9 @@ __all__ = [
     "NormalTrialSelection",
     "OriginalDirection",
     "OriginalState",
+    "DifferentiableFixedSupportResult",
+    "FixedSupportSolveDiagnostics",
+    "FixedSupportSourceCotangents",
     "PhysicalAmounts",
     "ResidualComponents",
     "RestorationConfig",

--- a/tests/unittests/equilibrium/condensate/fixed_support/autodiff_test.py
+++ b/tests/unittests/equilibrium/condensate/fixed_support/autodiff_test.py
@@ -1,0 +1,480 @@
+"""Regression tests for the fixed-support zero-barrier custom VJP."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+from exogibbs.equilibrium.condensate.fixed_support.autodiff import (
+    fixed_support_source_vjp,
+    minimize_gibbs_fixed_support,
+    minimize_gibbs_fixed_support_with_diagnostics,
+    zero_barrier_residual_vector,
+)
+from exogibbs.equilibrium.gas.types import ThermoState
+
+
+jax.config.update("jax_enable_x64", True)
+
+
+_LOG_K = jnp.log(0.25)
+
+
+def _gas_hvector(temperature):
+    return jnp.asarray([0.2 * temperature, -0.1 * temperature])
+
+
+def _condensate_hvector(temperature):
+    # At T=2 and log(P/Pref)=0 this gives
+    # h_cond - h_gas[0] = log(0.25).
+    return jnp.asarray([0.05 * temperature + _LOG_K + 0.3])
+
+
+def _fixture():
+    gas_formula_matrix = jnp.eye(2)
+    condensate_formula_matrix = jnp.asarray([[1.0], [0.0]])
+    target = jnp.asarray([2.0, 1.0])
+    gas_log_amounts_init = jnp.log(jnp.asarray([0.4, 0.9]))
+    condensate_amounts_init = jnp.asarray([1.6])
+    total_gas_log_amount_init = jnp.log(
+        jnp.sum(jnp.exp(gas_log_amounts_init))
+    )
+    return (
+        gas_formula_matrix,
+        condensate_formula_matrix,
+        target,
+        gas_log_amounts_init,
+        condensate_amounts_init,
+        total_gas_log_amount_init,
+    )
+
+
+def _solve(
+    temperature=2.0,
+    log_pressure=0.0,
+    target=None,
+    gas_log_amounts_init=None,
+    condensate_amounts_init=None,
+    return_diagnostics=False,
+):
+    ag, ac, default_target, q0, m0, qtot0 = _fixture()
+    if target is None:
+        target = default_target
+    if gas_log_amounts_init is None:
+        gas_log_amounts_init = q0
+    if condensate_amounts_init is None:
+        condensate_amounts_init = m0
+    solver = (
+        minimize_gibbs_fixed_support_with_diagnostics
+        if return_diagnostics
+        else minimize_gibbs_fixed_support
+    )
+    return solver(
+        ThermoState(temperature, log_pressure, target),
+        gas_log_amounts_init,
+        condensate_amounts_init,
+        qtot0,
+        ag,
+        ac,
+        _gas_hvector,
+        _condensate_hvector,
+        residual_crit=1.0e-12,
+        max_iter=50,
+    )
+
+
+def test_fixed_support_zero_barrier_solver_matches_analytic_coexistence():
+    result, diagnostics = _solve(return_diagnostics=True)
+    expected_gas = jnp.asarray([1.0 / 3.0, 1.0])
+    expected_condensate = jnp.asarray([5.0 / 3.0])
+
+    assert jnp.exp(result.gas_log_amounts) == pytest.approx(expected_gas)
+    assert result.condensate_amounts == pytest.approx(expected_condensate)
+    assert bool(diagnostics.converged)
+    assert diagnostics.residual_norm < 1.0e-12
+    assert int(diagnostics.iterations) > 0
+
+
+def test_reduced_source_vjp_matches_dense_transpose_jacobian():
+    ag, ac, target, _q0, _m0, _qtot0 = _fixture()
+    result = _solve()
+    q = result.gas_log_amounts
+    m = result.condensate_amounts
+    qtot = jnp.log(jnp.sum(jnp.exp(q)))
+    gamma = _gas_hvector(2.0)
+    hcond = _condensate_hvector(2.0)
+    element_potential = jnp.asarray(
+        [hcond[0], q[1] + gamma[1] - qtot]
+    )
+    gas_cotangent = jnp.asarray([0.7, -0.4])
+    condensate_cotangent = jnp.asarray([1.3])
+
+    reduced = fixed_support_source_vjp(
+        gas_cotangent,
+        condensate_cotangent,
+        q,
+        m,
+        qtot,
+        ag,
+        ac,
+    )
+
+    def residual_from_variables(variables):
+        q_value = variables[:2]
+        m_value = variables[2:3]
+        potential_value = variables[3:5]
+        qtot_value = variables[-1]
+        return zero_barrier_residual_vector(
+            target,
+            gamma,
+            hcond,
+            q_value,
+            m_value,
+            potential_value,
+            qtot_value,
+            ag,
+            ac,
+        )
+
+    variables = jnp.concatenate(
+        [q, m, element_potential, qtot.reshape((1,))]
+    )
+    jacobian = jax.jacrev(residual_from_variables)(variables)
+    output_cotangent = jnp.concatenate(
+        [gas_cotangent, condensate_cotangent, jnp.zeros((3,))]
+    )
+    adjoint = jnp.linalg.solve(jacobian.T, output_cotangent)
+    gas_count = q.shape[0]
+    condensate_count = m.shape[0]
+    element_count = target.shape[0]
+    expected_gas_source = -adjoint[:gas_count]
+    expected_condensate_source = -adjoint[
+        gas_count : gas_count + condensate_count
+    ]
+    expected_target = adjoint[
+        gas_count
+        + condensate_count : gas_count
+        + condensate_count
+        + element_count
+    ]
+
+    assert reduced.gas_source == pytest.approx(expected_gas_source)
+    assert reduced.condensate_standard_source == pytest.approx(
+        expected_condensate_source
+    )
+    assert reduced.target_inventory == pytest.approx(expected_target)
+
+
+def test_reduced_source_vjp_handles_nonsquare_gas_and_multiple_support():
+    ag = jnp.asarray(
+        [
+            [1.0, 0.0, 0.0, 1.0],
+            [0.0, 1.0, 0.0, 1.0],
+            [0.0, 0.0, 1.0, 1.0],
+        ]
+    )
+    ac = jnp.asarray(
+        [
+            [1.0, 0.0],
+            [0.0, 1.0],
+            [0.0, 0.0],
+        ]
+    )
+    gas_amounts = jnp.asarray([0.2, 0.3, 0.4, 0.1])
+    q = jnp.log(gas_amounts)
+    m = jnp.asarray([0.7, 0.5])
+    qtot = jnp.log(jnp.sum(gas_amounts))
+    element_potential = jnp.asarray([0.4, -0.2, 0.1])
+    gamma = ag.T @ element_potential - q + qtot
+    hcond = ac.T @ element_potential
+    target = ag @ gas_amounts + ac @ m
+    gas_cotangent = jnp.asarray([0.7, -0.4, 0.2, 0.9])
+    condensate_cotangent = jnp.asarray([1.3, -0.6])
+
+    reduced = fixed_support_source_vjp(
+        gas_cotangent,
+        condensate_cotangent,
+        q,
+        m,
+        qtot,
+        ag,
+        ac,
+    )
+
+    def residual_from_variables(variables):
+        gas_count = ag.shape[1]
+        condensate_count = ac.shape[1]
+        element_count = ag.shape[0]
+        m_start = gas_count
+        potential_start = m_start + condensate_count
+        qtot_index = potential_start + element_count
+        return zero_barrier_residual_vector(
+            target,
+            gamma,
+            hcond,
+            variables[:gas_count],
+            variables[m_start:potential_start],
+            variables[potential_start:qtot_index],
+            variables[qtot_index],
+            ag,
+            ac,
+        )
+
+    variables = jnp.concatenate(
+        [q, m, element_potential, qtot.reshape((1,))]
+    )
+    jacobian = jax.jacrev(residual_from_variables)(variables)
+    output_cotangent = jnp.concatenate(
+        [gas_cotangent, condensate_cotangent, jnp.zeros((4,))]
+    )
+    adjoint = jnp.linalg.solve(jacobian.T, output_cotangent)
+    gas_count = ag.shape[1]
+    condensate_count = ac.shape[1]
+    element_count = ag.shape[0]
+
+    assert reduced.gas_source == pytest.approx(-adjoint[:gas_count])
+    assert reduced.condensate_standard_source == pytest.approx(
+        -adjoint[gas_count : gas_count + condensate_count]
+    )
+    assert reduced.target_inventory == pytest.approx(
+        adjoint[
+            gas_count
+            + condensate_count : gas_count
+            + condensate_count
+            + element_count
+        ]
+    )
+
+
+def test_custom_vjp_matches_analytic_temperature_pressure_and_budget_derivatives():
+    _ag, _ac, target, _q0, _m0, _qtot0 = _fixture()
+    gas_pressure_jacobian = jax.jacrev(
+        lambda log_pressure: _solve(
+            log_pressure=log_pressure
+        ).gas_log_amounts
+    )(0.0)
+    condensate_pressure_jacobian = jax.jacrev(
+        lambda log_pressure: _solve(
+            log_pressure=log_pressure
+        ).condensate_amounts
+    )(0.0)
+    gas_temperature_jacobian = jax.jacrev(
+        lambda temperature: _solve(
+            temperature=temperature
+        ).gas_log_amounts
+    )(2.0)
+    condensate_temperature_jacobian = jax.jacrev(
+        lambda temperature: _solve(
+            temperature=temperature
+        ).condensate_amounts
+    )(2.0)
+    gas_budget_jacobian = jax.jacrev(
+        lambda inventory: _solve(target=inventory).gas_log_amounts
+    )(target)
+    condensate_budget_jacobian = jax.jacrev(
+        lambda inventory: _solve(target=inventory).condensate_amounts
+    )(target)
+
+    assert gas_pressure_jacobian == pytest.approx([-4.0 / 3.0, 0.0])
+    assert condensate_pressure_jacobian == pytest.approx([4.0 / 9.0])
+    assert gas_temperature_jacobian == pytest.approx([-0.2, 0.0])
+    assert condensate_temperature_jacobian == pytest.approx([1.0 / 15.0])
+    assert gas_budget_jacobian == pytest.approx(
+        jnp.asarray([[0.0, 1.0], [0.0, 1.0]])
+    )
+    assert condensate_budget_jacobian == pytest.approx(
+        jnp.asarray([[1.0, -1.0 / 3.0]])
+    )
+
+
+def test_custom_vjp_differentiates_the_complete_physical_result_pytree():
+    jacobian = jax.jacrev(lambda temperature: _solve(temperature=temperature))(
+        2.0
+    )
+
+    assert jacobian.gas_log_amounts == pytest.approx([-0.2, 0.0])
+    assert jacobian.condensate_amounts == pytest.approx([1.0 / 15.0])
+
+
+def test_custom_vjp_stops_initialization_gradients_and_is_jittable():
+    ag, ac, target, q0, m0, qtot0 = _fixture()
+
+    def loss(q_init, m_init, qtot_init, potential_init, gas_matrix, cond_matrix):
+        result = minimize_gibbs_fixed_support(
+            ThermoState(2.0, 0.0, target),
+            q_init,
+            m_init,
+            qtot_init,
+            gas_matrix,
+            cond_matrix,
+            _gas_hvector,
+            _condensate_hvector,
+            element_potential_init=potential_init,
+            residual_crit=1.0e-12,
+            max_iter=50,
+        )
+        return jnp.sum(result.gas_log_amounts) + jnp.sum(
+            result.condensate_amounts
+        )
+
+    potential0 = jnp.zeros((ag.shape[0],), dtype=q0.dtype)
+    gradients = jax.grad(loss, argnums=(0, 1, 2, 3, 4, 5))(
+        q0, m0, qtot0, potential0, ag, ac
+    )
+    compiled = jax.jit(
+        lambda temperature: _solve(
+            temperature=temperature
+        ).gas_log_amounts
+    )(2.0)
+    compiled_gradient = jax.jit(
+        jax.grad(
+            lambda temperature: jnp.sum(
+                _solve(temperature=temperature).gas_log_amounts
+            )
+        )
+    )(2.0)
+    batched_gradients = jax.vmap(
+        jax.grad(
+            lambda temperature: jnp.sum(
+                _solve(temperature=temperature).gas_log_amounts
+            )
+        )
+    )(jnp.asarray([1.9, 2.0, 2.1]))
+
+    for gradient, value in zip(
+        gradients, (q0, m0, qtot0, potential0, ag, ac)
+    ):
+        assert gradient == pytest.approx(jnp.zeros_like(value))
+    assert jnp.all(jnp.isfinite(compiled))
+    assert compiled_gradient == pytest.approx(-0.2)
+    assert jnp.all(jnp.isfinite(batched_gradients))
+
+
+def test_public_solver_can_be_jitted_directly_with_dynamic_config_values():
+    ag, ac, target, q0, m0, qtot0 = _fixture()
+    compiled_solver = jax.jit(
+        minimize_gibbs_fixed_support,
+        static_argnums=(6, 7),
+    )
+
+    result = compiled_solver(
+        ThermoState(2.0, 0.0, target),
+        q0,
+        m0,
+        qtot0,
+        ag,
+        ac,
+        _gas_hvector,
+        _condensate_hvector,
+        residual_crit=1.0e-12,
+        max_iter=50,
+    )
+
+    assert jnp.exp(result.gas_log_amounts) == pytest.approx([1.0 / 3.0, 1.0])
+    assert result.condensate_amounts == pytest.approx([5.0 / 3.0])
+
+
+def test_fixed_support_forward_mode_is_explicitly_unsupported():
+    with pytest.raises(TypeError, match="forward-mode autodiff"):
+        jax.jvp(
+            lambda temperature: _solve(
+                temperature=temperature
+            ).gas_log_amounts,
+            (2.0,),
+            (1.0,),
+        )
+
+
+def test_failed_zero_barrier_solve_returns_nonfinite_source_gradient():
+    ag, ac, target, q0, m0, qtot0 = _fixture()
+
+    def solve(temperature, *, diagnostics=False):
+        solver = (
+            minimize_gibbs_fixed_support_with_diagnostics
+            if diagnostics
+            else minimize_gibbs_fixed_support
+        )
+        return solver(
+            ThermoState(temperature, 0.0, target),
+            q0,
+            m0,
+            qtot0,
+            ag,
+            ac,
+            _gas_hvector,
+            _condensate_hvector,
+            residual_crit=1.0e-12,
+            max_iter=0,
+        )
+
+    def loss(temperature):
+        result = solve(temperature)
+        return jnp.sum(result.gas_log_amounts)
+
+    _result, diagnostics = solve(2.0, diagnostics=True)
+    assert not bool(diagnostics.converged)
+    assert diagnostics.residual_norm > 1.0e-12
+    assert jnp.isnan(jax.grad(loss)(2.0))
+
+
+def test_float32_uses_a_representable_convergence_tolerance():
+    ag = jnp.eye(2, dtype=jnp.float32)
+    ac = jnp.asarray([[1.0], [0.0]], dtype=jnp.float32)
+    target = jnp.asarray([2.0, 1.0], dtype=jnp.float32)
+    q0 = jnp.log(jnp.asarray([0.4, 0.9], dtype=jnp.float32))
+    m0 = jnp.asarray([1.6], dtype=jnp.float32)
+    qtot0 = jnp.log(jnp.sum(jnp.exp(q0)))
+
+    def loss(temperature):
+        result = minimize_gibbs_fixed_support(
+            ThermoState(temperature, jnp.float32(0.0), target),
+            q0,
+            m0,
+            qtot0,
+            ag,
+            ac,
+            _gas_hvector,
+            _condensate_hvector,
+        )
+        return (
+            jnp.sum(result.gas_log_amounts)
+            + jnp.sum(result.condensate_amounts)
+        )
+
+    _diagnostic_result, diagnostics = (
+        minimize_gibbs_fixed_support_with_diagnostics(
+            ThermoState(jnp.float32(2.0), jnp.float32(0.0), target),
+            q0,
+            m0,
+            qtot0,
+            ag,
+            ac,
+            _gas_hvector,
+            _condensate_hvector,
+        )
+    )
+    gradient = jax.grad(loss)(jnp.float32(2.0))
+
+    assert bool(diagnostics.converged)
+    assert jnp.isfinite(gradient)
+    assert gradient == pytest.approx(-2.0 / 15.0, rel=2.0e-5)
+
+
+def test_integer_stoichiometric_matrices_promote_to_floating_solver_dtype():
+    ag, ac, target, q0, m0, qtot0 = _fixture()
+    result, diagnostics = minimize_gibbs_fixed_support_with_diagnostics(
+        ThermoState(2.0, 0.0, target),
+        q0,
+        m0,
+        qtot0,
+        ag.astype(jnp.int32),
+        ac.astype(jnp.int32),
+        _gas_hvector,
+        _condensate_hvector,
+        residual_crit=1.0e-12,
+    )
+
+    assert jnp.issubdtype(result.gas_log_amounts.dtype, jnp.floating)
+    assert bool(diagnostics.converged)
+    assert jnp.exp(result.gas_log_amounts) == pytest.approx([1.0 / 3.0, 1.0])


### PR DESCRIPTION
## Summary

- add a JAX-native zero-barrier solver and implicit custom VJP for a caller-selected positive condensate support
- reuse the symmetric reduced-system scaling policy for Newton and adjoint solves, with a separate non-differentiable diagnostics route
- document the fixed-support KKT/adjoint contract in the equilibrium solver guide
- add analytic, dense-adjoint, JIT/vmap, float32, integer-stoichiometry, and failure-path regression tests

## Motivation

The condensate lifecycle publishes a zero-barrier physical state, so differentiating a finite-barrier endpoint would produce a biased derivative. Support discovery and rainout are discrete host-side operations; this change therefore differentiates the smooth fixed-support zero-barrier branch using the implicit function theorem.

## User impact

Users can compute first-order reverse-mode derivatives of gas log amounts and active condensate amounts with respect to temperature, normalized log pressure, and elemental inventory. Formula matrices, support, and initialization remain fixed. Support changes, lifecycle selection, rainout propagation, forward-mode JVP, and higher-order derivatives are outside this local contract.

## Validation

- `env JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 pytest -q tests/unittests` — 383 passed
- fixed-support autodiff regressions — 11 passed
- non-square 4-gas/3-element/2-condensate VJP agrees with central differences within `4.4e-11`
- `git diff --check`