### PR TITLE
examples: add ExoJAX NUTS VJP retrieval demos

### DIFF
--- a/benchmarks/vjp_retrieval/README.md
+++ b/benchmarks/vjp_retrieval/README.md
@@ -1,0 +1,71 @@
+# ExoJAX NUTS VJP GPU runs
+
+`run_exojax_nuts_gpu.csh` is a scheduler-independent tcsh launcher for the
+three retrieval demonstrations:
+
+- `gas_no_grid`: gas equilibrium with the default initialization;
+- `gas_grid`: the same model with `GridEquilibriumInitializer`;
+- `condensate_fixed_support`: a locally differentiable, fixed-support model
+  with the full FastChem4 gas catalog but an explicit `C(s)`-only reduced
+  condensate catalog.
+
+ExoJAX, NumPyro, and a CUDA-enabled JAX installation are optional runtime
+dependencies and are not installed by ExoGibbs itself. The demos were
+validated with ExoJAX 1.6, NumPyro 0.16.1, and JAX 0.4.30. Match the JAX build
+to the CUDA installation on the execution host.
+
+The production launcher requires a CUDA-enabled JAX installation and the
+exact local ExoMol CO database directory, for example
+`/data/exojax/CO/12C-16O/Li2015`. It checks both `nvidia-smi` and the JAX
+backend, performs the demo's read-only preflight, and then requests 500 NUTS
+warmup steps and 1000 posterior samples. It does not submit a PBS or Slurm job.
+
+Run one case directly with:
+
+```tcsh
+benchmarks/vjp_retrieval/run_exojax_nuts_gpu.csh \
+  gas_no_grid /data/exojax/CO/12C-16O/Li2015
+```
+
+The database path can instead be supplied through the environment:
+
+```tcsh
+setenv EXOJAX_CO_DATABASE /data/exojax/CO/12C-16O/Li2015
+benchmarks/vjp_retrieval/run_exojax_nuts_gpu.csh gas_grid
+```
+
+Additional demo options are forwarded to both the preflight and retrieval
+commands after the database argument. In particular, use `--quick` to exercise
+the complete pipeline with the demo's short configuration before submitting a
+production job:
+
+```tcsh
+benchmarks/vjp_retrieval/run_exojax_nuts_gpu.csh \
+  condensate_fixed_support /data/exojax/CO/12C-16O/Li2015 --quick
+```
+
+The quick configuration is only an end-to-end smoke test. Its five warmup
+steps are too few for scientific inference; in particular, short gas-case
+runs can consist entirely of divergent transitions.
+
+The condensate case demonstrates the fixed-support VJP mechanics only. It
+does not claim equilibrium or support closure against the other FastChem4
+condensates. Full-catalog support discovery and its production-scale NUTS
+practicality require a separate A100 study.
+
+Outputs are written under `results/vjp_retrieval/<case>/`, which is ignored by
+Git. Set `EXOGIBBS_VJP_OUTPUT_ROOT` to choose a different output root. The
+launcher enables JAX 64-bit mode, requires the CUDA platform, disables JAX GPU
+memory preallocation, and selects a non-interactive Matplotlib backend. It
+also sets `NUMBA_DISABLE_JIT=1` to avoid the read-only RADIS cache issue in the
+current environment; the retrieval calculation itself is compiled by JAX.
+
+The corresponding narrative tutorials are generated from the notebooks under
+`documents/ipynb/`. Notebook-to-RST conversion never runs the expensive NUTS
+calculation. The converter additionally requires `nbformat` and `nbconvert`;
+the committed output was checked with versions 5.1.3 and 6.1.0, respectively:
+
+```bash
+python documents/ipynb/convert_vjp_retrieval_notebooks.py
+python documents/ipynb/convert_vjp_retrieval_notebooks.py --check
+```

--- a/benchmarks/vjp_retrieval/run_exojax_nuts_gpu.csh
+++ b/benchmarks/vjp_retrieval/run_exojax_nuts_gpu.csh
@@ -1,0 +1,137 @@
+#!/bin/tcsh -f
+
+set SCRIPT_DIR = `dirname "$0"`
+cd "$SCRIPT_DIR/../.."
+if ( $status != 0 ) then
+  echo "ERROR: could not enter the ExoGibbs repository root"
+  exit 1
+endif
+
+if ( $#argv < 1 ) then
+  echo "usage: $0 CASE [CO_DATABASE] [demo options]"
+  echo "CASE: gas_no_grid | gas_grid | condensate_fixed_support"
+  echo "CO_DATABASE may instead be set with EXOJAX_CO_DATABASE."
+  exit 2
+endif
+
+set CASE_NAME = "$1"
+shift argv
+switch ( "$CASE_NAME" )
+case gas_no_grid:
+  set RUNNER = examples/retrievals/exojax_nuts_gas_no_grid.py
+  breaksw
+case gas_grid:
+  set RUNNER = examples/retrievals/exojax_nuts_gas_grid.py
+  breaksw
+case condensate_fixed_support:
+  set RUNNER = examples/retrievals/exojax_nuts_condensate_fixed_support.py
+  breaksw
+default:
+  echo "ERROR: unknown CASE '$CASE_NAME'"
+  echo "expected gas_no_grid, gas_grid, or condensate_fixed_support"
+  exit 2
+endsw
+
+set CO_DATABASE = ""
+if ( $?EXOJAX_CO_DATABASE ) then
+  set CO_DATABASE = "$EXOJAX_CO_DATABASE"
+endif
+if ( $#argv > 0 ) then
+  if ( "$1" !~ --* ) then
+    set CO_DATABASE = "$1"
+    shift argv
+  endif
+endif
+if ( "$CO_DATABASE" == "" ) then
+  echo "ERROR: provide the exact CO/12C-16O/Li2015 directory as CO_DATABASE"
+  echo "or set EXOJAX_CO_DATABASE before launching the job"
+  exit 2
+endif
+if ( ! -d "$CO_DATABASE" ) then
+  echo "ERROR: CO database directory does not exist: $CO_DATABASE"
+  exit 2
+endif
+if ( ! -f "$RUNNER" ) then
+  echo "ERROR: retrieval demo is missing: $RUNNER"
+  exit 2
+endif
+
+if ( $?PYTHONPATH ) then
+  setenv PYTHONPATH "$cwd/src:$PYTHONPATH"
+else
+  setenv PYTHONPATH "$cwd/src"
+endif
+setenv JAX_ENABLE_X64 1
+setenv JAX_PLATFORMS cuda
+setenv JAX_PLATFORM_NAME cuda
+setenv XLA_PYTHON_CLIENT_PREALLOCATE false
+setenv PYTHONHASHSEED 0
+setenv MPLBACKEND Agg
+# The locally installed RADIS package otherwise attempts to cache Numba code
+# inside its read-only egg. This does not disable JAX compilation.
+setenv NUMBA_DISABLE_JIT 1
+
+set OUTPUT_ROOT = results/vjp_retrieval
+if ( $?EXOGIBBS_VJP_OUTPUT_ROOT ) then
+  set OUTPUT_ROOT = "$EXOGIBBS_VJP_OUTPUT_ROOT"
+endif
+set OUTDIR = "$OUTPUT_ROOT/$CASE_NAME"
+mkdir -p "$OUTDIR/matplotlib"
+if ( $status != 0 ) then
+  echo "ERROR: could not create output directory: $OUTDIR"
+  exit 1
+endif
+if ( "$OUTDIR" =~ /* ) then
+  setenv MPLCONFIGDIR "$OUTDIR/matplotlib"
+else
+  setenv MPLCONFIGDIR "$cwd/$OUTDIR/matplotlib"
+endif
+
+echo "== ExoJAX + ExoGibbs NUTS VJP retrieval =="
+echo "case:        $CASE_NAME"
+echo "runner:      $RUNNER"
+echo "CO database: $CO_DATABASE"
+echo "output:      $OUTDIR"
+if ( "$CASE_NAME" == "condensate_fixed_support" ) then
+  echo "model:       FastChem4 gas + reduced C(s)-only condensate catalog"
+  echo "             (not full-catalog condensate equilibrium)"
+endif
+date
+
+nvidia-smi
+if ( $status != 0 ) then
+  echo "ERROR: nvidia-smi failed"
+  exit 1
+endif
+
+python -c 'import jax; devices=jax.devices(); print("JAX backend:", jax.default_backend()); print("JAX devices:", devices); raise SystemExit(0 if jax.default_backend() == "gpu" and devices else 1)'
+if ( $status != 0 ) then
+  echo "ERROR: JAX did not initialize a CUDA GPU backend"
+  exit 1
+endif
+
+python "$RUNNER" \
+  --co-database "$CO_DATABASE" \
+  --output-dir "$OUTDIR" \
+  --preflight-only \
+  $argv:q
+if ( $status != 0 ) then
+  echo "ERROR: retrieval preflight failed"
+  exit 1
+endif
+
+python "$RUNNER" \
+  --co-database "$CO_DATABASE" \
+  --output-dir "$OUTDIR" \
+  --num-warmup 500 \
+  --num-samples 1000 \
+  --seed 0 \
+  $argv:q
+if ( $status != 0 ) then
+  echo "ERROR: retrieval run failed"
+  exit 1
+endif
+
+echo "== completed: $CASE_NAME =="
+date
+find "$OUTDIR" -maxdepth 1 -type f -ls

--- a/documents/index.rst
+++ b/documents/index.rst
@@ -37,6 +37,14 @@ Contents
 
 .. toctree::
    :maxdepth: 1
+   :caption: VJP RETRIEVALS:
+
+   ipynb/exojax_nuts_gas_no_grid
+   ipynb/exojax_nuts_gas_grid
+   ipynb/exojax_nuts_condensate_fixed_support
+
+.. toctree::
+   :maxdepth: 1
    :caption: API:
 
    exogibbs/index.rst

--- a/documents/ipynb/convert_vjp_retrieval_notebooks.py
+++ b/documents/ipynb/convert_vjp_retrieval_notebooks.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Convert the VJP retrieval notebooks to committed RST without execution.
+
+The notebooks are the editable sources.  This script intentionally uses the
+``nbconvert`` exporter directly and never starts a Jupyter kernel.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import shutil
+from typing import Mapping
+
+try:
+    import nbformat
+    from nbconvert import RSTExporter
+except ImportError as exc:  # pragma: no cover - depends on the docs environment
+    raise SystemExit(
+        "Notebook conversion requires nbformat and nbconvert. Install them in "
+        "the documentation environment before running this script."
+    ) from exc
+
+
+NOTEBOOK_DIRECTORY = Path(__file__).resolve().parent
+NOTEBOOK_STEMS = (
+    "exojax_nuts_gas_no_grid",
+    "exojax_nuts_gas_grid",
+    "exojax_nuts_condensate_fixed_support",
+)
+GENERATED_HEADER = (
+    ".. This file is generated from the sibling .ipynb by "
+    "convert_vjp_retrieval_notebooks.py.\n"
+    ".. Do not edit this RST file directly.\n\n"
+)
+
+
+def _separate_directives(body: str) -> str:
+    """Insert the blank line required before top-level RST directives."""
+
+    lines = [line.rstrip() for line in body.splitlines()]
+    separated = []
+    for line in lines:
+        if line.startswith(".. ") and separated and separated[-1].strip():
+            separated.append("")
+        separated.append(line)
+    return "\n".join(separated)
+
+
+def _export_notebook(notebook_path: Path) -> tuple[str, Mapping[str, bytes]]:
+    """Return deterministic RST text and binary resources without execution."""
+
+    notebook = nbformat.read(notebook_path, as_version=4)
+    exporter = RSTExporter()
+    exporter.exclude_input_prompt = True
+    exporter.exclude_output_prompt = True
+    resources = {
+        "unique_key": notebook_path.stem,
+        "output_files_dir": f"{notebook_path.stem}_files",
+    }
+    body, exported_resources = exporter.from_notebook_node(
+        notebook,
+        resources=resources,
+    )
+    body = _separate_directives(body)
+    rst = GENERATED_HEADER + body.rstrip() + "\n"
+    outputs = exported_resources.get("outputs", {})
+    return rst, outputs
+
+
+def _validate_resource_name(name: str, stem: str) -> Path:
+    """Reject exporter output paths outside the notebook-specific asset tree."""
+
+    relative_path = Path(name)
+    expected_directory = f"{stem}_files"
+    if (
+        relative_path.is_absolute()
+        or ".." in relative_path.parts
+        or not relative_path.parts
+        or relative_path.parts[0] != expected_directory
+    ):
+        raise ValueError(f"Unsafe nbconvert resource path: {name!r}")
+    return relative_path
+
+
+def _check_notebook(stem: str, rst: str, outputs: Mapping[str, bytes]) -> bool:
+    """Return whether committed RST and assets exactly match the notebook."""
+
+    rst_path = NOTEBOOK_DIRECTORY / f"{stem}.rst"
+    if not rst_path.is_file() or rst_path.read_text(encoding="utf-8") != rst:
+        return False
+
+    expected_resources = {
+        _validate_resource_name(name, stem): content
+        for name, content in outputs.items()
+    }
+    asset_directory = NOTEBOOK_DIRECTORY / f"{stem}_files"
+    actual_resources = {}
+    if asset_directory.is_symlink():
+        return False
+    if asset_directory.is_dir():
+        actual_resources = {
+            path.relative_to(NOTEBOOK_DIRECTORY): path.read_bytes()
+            for path in sorted(asset_directory.rglob("*"))
+            if path.is_file()
+        }
+    return actual_resources == expected_resources
+
+
+def _write_notebook(stem: str, rst: str, outputs: Mapping[str, bytes]) -> None:
+    """Replace one notebook's generated RST and exact generated asset tree."""
+
+    rst_path = NOTEBOOK_DIRECTORY / f"{stem}.rst"
+    with rst_path.open("w", encoding="utf-8", newline="\n") as stream:
+        stream.write(rst)
+
+    asset_directory = NOTEBOOK_DIRECTORY / f"{stem}_files"
+    if asset_directory.exists():
+        if (
+            asset_directory.is_symlink()
+            or not asset_directory.is_dir()
+            or asset_directory.parent != NOTEBOOK_DIRECTORY
+        ):
+            raise ValueError(f"Refusing to replace unsafe asset path: {asset_directory}")
+        shutil.rmtree(asset_directory)
+
+    for name, content in sorted(outputs.items()):
+        relative_path = _validate_resource_name(name, stem)
+        output_path = NOTEBOOK_DIRECTORY / relative_path
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(content)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "stems",
+        nargs="*",
+        metavar="STEM",
+        help="Notebook stems to convert (default: all VJP retrieval tutorials).",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Check committed generated files without modifying them.",
+    )
+    args = parser.parse_args()
+
+    selected_stems = args.stems or NOTEBOOK_STEMS
+    unknown_stems = sorted(set(selected_stems) - set(NOTEBOOK_STEMS))
+    if unknown_stems:
+        parser.error(
+            "unknown notebook stem(s): "
+            + ", ".join(unknown_stems)
+            + "; expected one of: "
+            + ", ".join(NOTEBOOK_STEMS)
+        )
+    stale = []
+    for stem in selected_stems:
+        notebook_path = NOTEBOOK_DIRECTORY / f"{stem}.ipynb"
+        if not notebook_path.is_file():
+            raise FileNotFoundError(f"Missing notebook source: {notebook_path}")
+        rst, outputs = _export_notebook(notebook_path)
+        if args.check:
+            if not _check_notebook(stem, rst, outputs):
+                stale.append(stem)
+        else:
+            _write_notebook(stem, rst, outputs)
+            print(f"converted {notebook_path.name} -> {stem}.rst")
+
+    if stale:
+        print("stale generated notebook documentation: " + ", ".join(stale))
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/documents/ipynb/exojax_nuts_condensate_fixed_support.ipynb
+++ b/documents/ipynb/exojax_nuts_condensate_fixed_support.ipynb
@@ -1,0 +1,270 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "title",
+   "metadata": {},
+   "source": [
+    "# ExoJAX NUTS with a graphite-only fixed-support VJP\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "overview",
+   "metadata": {},
+   "source": [
+    "This tutorial demonstrates the local condensate custom VJP used by `examples/retrievals/exojax_nuts_condensate_fixed_support.py`. The atmosphere is carbon rich with C/O = 2. The declared chemistry model uses the full FastChem4 gas catalog but an explicit reduced condensate catalog containing only graphite, `C(s)`. A nominal calculation discovers graphite within that one-phase catalog and freezes the graphite-active layer mask and all numerical initial values before inference. Active layers use the condensate fixed-support VJP; the remaining layers use the gas VJP.\n",
+    "\n",
+    "This is deliberately not a full FastChem4 condensate-equilibrium, differentiable phase-discovery, production-lifecycle, or rainout example. The other 218 phases in the current FastChem4 condensate catalog are outside the model, so their phase stability and full-catalog support closure are not claimed. A support or temperature-validity change is generally nondifferentiable. The narrow priors are $T_0\\in[1155,1165]$ K, $\\alpha\\in[0.029,0.031]$, and `log_co_scale` $\\in[-0.005,0.005]$; all eight corners must retain the reduced-model support and pass the primal diagnostics using exactly the frozen initialization used by NUTS. The validated corners had a minimum active graphite amount of $2.498\\times10^{-7}$, a minimum inactive driving margin of $0.714$, a maximum active fixed-support residual of $2.274\\times10^{-13}$, and a maximum scaled element-budget residual of $1.159\\times10^{-13}$. The completed reference GPU run below exercises the normal 500-warmup, 1000-sample configuration; `--quick` remains an end-to-end smoke mode only.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "plan-heading",
+   "metadata": {},
+   "source": [
+    "## Discover, freeze, and certify support\n",
+    "\n",
+    "The chemistry-only preflight needs no ExoJAX database. `prepare_graphite_profile` constructs the explicit graphite-only setup, discovers its nominal support, and freezes the numerical initial values. `preflight_graphite_plan` checks the complete prior box with those same initial values and checks a reverse-mode chemistry gradient. The report, rather than an assumed layer list, is the authority for the fixed mask within this reduced model.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "prepare-plan",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from jax import config\n",
+    "config.update(\"jax_enable_x64\", True)\n",
+    "\n",
+    "import jax\n",
+    "import jax.numpy as jnp\n",
+    "\n",
+    "from examples.retrievals.exojax_nuts_condensate_fixed_support import (\n",
+    "    TRUTH_ALPHA,\n",
+    "    TRUTH_LOG_CO_SCALE,\n",
+    "    TRUTH_T0_K,\n",
+    "    co_vmr_profile,\n",
+    "    powerlaw_temperature,\n",
+    "    preflight_graphite_plan,\n",
+    "    prepare_graphite_profile,\n",
+    "    pressure_profile,\n",
+    "    scale_carbon_and_oxygen,\n",
+    ")\n",
+    "\n",
+    "pressures_bar = pressure_profile(8)\n",
+    "plan = prepare_graphite_profile(pressures_bar)\n",
+    "preflight = preflight_graphite_plan(plan)\n",
+    "(\n",
+    "    preflight[\"condensate_catalog_species\"],\n",
+    "    preflight[\"active_indices\"],\n",
+    "    preflight[\"gradient_finite\"],\n",
+    "    preflight[\"full_catalog_equilibrium_claimed\"],\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "kernel-heading",
+   "metadata": {},
+   "source": [
+    "## The active-layer fixed-support call\n",
+    "\n",
+    "The following is the essential active-layer call used by the hybrid profile. The condensate formula matrix, thermochemical source, amount seed, and ordering all contain exactly the one frozen graphite support. Initialization and support are nondifferentiable; temperature, normalized log pressure, and the elemental inventory in `ThermoState` are differentiable.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fixed-support-call",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from exogibbs.equilibrium.condensate.fixed_support import (\n",
+    "    minimize_gibbs_fixed_support,\n",
+    ")\n",
+    "from exogibbs.equilibrium.gas.types import ThermoState\n",
+    "\n",
+    "support = jnp.asarray([plan.graphite_species_index], dtype=jnp.int32)\n",
+    "formula_matrix_cond = plan.setup.formula_matrix_cond[:, support]\n",
+    "\n",
+    "def graphite_hvector(temperature):\n",
+    "    return plan.setup.condensate_setup.hvector_func(temperature)[support]\n",
+    "\n",
+    "temperature = powerlaw_temperature(\n",
+    "    plan.pressures_bar, TRUTH_T0_K, TRUTH_ALPHA\n",
+    ")\n",
+    "inventory = scale_carbon_and_oxygen(\n",
+    "    plan.reference_element_vector,\n",
+    "    plan.carbon_index,\n",
+    "    plan.oxygen_index,\n",
+    "    TRUTH_LOG_CO_SCALE,\n",
+    ")\n",
+    "layer = plan.active_indices[0]\n",
+    "fixed_result = minimize_gibbs_fixed_support(\n",
+    "    ThermoState(\n",
+    "        temperature[layer],\n",
+    "        jnp.log(plan.pressures_bar[layer]),\n",
+    "        inventory,\n",
+    "    ),\n",
+    "    plan.hybrid_log_amounts_init[layer],\n",
+    "    plan.graphite_amounts_init[layer].reshape((1,)),\n",
+    "    plan.hybrid_total_log_amounts_init[layer],\n",
+    "    plan.setup.formula_matrix,\n",
+    "    formula_matrix_cond,\n",
+    "    plan.setup.gas_setup.hvector_func,\n",
+    "    graphite_hvector,\n",
+    "    residual_crit=1.0e-10,\n",
+    "    max_iter=100,\n",
+    ")\n",
+    "fixed_result.gas_log_amounts.shape, fixed_result.condensate_amounts\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "vjp-heading",
+   "metadata": {},
+   "source": [
+    "## Reverse-mode hybrid-profile check\n",
+    "\n",
+    "`co_vmr_profile` batches the frozen graphite-active layers through `minimize_gibbs_fixed_support` and batches the inactive layers through the gas custom VJP. This scalar check traverses both groups. The full demo additionally checks an ExoJAX spectral loss when a CO database is supplied.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "hybrid-vjp",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def chemistry_summary(t0_kelvin, alpha, log_co_scale):\n",
+    "    temperatures = powerlaw_temperature(\n",
+    "        plan.pressures_bar, t0_kelvin, alpha\n",
+    "    )\n",
+    "    co_vmr = co_vmr_profile(plan, temperatures, log_co_scale)\n",
+    "    return jnp.sum(jnp.log(jnp.clip(co_vmr, 1.0e-300)))\n",
+    "\n",
+    "summary, gradient = jax.value_and_grad(\n",
+    "    chemistry_summary, argnums=(0, 1, 2)\n",
+    ")(TRUTH_T0_K, TRUTH_ALPHA, TRUTH_LOG_CO_SCALE)\n",
+    "summary, gradient\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nuts-heading",
+   "metadata": {},
+   "source": [
+    "## Reverse-mode NUTS\n",
+    "\n",
+    "The fixed-support and gas equilibrium solvers expose first-order custom VJPs. Forward-mode JVPs and higher-order derivatives are outside this contract, so the shared runner makes the NumPyro choice explicit.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "nuts-call",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from numpyro.infer import MCMC, NUTS\n",
+    "\n",
+    "def build_reverse_mode_mcmc(model):\n",
+    "    kernel = NUTS(\n",
+    "        model,\n",
+    "        forward_mode_differentiation=False,\n",
+    "        max_tree_depth=10,\n",
+    "    )\n",
+    "    return MCMC(\n",
+    "        kernel, num_warmup=500, num_samples=1000, num_chains=1\n",
+    "    )\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "completed-reference-run",
+   "metadata": {},
+   "source": [
+    "## Completed reference GPU run\n",
+    "\n",
+    "A reference CUDA GPU run completed with 8 atmospheric layers, 1024 spectral points, 500 warmup steps, 1000 posterior samples, and seed 0. The NUTS call took 170.96 s, including JIT compilation, warmup, and sampling, and reported zero divergences. All eight prior corners passed the frozen-support preflight. Layers 0--2 used the graphite fixed-support VJP and layers 3--7 used the gas VJP.\n",
+    "\n",
+    "| parameter | mock truth | posterior mean $\\pm$ standard deviation |\n",
+    "| --- | ---: | ---: |\n",
+    "| T0 [K] | 1160 | 1159.9514 $\\pm$ 0.0299 |\n",
+    "| alpha | 0.03 | 0.0300438 $\\pm$ 0.0000313 |\n",
+    "| log_co_scale | 0 | -0.0003831 $\\pm$ 0.0003866 |\n",
+    "\n",
+    "All three mock truth values lie inside their central 90% posterior intervals. This is a compact, one-chain demonstration that the hybrid fixed-support/gas VJP can be used end to end by ExoJAX and NUTS.\n",
+    "\n",
+    "The timing is not a like-for-like comparison with the 24-layer gas no-grid baseline. This reduced case has only eight layers, retains only graphite from the condensate catalog, reuses frozen nominal solutions as warm starts, and performs no support discovery inside NUTS. The result therefore does not imply that general or full-catalog condensation retrieval is faster than gas-only equilibrium. Runtime is also hardware and software dependent.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "run-heading",
+   "metadata": {},
+   "source": [
+    "## Run the plain demo\n",
+    "\n",
+    "A chemistry-only preflight can run without ExoJAX. The guarded command below writes the support and corner audit to `results/`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "chemistry-preflight",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import subprocess\n",
+    "import sys\n",
+    "\n",
+    "RUN_CHEMISTRY_PREFLIGHT = False\n",
+    "preflight_command = [\n",
+    "    sys.executable,\n",
+    "    \"examples/retrievals/exojax_nuts_condensate_fixed_support.py\",\n",
+    "    \"--preflight-only\",\n",
+    "    \"--nlayer\", \"8\",\n",
+    "    \"--output-dir\",\n",
+    "    \"results/vjp_retrieval/condensate_chemistry_preflight\",\n",
+    "]\n",
+    "if RUN_CHEMISTRY_PREFLIGHT:\n",
+    "    subprocess.run(preflight_command, check=True)\n",
+    "preflight_command\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "quick-run-heading",
+   "metadata": {},
+   "source": [
+    "For a short ExoJAX + NUTS exercise, set `EXOJAX_CO_DATABASE` to the exact local `CO/12C-16O/Li2015` directory, add `--quick`, and supply `--co-database` as in the two gas tutorials. The demo never downloads database files.\n",
+    "\n",
+    "The CUDA-only wrapper first runs the complete spectral preflight for this reduced model, then requests 500 warmup steps and 1000 samples:\n",
+    "\n",
+    "```tcsh\n",
+    "benchmarks/vjp_retrieval/run_exojax_nuts_gpu.csh \\\n",
+    "  condensate_fixed_support /path/to/CO/12C-16O/Li2015\n",
+    "```\n",
+    "\n",
+    "The completed reference run establishes practicality for this local reduced-model demonstration only. It does not justify widening the priors or interpreting the posterior as full-catalog condensate equilibrium. Full FastChem4 condensate-catalog support discovery, closure certification, phase changes, and rainout remain separate problems.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/documents/ipynb/exojax_nuts_condensate_fixed_support.rst
+++ b/documents/ipynb/exojax_nuts_condensate_fixed_support.rst
@@ -1,0 +1,249 @@
+.. This file is generated from the sibling .ipynb by convert_vjp_retrieval_notebooks.py.
+.. Do not edit this RST file directly.
+
+ExoJAX NUTS with a graphite-only fixed-support VJP
+==================================================
+
+This tutorial demonstrates the local condensate custom VJP used by
+``examples/retrievals/exojax_nuts_condensate_fixed_support.py``. The
+atmosphere is carbon rich with C/O = 2. The declared chemistry model
+uses the full FastChem4 gas catalog but an explicit reduced condensate
+catalog containing only graphite, ``C(s)``. A nominal calculation
+discovers graphite within that one-phase catalog and freezes the
+graphite-active layer mask and all numerical initial values before
+inference. Active layers use the condensate fixed-support VJP; the
+remaining layers use the gas VJP.
+
+This is deliberately not a full FastChem4 condensate-equilibrium,
+differentiable phase-discovery, production-lifecycle, or rainout
+example. The other 218 phases in the current FastChem4 condensate
+catalog are outside the model, so their phase stability and full-catalog
+support closure are not claimed. A support or temperature-validity
+change is generally nondifferentiable. The narrow priors are
+:math:`T_0\in[1155,1165]` K, :math:`\alpha\in[0.029,0.031]`, and
+``log_co_scale`` :math:`\in[-0.005,0.005]`; all eight corners must
+retain the reduced-model support and pass the primal diagnostics using
+exactly the frozen initialization used by NUTS. The validated corners
+had a minimum active graphite amount of :math:`2.498\times10^{-7}`, a
+minimum inactive driving margin of :math:`0.714`, a maximum active
+fixed-support residual of :math:`2.274\times10^{-13}`, and a maximum
+scaled element-budget residual of :math:`1.159\times10^{-13}`. The
+completed reference GPU run below exercises the normal 500-warmup,
+1000-sample configuration; ``--quick`` remains an end-to-end smoke mode
+only.
+
+Discover, freeze, and certify support
+-------------------------------------
+
+The chemistry-only preflight needs no ExoJAX database.
+``prepare_graphite_profile`` constructs the explicit graphite-only
+setup, discovers its nominal support, and freezes the numerical initial
+values. ``preflight_graphite_plan`` checks the complete prior box with
+those same initial values and checks a reverse-mode chemistry gradient.
+The report, rather than an assumed layer list, is the authority for the
+fixed mask within this reduced model.
+
+.. code:: python
+
+    from jax import config
+    config.update("jax_enable_x64", True)
+
+    import jax
+    import jax.numpy as jnp
+
+    from examples.retrievals.exojax_nuts_condensate_fixed_support import (
+        TRUTH_ALPHA,
+        TRUTH_LOG_CO_SCALE,
+        TRUTH_T0_K,
+        co_vmr_profile,
+        powerlaw_temperature,
+        preflight_graphite_plan,
+        prepare_graphite_profile,
+        pressure_profile,
+        scale_carbon_and_oxygen,
+    )
+
+    pressures_bar = pressure_profile(8)
+    plan = prepare_graphite_profile(pressures_bar)
+    preflight = preflight_graphite_plan(plan)
+    (
+        preflight["condensate_catalog_species"],
+        preflight["active_indices"],
+        preflight["gradient_finite"],
+        preflight["full_catalog_equilibrium_claimed"],
+    )
+
+
+The active-layer fixed-support call
+-----------------------------------
+
+The following is the essential active-layer call used by the hybrid
+profile. The condensate formula matrix, thermochemical source, amount
+seed, and ordering all contain exactly the one frozen graphite support.
+Initialization and support are nondifferentiable; temperature,
+normalized log pressure, and the elemental inventory in ``ThermoState``
+are differentiable.
+
+.. code:: python
+
+    from exogibbs.equilibrium.condensate.fixed_support import (
+        minimize_gibbs_fixed_support,
+    )
+    from exogibbs.equilibrium.gas.types import ThermoState
+
+    support = jnp.asarray([plan.graphite_species_index], dtype=jnp.int32)
+    formula_matrix_cond = plan.setup.formula_matrix_cond[:, support]
+
+    def graphite_hvector(temperature):
+        return plan.setup.condensate_setup.hvector_func(temperature)[support]
+
+    temperature = powerlaw_temperature(
+        plan.pressures_bar, TRUTH_T0_K, TRUTH_ALPHA
+    )
+    inventory = scale_carbon_and_oxygen(
+        plan.reference_element_vector,
+        plan.carbon_index,
+        plan.oxygen_index,
+        TRUTH_LOG_CO_SCALE,
+    )
+    layer = plan.active_indices[0]
+    fixed_result = minimize_gibbs_fixed_support(
+        ThermoState(
+            temperature[layer],
+            jnp.log(plan.pressures_bar[layer]),
+            inventory,
+        ),
+        plan.hybrid_log_amounts_init[layer],
+        plan.graphite_amounts_init[layer].reshape((1,)),
+        plan.hybrid_total_log_amounts_init[layer],
+        plan.setup.formula_matrix,
+        formula_matrix_cond,
+        plan.setup.gas_setup.hvector_func,
+        graphite_hvector,
+        residual_crit=1.0e-10,
+        max_iter=100,
+    )
+    fixed_result.gas_log_amounts.shape, fixed_result.condensate_amounts
+
+
+Reverse-mode hybrid-profile check
+---------------------------------
+
+``co_vmr_profile`` batches the frozen graphite-active layers through
+``minimize_gibbs_fixed_support`` and batches the inactive layers through
+the gas custom VJP. This scalar check traverses both groups. The full
+demo additionally checks an ExoJAX spectral loss when a CO database is
+supplied.
+
+.. code:: python
+
+    def chemistry_summary(t0_kelvin, alpha, log_co_scale):
+        temperatures = powerlaw_temperature(
+            plan.pressures_bar, t0_kelvin, alpha
+        )
+        co_vmr = co_vmr_profile(plan, temperatures, log_co_scale)
+        return jnp.sum(jnp.log(jnp.clip(co_vmr, 1.0e-300)))
+
+    summary, gradient = jax.value_and_grad(
+        chemistry_summary, argnums=(0, 1, 2)
+    )(TRUTH_T0_K, TRUTH_ALPHA, TRUTH_LOG_CO_SCALE)
+    summary, gradient
+
+
+Reverse-mode NUTS
+-----------------
+
+The fixed-support and gas equilibrium solvers expose first-order custom
+VJPs. Forward-mode JVPs and higher-order derivatives are outside this
+contract, so the shared runner makes the NumPyro choice explicit.
+
+.. code:: python
+
+    from numpyro.infer import MCMC, NUTS
+
+    def build_reverse_mode_mcmc(model):
+        kernel = NUTS(
+            model,
+            forward_mode_differentiation=False,
+            max_tree_depth=10,
+        )
+        return MCMC(
+            kernel, num_warmup=500, num_samples=1000, num_chains=1
+        )
+
+
+Completed reference GPU run
+---------------------------
+
+A reference CUDA GPU run completed with 8 atmospheric layers, 1024
+spectral points, 500 warmup steps, 1000 posterior samples, and seed 0.
+The NUTS call took 170.96 s, including JIT compilation, warmup, and
+sampling, and reported zero divergences. All eight prior corners passed
+the frozen-support preflight. Layers 0–2 used the graphite fixed-support
+VJP and layers 3–7 used the gas VJP.
+
+============ ========== =============================================
+parameter    mock truth posterior mean :math:`\pm` standard deviation
+============ ========== =============================================
+T0 [K]       1160       1159.9514 :math:`\pm` 0.0299
+alpha        0.03       0.0300438 :math:`\pm` 0.0000313
+log_co_scale 0          -0.0003831 :math:`\pm` 0.0003866
+============ ========== =============================================
+
+All three mock truth values lie inside their central 90% posterior
+intervals. This is a compact, one-chain demonstration that the hybrid
+fixed-support/gas VJP can be used end to end by ExoJAX and NUTS.
+
+The timing is not a like-for-like comparison with the 24-layer gas
+no-grid baseline. This reduced case has only eight layers, retains only
+graphite from the condensate catalog, reuses frozen nominal solutions as
+warm starts, and performs no support discovery inside NUTS. The result
+therefore does not imply that general or full-catalog condensation
+retrieval is faster than gas-only equilibrium. Runtime is also hardware
+and software dependent.
+
+Run the plain demo
+------------------
+
+A chemistry-only preflight can run without ExoJAX. The guarded command
+below writes the support and corner audit to ``results/``.
+
+.. code:: python
+
+    from pathlib import Path
+    import subprocess
+    import sys
+
+    RUN_CHEMISTRY_PREFLIGHT = False
+    preflight_command = [
+        sys.executable,
+        "examples/retrievals/exojax_nuts_condensate_fixed_support.py",
+        "--preflight-only",
+        "--nlayer", "8",
+        "--output-dir",
+        "results/vjp_retrieval/condensate_chemistry_preflight",
+    ]
+    if RUN_CHEMISTRY_PREFLIGHT:
+        subprocess.run(preflight_command, check=True)
+    preflight_command
+
+
+For a short ExoJAX + NUTS exercise, set ``EXOJAX_CO_DATABASE`` to the
+exact local ``CO/12C-16O/Li2015`` directory, add ``--quick``, and supply
+``--co-database`` as in the two gas tutorials. The demo never downloads
+database files.
+
+The CUDA-only wrapper first runs the complete spectral preflight for
+this reduced model, then requests 500 warmup steps and 1000 samples:
+
+.. code:: tcsh
+
+   benchmarks/vjp_retrieval/run_exojax_nuts_gpu.csh \
+     condensate_fixed_support /path/to/CO/12C-16O/Li2015
+
+The completed reference run establishes practicality for this local
+reduced-model demonstration only. It does not justify widening the
+priors or interpreting the posterior as full-catalog condensate
+equilibrium. Full FastChem4 condensate-catalog support discovery,
+closure certification, phase changes, and rainout remain separate
+problems.

--- a/documents/ipynb/exojax_nuts_gas_grid.ipynb
+++ b/documents/ipynb/exojax_nuts_gas_grid.ipynb
@@ -1,0 +1,260 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "title",
+   "metadata": {},
+   "source": [
+    "# ExoJAX NUTS with the gas VJP: grid initialization\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "overview",
+   "metadata": {},
+   "source": [
+    "This tutorial repeats the no-grid retrieval with ExoGibbs' packaged FastChem grid supplying the initial gas amounts. The likelihood, priors, deterministic mock data, profile method, and reverse-mode NUTS settings are shared with `examples/retrievals/exojax_nuts_gas_no_grid.py`. The only algorithmic change in `examples/retrievals/exojax_nuts_gas_grid.py` is `GridEquilibriumInitializer`.\n",
+    "\n",
+    "Initialization values have stopped gradients in the custom VJP. Once both primal solves converge, grid and no-grid spectra and posterior derivatives should agree; the grid is intended to reduce primal iterations. The plain demo checks all eight prior corners and records grid bounds and the spectral-loss gradient in `run_summary.json`.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "grid-heading",
+   "metadata": {},
+   "source": [
+    "## Load the packaged grid\n",
+    "\n",
+    "The grid metadata must match the runtime FastChem setup exactly. Its interpolation is used only to initialize each scalar layer solve.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "grid-load",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from jax import config\n",
+    "config.update(\"jax_enable_x64\", True)\n",
+    "\n",
+    "import jax\n",
+    "import jax.numpy as jnp\n",
+    "\n",
+    "from exogibbs.api import (\n",
+    "    get_default_equilibrium_grid_path,\n",
+    "    load_equilibrium_grid_netcdf,\n",
+    ")\n",
+    "from exogibbs.api.gas import (\n",
+    "    EquilibriumOptions,\n",
+    "    GridEquilibriumInitializer,\n",
+    "    solve_profile,\n",
+    ")\n",
+    "from exogibbs.presets.fastchem import chemsetup\n",
+    "\n",
+    "chemistry = chemsetup(silent=True)\n",
+    "grid_path = get_default_equilibrium_grid_path(\"fastchem\")\n",
+    "grid = load_equilibrium_grid_netcdf(str(grid_path))\n",
+    "initializer = GridEquilibriumInitializer(\n",
+    "    grid=grid, preset_name=\"fastchem\"\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "chemistry-heading",
+   "metadata": {},
+   "source": [
+    "## The grid-initialized equilibrium call\n",
+    "\n",
+    "As in the plain demo, carbon and oxygen are scaled together and `vmap_cold` solves all layers in parallel. `GridEquilibriumInitializer` infers the physical metallicity coordinate from the traced elemental vector.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "grid-call",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pressure_bar = jnp.logspace(-3.0, 1.0, 8)\n",
+    "reference = jnp.asarray(chemistry.element_vector_reference)\n",
+    "carbon_index = chemistry.elements.index(\"C\")\n",
+    "oxygen_index = chemistry.elements.index(\"O\")\n",
+    "co_species_index = chemistry.species.index(\"C1O1\")\n",
+    "co_element_indices = jnp.asarray([carbon_index, oxygen_index])\n",
+    "options = EquilibriumOptions(\n",
+    "    epsilon_crit=1.0e-10, max_iter=1000, method=\"vmap_cold\"\n",
+    ")\n",
+    "\n",
+    "def co_vmr_with_grid(t0_kelvin, alpha, log_co_scale):\n",
+    "    temperature = t0_kelvin * pressure_bar**alpha\n",
+    "    scale = jnp.power(10.0, log_co_scale)\n",
+    "    inventory = reference.at[co_element_indices].set(\n",
+    "        reference[co_element_indices] * scale\n",
+    "    )\n",
+    "    result = solve_profile(\n",
+    "        chemistry,\n",
+    "        temperature,\n",
+    "        pressure_bar,\n",
+    "        inventory,\n",
+    "        Pref=1.0,\n",
+    "        initializer=initializer,\n",
+    "        options=options,\n",
+    "    )\n",
+    "    return result.x[:, co_species_index]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "vjp-heading",
+   "metadata": {},
+   "source": [
+    "## Reverse-mode check\n",
+    "\n",
+    "The grid affects the forward initialization, but the implicit equilibrium VJP differentiates the converged physical state with respect to temperature, pressure, and elemental inventory. It does not differentiate the initial guess.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "grid-vjp",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def chemistry_summary(t0_kelvin, alpha, log_co_scale):\n",
+    "    co_vmr = co_vmr_with_grid(t0_kelvin, alpha, log_co_scale)\n",
+    "    return jnp.sum(jnp.log(jnp.clip(co_vmr, 1.0e-300)))\n",
+    "\n",
+    "summary, gradient = jax.value_and_grad(\n",
+    "    chemistry_summary, argnums=(0, 1, 2)\n",
+    ")(1160.0, 0.03, 0.0)\n",
+    "summary, gradient\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "validation-result",
+   "metadata": {},
+   "source": [
+    "## Completed reference GPU runs\n",
+    "\n",
+    "Reference CUDA GPU runs completed for both gas cases with the same normal demo settings: 24 atmospheric layers, 1024 spectral points, 500 warmup steps, 1000 posterior samples, and seed 0.\n",
+    "\n",
+    "| quantity | no grid | grid initialized |\n",
+    "| --- | ---: | ---: |\n",
+    "| NUTS time | 6067.69 s | 331.95 s |\n",
+    "| mean prior-corner Newton iterations | 240.75 | 10.0 |\n",
+    "| largest prior-corner Newton iteration count | 252 | 11 |\n",
+    "| divergences | 0 | 0 |\n",
+    "\n",
+    "The grid initializer made this run 18.28 times faster. Runtime is hardware and software dependent, but the reduction in Newton iterations shows the intended role of the initializer directly. All eight prior corners converged in both cases, and all grid-case corners remained inside the initializer grid.\n",
+    "\n",
+    "| parameter | mock truth | no-grid posterior | grid posterior |\n",
+    "| --- | ---: | ---: | ---: |\n",
+    "| $T_0$ [K] | 1160 | 1159.9783 $\\pm$ 0.0335 | 1159.9768 $\\pm$ 0.0325 |\n",
+    "| $\\alpha$ | 0.03 | 0.0300155 $\\pm$ 0.0000341 | 0.0300121 $\\pm$ 0.0000334 |\n",
+    "| log_co_scale | 0 | -0.0000416 $\\pm$ 0.0005270 | 0.0000027 $\\pm$ 0.0005110 |\n",
+    "\n",
+    "The mock truth lies inside every central 90% posterior interval, and the grid and no-grid posteriors agree at the scale resolved by this demo. At the mock truth, the complete spectral loss agrees to about $2 \\times 10^{-15}$ relatively and the three reverse-mode gradients agree to better than $6 \\times 10^{-9}$ relatively. Thus the initializer accelerates the primal equilibrium solves without materially changing the converged spectrum or its VJP. These are compact, one-chain demonstrations rather than precision convergence benchmarks.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nuts-heading",
+   "metadata": {},
+   "source": [
+    "## Reverse-mode NUTS\n",
+    "\n",
+    "Forward-mode differentiation is intentionally disabled because ExoGibbs exposes custom VJPs for these equilibrium solves.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "nuts-call",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from numpyro.infer import MCMC, NUTS\n",
+    "\n",
+    "def build_reverse_mode_mcmc(model):\n",
+    "    kernel = NUTS(\n",
+    "        model,\n",
+    "        forward_mode_differentiation=False,\n",
+    "        max_tree_depth=10,\n",
+    "    )\n",
+    "    return MCMC(\n",
+    "        kernel, num_warmup=500, num_samples=1000, num_chains=1\n",
+    "    )\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "run-heading",
+   "metadata": {},
+   "source": [
+    "## Run the complete demo\n",
+    "\n",
+    "Launch Jupyter from the repository root and point `EXOJAX_CO_DATABASE` at the exact existing `CO/12C-16O/Li2015` directory. No database is downloaded.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "quick-run",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "import subprocess\n",
+    "import sys\n",
+    "\n",
+    "RUN_QUICK = False\n",
+    "co_database = Path(\n",
+    "    os.environ.get(\n",
+    "        \"EXOJAX_CO_DATABASE\", \"/path/to/CO/12C-16O/Li2015\"\n",
+    "    )\n",
+    ")\n",
+    "command = [\n",
+    "    sys.executable,\n",
+    "    \"examples/retrievals/exojax_nuts_gas_grid.py\",\n",
+    "    \"--co-database\", str(co_database),\n",
+    "    \"--output-dir\", \"results/vjp_retrieval/gas_grid_quick\",\n",
+    "    \"--quick\",\n",
+    "    \"--no-progress-bar\",\n",
+    "]\n",
+    "if RUN_QUICK:\n",
+    "    subprocess.run(command, check=True)\n",
+    "command\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "production-run",
+   "metadata": {},
+   "source": [
+    "The CUDA-only production wrapper uses 500 warmup steps, 1000 samples, seed 0, and writes to `results/vjp_retrieval/gas_grid/`. The five-warmup `--quick` mode is only an end-to-end smoke test, not an inference-quality chain.\n",
+    "\n",
+    "```tcsh\n",
+    "benchmarks/vjp_retrieval/run_exojax_nuts_gpu.csh \\\n",
+    "  gas_grid /path/to/CO/12C-16O/Li2015\n",
+    "```\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/documents/ipynb/exojax_nuts_gas_grid.rst
+++ b/documents/ipynb/exojax_nuts_gas_grid.rst
@@ -1,0 +1,223 @@
+.. This file is generated from the sibling .ipynb by convert_vjp_retrieval_notebooks.py.
+.. Do not edit this RST file directly.
+
+ExoJAX NUTS with the gas VJP: grid initialization
+=================================================
+
+This tutorial repeats the no-grid retrieval with ExoGibbs’ packaged
+FastChem grid supplying the initial gas amounts. The likelihood, priors,
+deterministic mock data, profile method, and reverse-mode NUTS settings
+are shared with ``examples/retrievals/exojax_nuts_gas_no_grid.py``. The
+only algorithmic change in
+``examples/retrievals/exojax_nuts_gas_grid.py`` is
+``GridEquilibriumInitializer``.
+
+Initialization values have stopped gradients in the custom VJP. Once
+both primal solves converge, grid and no-grid spectra and posterior
+derivatives should agree; the grid is intended to reduce primal
+iterations. The plain demo checks all eight prior corners and records
+grid bounds and the spectral-loss gradient in ``run_summary.json``.
+
+Load the packaged grid
+----------------------
+
+The grid metadata must match the runtime FastChem setup exactly. Its
+interpolation is used only to initialize each scalar layer solve.
+
+.. code:: python
+
+    from jax import config
+    config.update("jax_enable_x64", True)
+
+    import jax
+    import jax.numpy as jnp
+
+    from exogibbs.api import (
+        get_default_equilibrium_grid_path,
+        load_equilibrium_grid_netcdf,
+    )
+    from exogibbs.api.gas import (
+        EquilibriumOptions,
+        GridEquilibriumInitializer,
+        solve_profile,
+    )
+    from exogibbs.presets.fastchem import chemsetup
+
+    chemistry = chemsetup(silent=True)
+    grid_path = get_default_equilibrium_grid_path("fastchem")
+    grid = load_equilibrium_grid_netcdf(str(grid_path))
+    initializer = GridEquilibriumInitializer(
+        grid=grid, preset_name="fastchem"
+    )
+
+
+The grid-initialized equilibrium call
+-------------------------------------
+
+As in the plain demo, carbon and oxygen are scaled together and
+``vmap_cold`` solves all layers in parallel.
+``GridEquilibriumInitializer`` infers the physical metallicity
+coordinate from the traced elemental vector.
+
+.. code:: python
+
+    pressure_bar = jnp.logspace(-3.0, 1.0, 8)
+    reference = jnp.asarray(chemistry.element_vector_reference)
+    carbon_index = chemistry.elements.index("C")
+    oxygen_index = chemistry.elements.index("O")
+    co_species_index = chemistry.species.index("C1O1")
+    co_element_indices = jnp.asarray([carbon_index, oxygen_index])
+    options = EquilibriumOptions(
+        epsilon_crit=1.0e-10, max_iter=1000, method="vmap_cold"
+    )
+
+    def co_vmr_with_grid(t0_kelvin, alpha, log_co_scale):
+        temperature = t0_kelvin * pressure_bar**alpha
+        scale = jnp.power(10.0, log_co_scale)
+        inventory = reference.at[co_element_indices].set(
+            reference[co_element_indices] * scale
+        )
+        result = solve_profile(
+            chemistry,
+            temperature,
+            pressure_bar,
+            inventory,
+            Pref=1.0,
+            initializer=initializer,
+            options=options,
+        )
+        return result.x[:, co_species_index]
+
+
+Reverse-mode check
+------------------
+
+The grid affects the forward initialization, but the implicit
+equilibrium VJP differentiates the converged physical state with respect
+to temperature, pressure, and elemental inventory. It does not
+differentiate the initial guess.
+
+.. code:: python
+
+    def chemistry_summary(t0_kelvin, alpha, log_co_scale):
+        co_vmr = co_vmr_with_grid(t0_kelvin, alpha, log_co_scale)
+        return jnp.sum(jnp.log(jnp.clip(co_vmr, 1.0e-300)))
+
+    summary, gradient = jax.value_and_grad(
+        chemistry_summary, argnums=(0, 1, 2)
+    )(1160.0, 0.03, 0.0)
+    summary, gradient
+
+
+Completed reference GPU runs
+----------------------------
+
+Reference CUDA GPU runs completed for both gas cases with the same
+normal demo settings: 24 atmospheric layers, 1024 spectral points, 500
+warmup steps, 1000 posterior samples, and seed 0.
+
+=========================================== ========= ================
+quantity                                    no grid   grid initialized
+=========================================== ========= ================
+NUTS time                                   6067.69 s 331.95 s
+mean prior-corner Newton iterations         240.75    10.0
+largest prior-corner Newton iteration count 252       11
+divergences                                 0         0
+=========================================== ========= ================
+
+The grid initializer made this run 18.28 times faster. Runtime is
+hardware and software dependent, but the reduction in Newton iterations
+shows the intended role of the initializer directly. All eight prior
+corners converged in both cases, and all grid-case corners remained
+inside the initializer grid.
+
++-----------------+------------+-----------------+-----------------+
+| parameter       | mock truth | no-grid         | grid posterior  |
+|                 |            | posterior       |                 |
++=================+============+=================+=================+
+| :math:`T_0` [K] | 1160       | 1159.9783       | 1159.9768       |
+|                 |            | :math:`\pm`     | :math:`\pm`     |
+|                 |            | 0.0335          | 0.0325          |
++-----------------+------------+-----------------+-----------------+
+| :math:`\alpha`  | 0.03       | 0.0300155       | 0.0300121       |
+|                 |            | :math:`\pm`     | :math:`\pm`     |
+|                 |            | 0.0000341       | 0.0000334       |
++-----------------+------------+-----------------+-----------------+
+| log_co_scale    | 0          | -0.0000416      | 0.0000027       |
+|                 |            | :math:`\pm`     | :math:`\pm`     |
+|                 |            | 0.0005270       | 0.0005110       |
++-----------------+------------+-----------------+-----------------+
+
+The mock truth lies inside every central 90% posterior interval, and the
+grid and no-grid posteriors agree at the scale resolved by this demo. At
+the mock truth, the complete spectral loss agrees to about
+:math:`2 \times 10^{-15}` relatively and the three reverse-mode
+gradients agree to better than :math:`6 \times 10^{-9}` relatively. Thus
+the initializer accelerates the primal equilibrium solves without
+materially changing the converged spectrum or its VJP. These are
+compact, one-chain demonstrations rather than precision convergence
+benchmarks.
+
+Reverse-mode NUTS
+-----------------
+
+Forward-mode differentiation is intentionally disabled because ExoGibbs
+exposes custom VJPs for these equilibrium solves.
+
+.. code:: python
+
+    from numpyro.infer import MCMC, NUTS
+
+    def build_reverse_mode_mcmc(model):
+        kernel = NUTS(
+            model,
+            forward_mode_differentiation=False,
+            max_tree_depth=10,
+        )
+        return MCMC(
+            kernel, num_warmup=500, num_samples=1000, num_chains=1
+        )
+
+
+Run the complete demo
+---------------------
+
+Launch Jupyter from the repository root and point ``EXOJAX_CO_DATABASE``
+at the exact existing ``CO/12C-16O/Li2015`` directory. No database is
+downloaded.
+
+.. code:: python
+
+    import os
+    from pathlib import Path
+    import subprocess
+    import sys
+
+    RUN_QUICK = False
+    co_database = Path(
+        os.environ.get(
+            "EXOJAX_CO_DATABASE", "/path/to/CO/12C-16O/Li2015"
+        )
+    )
+    command = [
+        sys.executable,
+        "examples/retrievals/exojax_nuts_gas_grid.py",
+        "--co-database", str(co_database),
+        "--output-dir", "results/vjp_retrieval/gas_grid_quick",
+        "--quick",
+        "--no-progress-bar",
+    ]
+    if RUN_QUICK:
+        subprocess.run(command, check=True)
+    command
+
+
+The CUDA-only production wrapper uses 500 warmup steps, 1000 samples,
+seed 0, and writes to ``results/vjp_retrieval/gas_grid/``. The
+five-warmup ``--quick`` mode is only an end-to-end smoke test, not an
+inference-quality chain.
+
+.. code:: tcsh
+
+   benchmarks/vjp_retrieval/run_exojax_nuts_gpu.csh \
+     gas_grid /path/to/CO/12C-16O/Li2015

--- a/documents/ipynb/exojax_nuts_gas_no_grid.ipynb
+++ b/documents/ipynb/exojax_nuts_gas_no_grid.ipynb
@@ -1,0 +1,221 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "title",
+   "metadata": {},
+   "source": [
+    "# ExoJAX NUTS with the gas VJP: no grid initializer\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "overview",
+   "metadata": {},
+   "source": [
+    "This tutorial demonstrates the gas-equilibrium custom VJP inside an ExoJAX emission-spectrum retrieval. It is the no-grid baseline: every atmospheric layer uses the same uniform cold initialization. The full, executable source is `examples/retrievals/exojax_nuts_gas_no_grid.py`; this notebook keeps the key equilibrium and reverse-mode calls visible and delegates the complete spectrum and output workflow to that script.\n",
+    "\n",
+    "The deterministic mock truth is $T_0=1160$ K, $\\alpha=0.03$, and `log_co_scale=0`. Carbon and oxygen are scaled together, so C/O remains fixed. The normal defaults use 24 layers, 1024 spectral points, 500 warmup steps, and 1000 samples. Use `--quick` before submitting the production GPU job. Its five warmup steps make it an end-to-end smoke test, not an inference-quality chain.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "chemistry-heading",
+   "metadata": {},
+   "source": [
+    "## The equilibrium call used by the forward model\n",
+    "\n",
+    "The following chemistry-only function is a compact version of the call inside the shared spectral model. It can be run without an ExoJAX database. Both gas demonstrations explicitly use `vmap_cold`; their only intended difference is the initializer.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "gas-call",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from jax import config\n",
+    "config.update(\"jax_enable_x64\", True)\n",
+    "\n",
+    "import jax\n",
+    "import jax.numpy as jnp\n",
+    "\n",
+    "from exogibbs.api.gas import EquilibriumOptions, solve_profile\n",
+    "from exogibbs.presets.fastchem import chemsetup\n",
+    "\n",
+    "chemistry = chemsetup(silent=True)\n",
+    "pressure_bar = jnp.logspace(-3.0, 1.0, 8)\n",
+    "reference = jnp.asarray(chemistry.element_vector_reference)\n",
+    "carbon_index = chemistry.elements.index(\"C\")\n",
+    "oxygen_index = chemistry.elements.index(\"O\")\n",
+    "co_species_index = chemistry.species.index(\"C1O1\")\n",
+    "co_element_indices = jnp.asarray([carbon_index, oxygen_index])\n",
+    "options = EquilibriumOptions(\n",
+    "    epsilon_crit=1.0e-10, max_iter=1000, method=\"vmap_cold\"\n",
+    ")\n",
+    "\n",
+    "def co_vmr_no_grid(t0_kelvin, alpha, log_co_scale):\n",
+    "    temperature = t0_kelvin * pressure_bar**alpha\n",
+    "    scale = jnp.power(10.0, log_co_scale)\n",
+    "    inventory = reference.at[co_element_indices].set(\n",
+    "        reference[co_element_indices] * scale\n",
+    "    )\n",
+    "    result = solve_profile(\n",
+    "        chemistry,\n",
+    "        temperature,\n",
+    "        pressure_bar,\n",
+    "        inventory,\n",
+    "        Pref=1.0,\n",
+    "        options=options,\n",
+    "    )\n",
+    "    return result.x[:, co_species_index]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "vjp-heading",
+   "metadata": {},
+   "source": [
+    "## Exercise the reverse-mode VJP\n",
+    "\n",
+    "NUTS needs gradients of a scalar log density. This small scalar summary checks the same temperature and elemental-inventory VJP paths before the spectral calculation is opened. The plain demo performs the stronger check on the complete ExoJAX spectral loss and checks all eight prior corners for primal convergence.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "gas-vjp",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def chemistry_summary(t0_kelvin, alpha, log_co_scale):\n",
+    "    co_vmr = co_vmr_no_grid(t0_kelvin, alpha, log_co_scale)\n",
+    "    return jnp.sum(jnp.log(jnp.clip(co_vmr, 1.0e-300)))\n",
+    "\n",
+    "summary, gradient = jax.value_and_grad(\n",
+    "    chemistry_summary, argnums=(0, 1, 2)\n",
+    ")(1160.0, 0.03, 0.0)\n",
+    "summary, gradient\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nuts-heading",
+   "metadata": {},
+   "source": [
+    "## Reverse-mode NUTS\n",
+    "\n",
+    "The ExoGibbs gas solver provides a custom VJP, not a forward-mode JVP. The shared runner therefore selects reverse mode explicitly. Its essential NumPyro construction is:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "nuts-call",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from numpyro.infer import MCMC, NUTS\n",
+    "\n",
+    "def build_reverse_mode_mcmc(model):\n",
+    "    # `model` closes over the deterministic observation and ExoJAX context.\n",
+    "    kernel = NUTS(\n",
+    "        model,\n",
+    "        forward_mode_differentiation=False,\n",
+    "        max_tree_depth=10,\n",
+    "    )\n",
+    "    return MCMC(\n",
+    "        kernel, num_warmup=500, num_samples=1000, num_chains=1\n",
+    "    )\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "completed-reference-run",
+   "metadata": {},
+   "source": [
+    "## Completed reference GPU run\n",
+    "\n",
+    "A reference CUDA GPU run completed with the normal demo settings: 24 atmospheric layers, 1024 spectral points, 500 warmup steps, 1000 posterior samples, and seed 0. The NUTS call took 6067.69 s (1 h 41 min 8 s), including JIT compilation, warmup, and sampling, and reported zero divergences. Runtime is hardware and software dependent.\n",
+    "\n",
+    "| parameter | mock truth | posterior mean $\\pm$ standard deviation |\n",
+    "| --- | ---: | ---: |\n",
+    "| $T_0$ [K] | 1160 | 1159.9783 $\\pm$ 0.0335 |\n",
+    "| $\\alpha$ | 0.03 | 0.0300155 $\\pm$ 0.0000341 |\n",
+    "| log_co_scale | 0 | -0.0000416 $\\pm$ 0.0005270 |\n",
+    "\n",
+    "All three mock truth values lie inside their central 90% posterior intervals. This is deliberately a compact, one-chain demonstration of an end-to-end ExoJAX retrieval through the ExoGibbs custom VJP, rather than a precision convergence benchmark.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "run-heading",
+   "metadata": {},
+   "source": [
+    "## Run the complete demo\n",
+    "\n",
+    "Launch Jupyter from the repository root. Set `EXOJAX_CO_DATABASE` to the exact existing `CO/12C-16O/Li2015` directory; the demo validates local files and never downloads them. The guarded cell below runs the small end-to-end configuration and writes only under `results/`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "quick-run",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "import subprocess\n",
+    "import sys\n",
+    "\n",
+    "RUN_QUICK = False\n",
+    "co_database = Path(\n",
+    "    os.environ.get(\n",
+    "        \"EXOJAX_CO_DATABASE\", \"/path/to/CO/12C-16O/Li2015\"\n",
+    "    )\n",
+    ")\n",
+    "command = [\n",
+    "    sys.executable,\n",
+    "    \"examples/retrievals/exojax_nuts_gas_no_grid.py\",\n",
+    "    \"--co-database\", str(co_database),\n",
+    "    \"--output-dir\", \"results/vjp_retrieval/gas_no_grid_quick\",\n",
+    "    \"--quick\",\n",
+    "    \"--no-progress-bar\",\n",
+    "]\n",
+    "if RUN_QUICK:\n",
+    "    subprocess.run(command, check=True)\n",
+    "command\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "production-run",
+   "metadata": {},
+   "source": [
+    "For the CUDA-only production configuration, submit or run the scheduler-independent tcsh wrapper:\n",
+    "\n",
+    "```tcsh\n",
+    "benchmarks/vjp_retrieval/run_exojax_nuts_gpu.csh \\\n",
+    "  gas_no_grid /path/to/CO/12C-16O/Li2015\n",
+    "```\n",
+    "\n",
+    "The wrapper checks `nvidia-smi`, requires the JAX GPU backend, runs a preflight, and writes artifacts to `results/vjp_retrieval/gas_no_grid/`.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/documents/ipynb/exojax_nuts_gas_no_grid.rst
+++ b/documents/ipynb/exojax_nuts_gas_no_grid.rst
@@ -1,0 +1,178 @@
+.. This file is generated from the sibling .ipynb by convert_vjp_retrieval_notebooks.py.
+.. Do not edit this RST file directly.
+
+ExoJAX NUTS with the gas VJP: no grid initializer
+=================================================
+
+This tutorial demonstrates the gas-equilibrium custom VJP inside an
+ExoJAX emission-spectrum retrieval. It is the no-grid baseline: every
+atmospheric layer uses the same uniform cold initialization. The full,
+executable source is ``examples/retrievals/exojax_nuts_gas_no_grid.py``;
+this notebook keeps the key equilibrium and reverse-mode calls visible
+and delegates the complete spectrum and output workflow to that script.
+
+The deterministic mock truth is :math:`T_0=1160` K, :math:`\alpha=0.03`,
+and ``log_co_scale=0``. Carbon and oxygen are scaled together, so C/O
+remains fixed. The normal defaults use 24 layers, 1024 spectral points,
+500 warmup steps, and 1000 samples. Use ``--quick`` before submitting
+the production GPU job. Its five warmup steps make it an end-to-end
+smoke test, not an inference-quality chain.
+
+The equilibrium call used by the forward model
+----------------------------------------------
+
+The following chemistry-only function is a compact version of the call
+inside the shared spectral model. It can be run without an ExoJAX
+database. Both gas demonstrations explicitly use ``vmap_cold``; their
+only intended difference is the initializer.
+
+.. code:: python
+
+    from jax import config
+    config.update("jax_enable_x64", True)
+
+    import jax
+    import jax.numpy as jnp
+
+    from exogibbs.api.gas import EquilibriumOptions, solve_profile
+    from exogibbs.presets.fastchem import chemsetup
+
+    chemistry = chemsetup(silent=True)
+    pressure_bar = jnp.logspace(-3.0, 1.0, 8)
+    reference = jnp.asarray(chemistry.element_vector_reference)
+    carbon_index = chemistry.elements.index("C")
+    oxygen_index = chemistry.elements.index("O")
+    co_species_index = chemistry.species.index("C1O1")
+    co_element_indices = jnp.asarray([carbon_index, oxygen_index])
+    options = EquilibriumOptions(
+        epsilon_crit=1.0e-10, max_iter=1000, method="vmap_cold"
+    )
+
+    def co_vmr_no_grid(t0_kelvin, alpha, log_co_scale):
+        temperature = t0_kelvin * pressure_bar**alpha
+        scale = jnp.power(10.0, log_co_scale)
+        inventory = reference.at[co_element_indices].set(
+            reference[co_element_indices] * scale
+        )
+        result = solve_profile(
+            chemistry,
+            temperature,
+            pressure_bar,
+            inventory,
+            Pref=1.0,
+            options=options,
+        )
+        return result.x[:, co_species_index]
+
+
+Exercise the reverse-mode VJP
+-----------------------------
+
+NUTS needs gradients of a scalar log density. This small scalar summary
+checks the same temperature and elemental-inventory VJP paths before the
+spectral calculation is opened. The plain demo performs the stronger
+check on the complete ExoJAX spectral loss and checks all eight prior
+corners for primal convergence.
+
+.. code:: python
+
+    def chemistry_summary(t0_kelvin, alpha, log_co_scale):
+        co_vmr = co_vmr_no_grid(t0_kelvin, alpha, log_co_scale)
+        return jnp.sum(jnp.log(jnp.clip(co_vmr, 1.0e-300)))
+
+    summary, gradient = jax.value_and_grad(
+        chemistry_summary, argnums=(0, 1, 2)
+    )(1160.0, 0.03, 0.0)
+    summary, gradient
+
+
+Reverse-mode NUTS
+-----------------
+
+The ExoGibbs gas solver provides a custom VJP, not a forward-mode JVP.
+The shared runner therefore selects reverse mode explicitly. Its
+essential NumPyro construction is:
+
+.. code:: python
+
+    from numpyro.infer import MCMC, NUTS
+
+    def build_reverse_mode_mcmc(model):
+        # `model` closes over the deterministic observation and ExoJAX context.
+        kernel = NUTS(
+            model,
+            forward_mode_differentiation=False,
+            max_tree_depth=10,
+        )
+        return MCMC(
+            kernel, num_warmup=500, num_samples=1000, num_chains=1
+        )
+
+
+Completed reference GPU run
+---------------------------
+
+A reference CUDA GPU run completed with the normal demo settings: 24
+atmospheric layers, 1024 spectral points, 500 warmup steps, 1000
+posterior samples, and seed 0. The NUTS call took 6067.69 s (1 h 41 min
+8 s), including JIT compilation, warmup, and sampling, and reported zero
+divergences. Runtime is hardware and software dependent.
+
+=============== ========== =============================================
+parameter       mock truth posterior mean :math:`\pm` standard deviation
+=============== ========== =============================================
+:math:`T_0` [K] 1160       1159.9783 :math:`\pm` 0.0335
+:math:`\alpha`  0.03       0.0300155 :math:`\pm` 0.0000341
+log_co_scale    0          -0.0000416 :math:`\pm` 0.0005270
+=============== ========== =============================================
+
+All three mock truth values lie inside their central 90% posterior
+intervals. This is deliberately a compact, one-chain demonstration of an
+end-to-end ExoJAX retrieval through the ExoGibbs custom VJP, rather than
+a precision convergence benchmark.
+
+Run the complete demo
+---------------------
+
+Launch Jupyter from the repository root. Set ``EXOJAX_CO_DATABASE`` to
+the exact existing ``CO/12C-16O/Li2015`` directory; the demo validates
+local files and never downloads them. The guarded cell below runs the
+small end-to-end configuration and writes only under ``results/``.
+
+.. code:: python
+
+    import os
+    from pathlib import Path
+    import subprocess
+    import sys
+
+    RUN_QUICK = False
+    co_database = Path(
+        os.environ.get(
+            "EXOJAX_CO_DATABASE", "/path/to/CO/12C-16O/Li2015"
+        )
+    )
+    command = [
+        sys.executable,
+        "examples/retrievals/exojax_nuts_gas_no_grid.py",
+        "--co-database", str(co_database),
+        "--output-dir", "results/vjp_retrieval/gas_no_grid_quick",
+        "--quick",
+        "--no-progress-bar",
+    ]
+    if RUN_QUICK:
+        subprocess.run(command, check=True)
+    command
+
+
+For the CUDA-only production configuration, submit or run the
+scheduler-independent tcsh wrapper:
+
+.. code:: tcsh
+
+   benchmarks/vjp_retrieval/run_exojax_nuts_gpu.csh \
+     gas_no_grid /path/to/CO/12C-16O/Li2015
+
+The wrapper checks ``nvidia-smi``, requires the JAX GPU backend, runs a
+preflight, and writes artifacts to
+``results/vjp_retrieval/gas_no_grid/``.

--- a/examples/retrievals/_exojax_nuts_common.py
+++ b/examples/retrievals/_exojax_nuts_common.py
@@ -1,0 +1,670 @@
+"""Shared ExoJAX spectrum and NumPyro helpers for the VJP demos.
+
+The module keeps ExoJAX and NumPyro imports lazy so repository tests and the
+chemistry-only condensate preflight do not require either optional package.
+No database download is attempted: callers must supply a complete local CO
+ExoMol directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import itertools
+import json
+from pathlib import Path
+import time
+from typing import Any, Callable, Mapping, Optional, Sequence, Union
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+
+jax.config.update("jax_enable_x64", True)
+
+TRUTH_T0_K = 1160.0
+TRUTH_ALPHA = 0.03
+TRUTH_LOG_CO_SCALE = 0.0
+
+T0_PRIOR_BOUNDS_K = (1120.0, 1200.0)
+ALPHA_PRIOR_BOUNDS = (0.025, 0.035)
+LOG_CO_SCALE_PRIOR_BOUNDS = (-0.15, 0.15)
+
+PRESSURE_TOP_BAR = 1.0e-3
+PRESSURE_BOTTOM_BAR = 10.0
+REFERENCE_PRESSURE_BAR = 1.0
+TEMPERATURE_RANGE_K = (700.0, 1500.0)
+DEFAULT_RELATIVE_NOISE = 2.0e-3
+
+
+@dataclass(frozen=True)
+class SpectralContext:
+    """Static ExoJAX objects used by a differentiable CO spectrum."""
+
+    nu_grid: Any
+    art: Any
+    opa: Any
+    molmass: float
+    gravity: float
+    mean_molecular_weight: float
+
+
+@dataclass(frozen=True)
+class MockObservation:
+    """Normalized deterministic mock spectrum and its known noise."""
+
+    observed: Any
+    truth: Any
+    flux_scale: Any
+    noise_std: Any
+
+
+@dataclass(frozen=True)
+class RunSettings:
+    """NUTS settings after applying the optional quick profile."""
+
+    num_warmup: int
+    num_samples: int
+    seed: int
+    progress_bar: bool
+    max_tree_depth: int
+
+
+def require_local_co_database(
+    path: Optional[Union[str, Path]],
+) -> Path:
+    """Validate a local Li2015-like ExoMol directory without downloading."""
+
+    if path is None:
+        raise ValueError(
+            "A local CO ExoMol directory is required. Pass --co-database "
+            "/path/to/CO/12C-16O/Li2015."
+        )
+    database = Path(path).expanduser().resolve()
+    if not database.is_dir():
+        raise FileNotFoundError(f"CO database directory does not exist: {database}")
+
+    exact_name = database.parent.name
+    database_name = database.name
+    prefix = f"{exact_name}__{database_name}"
+    required = (database / f"{prefix}.def", database / f"{prefix}.pf")
+    missing = [item.name for item in required if not item.is_file()]
+    state_files = tuple(database.glob(f"{prefix}.states*"))
+    transition_files = tuple(database.glob(f"{prefix}.trans*"))
+    if not state_files:
+        missing.append(f"{prefix}.states[.bz2/.hdf5/.feather]")
+    if not transition_files:
+        missing.append(f"{prefix}.trans[.bz2/.hdf5/.feather]")
+    if missing:
+        raise FileNotFoundError(
+            "The CO database is incomplete and this offline demo will not "
+            f"download missing files. Missing: {', '.join(missing)}"
+        )
+    return database
+
+
+def build_spectral_context(
+    co_database_path: Union[str, Path],
+    *,
+    nlayer: int,
+    nu_points: int,
+) -> SpectralContext:
+    """Build the CO opacity and pure-absorption emission calculation."""
+
+    if nlayer < 2:
+        raise ValueError("nlayer must be at least two.")
+    if nu_points < 128:
+        raise ValueError("nu_points must be at least 128 for PreMODIT.")
+    database = require_local_co_database(co_database_path)
+
+    from exojax.database.exomol.api import MdbExomol
+    from exojax.database.molinfo.mass import isotope_molmass
+    from exojax.opacity import OpaPremodit
+    from exojax.rt import ArtEmisPure
+    from exojax.utils.grids import wavenumber_grid
+
+    nu_grid, _wavelength, _resolution = wavenumber_grid(
+        22920.0,
+        23000.0,
+        nu_points,
+        unit="AA",
+        xsmode="premodit",
+    )
+    # broadf=False and broadf_download=False make the offline contract explicit.
+    # The default .def broadening parameters are sufficient for this VJP demo.
+    mdb = MdbExomol(
+        str(database),
+        nurange=nu_grid,
+        broadf=False,
+        broadf_download=False,
+        gpu_transfer=False,
+    )
+    opa = OpaPremodit(
+        mdb,
+        nu_grid,
+        auto_trange=list(TEMPERATURE_RANGE_K),
+        dit_grid_resolution=1.0,
+    )
+    art = ArtEmisPure(
+        nu_grid=nu_grid,
+        pressure_btm=PRESSURE_BOTTOM_BAR,
+        pressure_top=PRESSURE_TOP_BAR,
+        nlayer=nlayer,
+        rtsolver="ibased",
+        nstream=4,
+    )
+    art.change_temperature_range(*TEMPERATURE_RANGE_K)
+    return SpectralContext(
+        nu_grid=nu_grid,
+        art=art,
+        opa=opa,
+        molmass=float(isotope_molmass("12C-16O")),
+        gravity=1.0e5,
+        mean_molecular_weight=2.33,
+    )
+
+
+def co_emission_flux(
+    context: SpectralContext,
+    temperature: Any,
+    co_vmr: Any,
+) -> jax.Array:
+    """Return an ExoJAX CO-only emission spectrum."""
+
+    from exojax.atm.atmconvert import vmr_to_mmr
+
+    temperature_array = jnp.asarray(temperature)
+    co_vmr_array = jnp.asarray(co_vmr)
+    co_mmr = vmr_to_mmr(
+        co_vmr_array,
+        context.molmass,
+        context.mean_molecular_weight,
+    )
+    cross_section = context.opa.xsmatrix(
+        temperature_array,
+        context.art.pressure,
+    )
+    optical_depth = context.art.opacity_profile_xs(
+        cross_section,
+        co_mmr,
+        context.molmass,
+        context.gravity,
+    )
+    return context.art.run(optical_depth, temperature_array)
+
+
+def make_mock_observation(
+    raw_truth_flux: Any,
+    *,
+    seed: int,
+    relative_noise: float,
+) -> MockObservation:
+    """Normalize a truth spectrum and add deterministic Gaussian noise."""
+
+    if relative_noise <= 0.0:
+        raise ValueError("relative_noise must be positive.")
+    raw = np.asarray(jax.device_get(raw_truth_flux), dtype=np.float64)
+    if raw.ndim != 1 or not np.all(np.isfinite(raw)):
+        raise ValueError("raw_truth_flux must be a finite one-dimensional array.")
+    scale = float(np.median(np.abs(raw)))
+    if not np.isfinite(scale) or scale <= 0.0:
+        raise ValueError("The truth spectrum does not have a positive flux scale.")
+    truth = raw / scale
+    noise = np.random.default_rng(seed).normal(
+        loc=0.0,
+        scale=relative_noise,
+        size=truth.shape,
+    )
+    dtype = jnp.asarray(raw_truth_flux).dtype
+    return MockObservation(
+        observed=jnp.asarray(truth + noise, dtype=dtype),
+        truth=jnp.asarray(truth, dtype=dtype),
+        flux_scale=jnp.asarray(scale, dtype=dtype),
+        noise_std=jnp.asarray(relative_noise, dtype=dtype),
+    )
+
+
+def add_common_cli_arguments(
+    parser: argparse.ArgumentParser,
+    *,
+    default_output_dir: Union[str, Path],
+) -> None:
+    """Add consistent data, profile, sampling, and output arguments."""
+
+    parser.add_argument(
+        "--co-database",
+        type=Path,
+        default=None,
+        help="Exact local CO/12C-16O/Li2015 directory (never downloaded).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path(default_output_dir),
+        help="Directory for JSON and NumPy output artifacts.",
+    )
+    parser.add_argument("--nlayer", type=int, default=24)
+    parser.add_argument("--nu-points", type=int, default=1024)
+    parser.add_argument("--num-warmup", type=int, default=500)
+    parser.add_argument("--num-samples", type=int, default=1000)
+    parser.add_argument("--max-tree-depth", type=int, default=10)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument(
+        "--quick",
+        action="store_true",
+        help="Use at most 5 warmup, 10 samples, 8 layers, and 256 grid points.",
+    )
+    parser.add_argument(
+        "--preflight-only",
+        action="store_true",
+        help="Run primal and reverse-mode checks without NUTS.",
+    )
+    parser.add_argument(
+        "--no-progress-bar",
+        action="store_true",
+        help="Disable the NumPyro progress bar.",
+    )
+
+
+def resolve_run_settings(args: argparse.Namespace) -> RunSettings:
+    """Validate sampling arguments and apply the quick upper bounds."""
+
+    for name in ("num_warmup", "num_samples", "max_tree_depth"):
+        if int(getattr(args, name)) <= 0:
+            raise ValueError(f"--{name.replace('_', '-')} must be positive.")
+    if args.quick:
+        num_warmup = min(int(args.num_warmup), 5)
+        num_samples = min(int(args.num_samples), 10)
+        max_tree_depth = min(int(args.max_tree_depth), 4)
+    else:
+        num_warmup = int(args.num_warmup)
+        num_samples = int(args.num_samples)
+        max_tree_depth = int(args.max_tree_depth)
+    return RunSettings(
+        num_warmup=num_warmup,
+        num_samples=num_samples,
+        seed=int(args.seed),
+        progress_bar=not bool(args.no_progress_bar),
+        max_tree_depth=max_tree_depth,
+    )
+
+
+def resolve_demo_shape(args: argparse.Namespace) -> tuple[int, int]:
+    """Validate the requested shape and apply quick-mode upper bounds."""
+
+    nlayer = int(args.nlayer)
+    nu_points = int(args.nu_points)
+    if args.quick:
+        nlayer = min(nlayer, 8)
+        nu_points = min(nu_points, 256)
+    if nlayer < 2:
+        raise ValueError("--nlayer must be at least two.")
+    if nu_points < 128:
+        raise ValueError("--nu-points must be at least 128.")
+    return nlayer, nu_points
+
+
+def run_reverse_mode_nuts(
+    model: Callable[[], None],
+    observation: MockObservation,
+    settings: RunSettings,
+):
+    """Run NumPyro NUTS with reverse-mode differentiation explicitly selected."""
+
+    del observation  # The closed-over model already contains the observation.
+    from numpyro.infer import MCMC, NUTS
+
+    kernel = NUTS(
+        model,
+        forward_mode_differentiation=False,
+        max_tree_depth=settings.max_tree_depth,
+    )
+    mcmc = MCMC(
+        kernel,
+        num_warmup=settings.num_warmup,
+        num_samples=settings.num_samples,
+        num_chains=1,
+        progress_bar=settings.progress_bar,
+    )
+    started = time.perf_counter()
+    mcmc.run(jax.random.PRNGKey(settings.seed))
+    jax.block_until_ready(mcmc.get_samples())
+    setattr(mcmc, "exogibbs_elapsed_seconds", time.perf_counter() - started)
+    return mcmc
+
+
+def _json_ready(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, Mapping):
+        return {str(key): _json_ready(item) for key, item in value.items()}
+    if isinstance(value, (tuple, list)):
+        return [_json_ready(item) for item in value]
+    array = np.asarray(jax.device_get(value))
+    if array.ndim == 0:
+        return array.item()
+    return array.tolist()
+
+
+def write_run_outputs(
+    output_dir: Union[str, Path],
+    *,
+    case_name: str,
+    context: SpectralContext,
+    observation: MockObservation,
+    mcmc: Any = None,
+    metadata: Optional[Mapping[str, Any]] = None,
+) -> None:
+    """Write deterministic inputs, posterior samples, and a compact summary."""
+
+    output = Path(output_dir)
+    output.mkdir(parents=True, exist_ok=True)
+    np.savez_compressed(
+        output / "mock_spectrum.npz",
+        wavenumber=np.asarray(jax.device_get(context.nu_grid)),
+        observed=np.asarray(jax.device_get(observation.observed)),
+        truth=np.asarray(jax.device_get(observation.truth)),
+        noise_std=float(observation.noise_std),
+        flux_scale=float(observation.flux_scale),
+    )
+    summary: dict[str, Any] = {
+        "schema": "exogibbs_exojax_nuts_vjp_demo_v1",
+        "case_name": case_name,
+        "jax_backend": jax.default_backend(),
+        "jax_devices": [str(device) for device in jax.devices()],
+        "nlayer": int(context.art.pressure.shape[0]),
+        "nu_points": int(np.asarray(context.nu_grid).shape[0]),
+        "metadata": _json_ready(metadata or {}),
+    }
+    if mcmc is not None:
+        samples = {
+            name: np.asarray(jax.device_get(values))
+            for name, values in mcmc.get_samples().items()
+        }
+        np.savez_compressed(output / "posterior_samples.npz", **samples)
+        extra_fields = mcmc.get_extra_fields()
+        divergent = np.asarray(
+            jax.device_get(extra_fields.get("diverging", np.asarray([])))
+        )
+        summary.update(
+            {
+                "elapsed_seconds": float(
+                    getattr(mcmc, "exogibbs_elapsed_seconds", np.nan)
+                ),
+                "divergences": int(np.sum(divergent)),
+                "posterior": {
+                    name: {
+                        "mean": float(np.mean(values)),
+                        "standard_deviation": float(np.std(values)),
+                        "q05": float(np.quantile(values, 0.05)),
+                        "q50": float(np.quantile(values, 0.50)),
+                        "q95": float(np.quantile(values, 0.95)),
+                    }
+                    for name, values in samples.items()
+                },
+            }
+        )
+    with (output / "run_summary.json").open(
+        "w", encoding="utf-8", newline="\n"
+    ) as stream:
+        json.dump(summary, stream, indent=2, sort_keys=True)
+        stream.write("\n")
+
+
+def _gas_prior_corners() -> tuple[tuple[float, float, float], ...]:
+    return tuple(
+        itertools.product(
+            T0_PRIOR_BOUNDS_K,
+            ALPHA_PRIOR_BOUNDS,
+            LOG_CO_SCALE_PRIOR_BOUNDS,
+        )
+    )
+
+
+def _scale_carbon_and_oxygen(
+    reference: Any,
+    carbon_index: int,
+    oxygen_index: int,
+    log_co_scale: Any,
+) -> jax.Array:
+    values = jnp.asarray(reference)
+    indices = jnp.asarray([carbon_index, oxygen_index], dtype=jnp.int32)
+    scale = jnp.power(jnp.asarray(10.0, dtype=values.dtype), log_co_scale)
+    return values.at[indices].set(values[indices] * scale)
+
+
+def run_gas_demo(
+    *,
+    use_grid_initializer: bool,
+    case_name: str,
+    argv: Optional[Sequence[str]] = None,
+) -> int:
+    """Run one gas-only retrieval; the two cases differ only by initializer."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    add_common_cli_arguments(
+        parser,
+        default_output_dir=Path("results") / "vjp_retrieval" / case_name,
+    )
+    parser.add_argument(
+        "--relative-noise",
+        type=float,
+        default=DEFAULT_RELATIVE_NOISE,
+    )
+    args = parser.parse_args(argv)
+    settings = resolve_run_settings(args)
+    nlayer, nu_points = resolve_demo_shape(args)
+    context = build_spectral_context(
+        args.co_database,
+        nlayer=nlayer,
+        nu_points=nu_points,
+    )
+
+    from exogibbs.api.gas import EquilibriumOptions, GridEquilibriumInitializer
+    from exogibbs.api.gas import solve_profile as solve_gas_profile
+    from exogibbs.presets.fastchem import chemsetup
+
+    chemistry = chemsetup(silent=True)
+    if chemistry.element_vector_reference is None:
+        raise ValueError("The FastChem preset has no reference element vector.")
+    reference = jnp.asarray(chemistry.element_vector_reference, dtype=jnp.float64)
+    carbon_index = chemistry.elements.index("C")
+    oxygen_index = chemistry.elements.index("O")
+    co_species_index = chemistry.species.index("C1O1")
+
+    initializer = None
+    grid = None
+    if use_grid_initializer:
+        from exogibbs.api import (
+            get_default_equilibrium_grid_path,
+            load_equilibrium_grid_netcdf,
+        )
+
+        grid = load_equilibrium_grid_netcdf(
+            str(get_default_equilibrium_grid_path("fastchem"))
+        )
+        initializer = GridEquilibriumInitializer(
+            grid=grid,
+            preset_name="fastchem",
+        )
+    options = EquilibriumOptions(
+        epsilon_crit=1.0e-10,
+        max_iter=1000,
+        method="vmap_cold",
+    )
+    pressure = jnp.asarray(context.art.pressure, dtype=jnp.float64)
+
+    def raw_flux(t0_kelvin, alpha, log_co_scale):
+        temperature = context.art.powerlaw_temperature(t0_kelvin, alpha)
+        inventory = _scale_carbon_and_oxygen(
+            reference,
+            carbon_index,
+            oxygen_index,
+            log_co_scale,
+        )
+        result = solve_gas_profile(
+            chemistry,
+            temperature,
+            pressure,
+            inventory,
+            Pref=REFERENCE_PRESSURE_BAR,
+            initializer=initializer,
+            options=options,
+        )
+        return co_emission_flux(
+            context,
+            temperature,
+            result.x[:, co_species_index],
+        )
+
+    truth_flux = raw_flux(TRUTH_T0_K, TRUTH_ALPHA, TRUTH_LOG_CO_SCALE)
+    observation = make_mock_observation(
+        truth_flux,
+        seed=settings.seed,
+        relative_noise=args.relative_noise,
+    )
+
+    corner_reports = []
+    for t0_kelvin, alpha, log_co_scale in _gas_prior_corners():
+        temperature = context.art.powerlaw_temperature(t0_kelvin, alpha)
+        inventory = _scale_carbon_and_oxygen(
+            reference,
+            carbon_index,
+            oxygen_index,
+            log_co_scale,
+        )
+        _result, diagnostics = solve_gas_profile(
+            chemistry,
+            temperature,
+            pressure,
+            inventory,
+            Pref=REFERENCE_PRESSURE_BAR,
+            initializer=initializer,
+            options=options,
+            return_diagnostics=True,
+        )
+        converged = bool(jnp.all(diagnostics["converged"]))
+        finite = bool(jnp.all(jnp.isfinite(diagnostics["final_residual"])))
+        corner_reports.append(
+            {
+                "t0_kelvin": t0_kelvin,
+                "alpha": alpha,
+                "log_co_scale": log_co_scale,
+                "temperature_min_kelvin": float(jnp.min(temperature)),
+                "temperature_max_kelvin": float(jnp.max(temperature)),
+                "converged": converged,
+                "finite_residual": finite,
+                "maximum_iterations": int(jnp.max(diagnostics["n_iter"])),
+            }
+        )
+    if not all(
+        item["converged"] and item["finite_residual"]
+        for item in corner_reports
+    ):
+        raise RuntimeError(f"Gas solver prior-corner preflight failed: {corner_reports}")
+
+    def spectral_loss(t0_kelvin, alpha, log_co_scale):
+        prediction = raw_flux(t0_kelvin, alpha, log_co_scale)
+        prediction = prediction / observation.flux_scale
+        return jnp.mean(jnp.square(prediction - observation.observed))
+
+    loss, gradient = jax.value_and_grad(
+        spectral_loss,
+        argnums=(0, 1, 2),
+    )(TRUTH_T0_K, TRUTH_ALPHA, TRUTH_LOG_CO_SCALE)
+    gradient_values = tuple(float(value) for value in gradient)
+    if not np.isfinite(float(loss)) or not np.all(np.isfinite(gradient_values)):
+        raise RuntimeError(
+            f"Reverse-mode spectrum preflight is non-finite: {loss}, {gradient_values}"
+        )
+    preflight = {
+        "case_name": case_name,
+        "initializer": "packaged_fastchem_grid" if initializer else "uniform_cold",
+        "reverse_mode_gradient": {
+            "T0": gradient_values[0],
+            "alpha": gradient_values[1],
+            "log_co_scale": gradient_values[2],
+        },
+        "spectral_loss": float(loss),
+        "prior_corners": corner_reports,
+        "passed": True,
+    }
+    if grid is not None:
+        preflight["grid_bounds"] = {
+            "temperature": [
+                float(jnp.min(grid.temperature_axis)),
+                float(jnp.max(grid.temperature_axis)),
+            ],
+            "pressure": [
+                float(jnp.min(grid.pressure_axis)),
+                float(jnp.max(grid.pressure_axis)),
+            ],
+            "log10_z_over_z_sun": [
+                float(jnp.min(grid.log10_z_over_z_sun_axis)),
+                float(jnp.max(grid.log10_z_over_z_sun_axis)),
+            ],
+        }
+
+    if args.preflight_only:
+        write_run_outputs(
+            args.output_dir,
+            case_name=case_name,
+            context=context,
+            observation=observation,
+            metadata={"preflight": preflight},
+        )
+        print(f"{case_name}: preflight passed; outputs: {args.output_dir}")
+        return 0
+
+    import numpyro
+    import numpyro.distributions as dist
+
+    def model():
+        t0_kelvin = numpyro.sample("T0", dist.Uniform(*T0_PRIOR_BOUNDS_K))
+        alpha = numpyro.sample("alpha", dist.Uniform(*ALPHA_PRIOR_BOUNDS))
+        log_co_scale = numpyro.sample(
+            "log_co_scale",
+            dist.Uniform(*LOG_CO_SCALE_PRIOR_BOUNDS),
+        )
+        prediction = raw_flux(t0_kelvin, alpha, log_co_scale)
+        prediction = prediction / observation.flux_scale
+        numpyro.sample(
+            "spectrum",
+            dist.Normal(prediction, observation.noise_std),
+            obs=observation.observed,
+        )
+
+    mcmc = run_reverse_mode_nuts(model, observation, settings)
+    write_run_outputs(
+        args.output_dir,
+        case_name=case_name,
+        context=context,
+        observation=observation,
+        mcmc=mcmc,
+        metadata={"preflight": preflight},
+    )
+    print(f"{case_name}: completed; outputs: {args.output_dir}")
+    return 0
+
+
+__all__ = (
+    "MockObservation",
+    "RunSettings",
+    "SpectralContext",
+    "TRUTH_ALPHA",
+    "TRUTH_LOG_CO_SCALE",
+    "TRUTH_T0_K",
+    "add_common_cli_arguments",
+    "build_spectral_context",
+    "co_emission_flux",
+    "make_mock_observation",
+    "require_local_co_database",
+    "resolve_demo_shape",
+    "resolve_run_settings",
+    "run_gas_demo",
+    "run_reverse_mode_nuts",
+    "write_run_outputs",
+)

--- a/examples/retrievals/exojax_nuts_condensate_fixed_support.py
+++ b/examples/retrievals/exojax_nuts_condensate_fixed_support.py
@@ -1,0 +1,1064 @@
+"""Local fixed-support condensation retrieval with ExoJAX and NUTS.
+
+This example uses the FastChem4 gas tables with a carbon-rich ``C/O = 2``
+elemental inventory and a deliberately reduced condensate catalog containing
+only FastChem4's graphite phase, ``C(s)``.  A nominal gas-only profile is
+solved before sampling, graphite stability is inspected, and the layers with
+a positive graphite solution are certified with the differentiable
+fixed-support zero-barrier kernel.  Those layer indices and all numerical
+initial values are then frozen.  Inside NUTS, active layers use the condensate
+custom VJP and the remaining layers use the gas-only custom VJP.
+
+The fixed mask is a deliberately local inference contract.  The script checks
+all corners of its narrow prior box before sampling and stops if a corner
+changes graphite support or fails a primal solve.  It does not differentiate
+support discovery, the production condensate lifecycle, phase transitions, or
+rainout.  It also makes no phase-stability or support-closure claim for the
+omitted FastChem4 condensates.  In particular, widening the priors or treating
+this reduced model as full-catalog equilibrium is not supported.
+
+Run a chemistry-only check (no ExoJAX database is opened) with::
+
+    python examples/retrievals/exojax_nuts_condensate_fixed_support.py \
+        --preflight-only --nlayer 8
+
+Run a short end-to-end retrieval with a pre-existing ExoMol CO database with::
+
+    python examples/retrievals/exojax_nuts_condensate_fixed_support.py \
+        --quick --co-database .database/CO/12C-16O/Li2015
+
+The full run is intended for a GPU.  This example never downloads a database.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import itertools
+import json
+from pathlib import Path
+import sys
+from typing import Any, Mapping, Optional, Sequence, Union
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+
+SCRIPT_DIRECTORY = Path(__file__).resolve().parent
+if str(SCRIPT_DIRECTORY) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIRECTORY))
+
+from _exojax_nuts_common import (  # noqa: E402
+    TRUTH_ALPHA,
+    TRUTH_LOG_CO_SCALE,
+    TRUTH_T0_K,
+    add_common_cli_arguments,
+    build_spectral_context,
+    co_emission_flux,
+    make_mock_observation,
+    resolve_demo_shape,
+    resolve_run_settings,
+    run_reverse_mode_nuts,
+    write_run_outputs,
+)
+from exogibbs.api.gas import (  # noqa: E402
+    EquilibriumOptions,
+    solve_profile as solve_gas_profile,
+)
+from exogibbs.equilibrium.condensate.acceptance import (  # noqa: E402
+    least_squares_element_potential,
+)
+from exogibbs.equilibrium.condensate.setup import (  # noqa: E402
+    build_condensate_chemical_setup,
+)
+from exogibbs.equilibrium.condensate.fixed_support import (  # noqa: E402
+    minimize_gibbs_fixed_support,
+    minimize_gibbs_fixed_support_with_diagnostics,
+)
+from exogibbs.equilibrium.gas.kernel.diagnostics import (  # noqa: E402
+    minimize_gibbs_with_diagnostics,
+)
+from exogibbs.equilibrium.gas.kernel.solver import minimize_gibbs  # noqa: E402
+from exogibbs.equilibrium.gas.types import ThermoState  # noqa: E402
+from exogibbs.presets.fastchem4_cond import condensate_chemical_setup  # noqa: E402
+from exogibbs.thermo.models import ChemicalSetup  # noqa: E402
+
+
+jax.config.update("jax_enable_x64", True)
+
+CASE_NAME = "condensate_fixed_support"
+GRAPHITE_SPECIES = "C(s)"
+CARBON_TO_OXYGEN_RATIO = 2.0
+REFERENCE_PRESSURE_BAR = 1.0
+PRESSURE_TOP_BAR = 1.0e-3
+PRESSURE_BOTTOM_BAR = 10.0
+
+# This box is intentionally narrow.  The eight corners are checked before NUTS.
+T0_PRIOR_BOUNDS_K = (1155.0, 1165.0)
+ALPHA_PRIOR_BOUNDS = (0.029, 0.031)
+LOG_CO_SCALE_PRIOR_BOUNDS = (-0.005, 0.005)
+
+GAS_RESIDUAL_TOLERANCE = 1.0e-11
+GAS_MAX_ITERATIONS = 1000
+CONDENSATE_RESIDUAL_TOLERANCE = 1.0e-10
+CONDENSATE_MAX_ITERATIONS = 100
+GRAPHITE_SEED_FRACTION = 1.0e-3
+MIN_ACTIVE_GRAPHITE_AMOUNT = 1.0e-8
+MIN_INACTIVE_DRIVING_MARGIN = 2.0e-2
+DEFAULT_RELATIVE_NOISE = 2.0e-3
+CONDENSATE_MODEL_SCOPE = "fastchem4_gas_plus_graphite_only"
+
+
+@dataclass(frozen=True)
+class GraphiteProfilePlan:
+    """Static layer partition and initial values used inside NUTS."""
+
+    setup: Any
+    pressures_bar: Any
+    nominal_temperatures: Any
+    reference_element_vector: Any
+    carbon_index: int
+    oxygen_index: int
+    co_species_index: int
+    graphite_species_index: int
+    active_indices: tuple[int, ...]
+    inactive_indices: tuple[int, ...]
+    gas_only_log_amounts: Any
+    gas_only_total_log_amounts: Any
+    hybrid_log_amounts_init: Any
+    hybrid_total_log_amounts_init: Any
+    graphite_amounts_init: Any
+    graphite_seed_amount: float
+    nominal_graphite_driving_margin: Any
+    nominal_fixed_support_residual: Any
+
+    @property
+    def active_mask(self) -> np.ndarray:
+        """Return the fixed graphite mask as a host NumPy array."""
+
+        mask = np.zeros((len(self.pressures_bar),), dtype=bool)
+        mask[np.asarray(self.active_indices, dtype=int)] = True
+        return mask
+
+
+def pressure_profile(
+    nlayer: int,
+    *,
+    pressure_top: float = PRESSURE_TOP_BAR,
+    pressure_bottom: float = PRESSURE_BOTTOM_BAR,
+) -> jax.Array:
+    """Return ExoJAX's endpoint-inclusive top-to-bottom pressure grid."""
+
+    if nlayer < 2:
+        raise ValueError("nlayer must be at least two for the hybrid demo.")
+    if pressure_top <= 0.0 or pressure_bottom <= pressure_top:
+        raise ValueError("pressure bounds must satisfy 0 < top < bottom.")
+    return jnp.logspace(
+        jnp.log10(pressure_top),
+        jnp.log10(pressure_bottom),
+        nlayer,
+        dtype=jnp.float64,
+    )
+
+
+def powerlaw_temperature(
+    pressures_bar: Any,
+    t0_kelvin: Any,
+    alpha: Any,
+) -> jax.Array:
+    """Use the same one-bar power-law convention as the ExoJAX atmosphere."""
+
+    pressure = jnp.asarray(pressures_bar, dtype=jnp.float64)
+    return jnp.asarray(t0_kelvin) * pressure ** jnp.asarray(alpha)
+
+
+def graphite_only_chemical_setup(
+    full_setup: Optional[Any] = None,
+):
+    """Build the declared FastChem4-gas plus graphite-only chemistry model."""
+
+    source = (
+        condensate_chemical_setup(silent=True)
+        if full_setup is None
+        else full_setup
+    )
+    graphite_index = source.condensate_species.index(GRAPHITE_SPECIES)
+    source_condensates = source.condensate_setup
+    selected_index = jnp.asarray([graphite_index], dtype=jnp.int32)
+
+    def graphite_hvector(temperature):
+        return jnp.take(
+            source_condensates.hvector_func(temperature),
+            selected_index,
+            axis=-1,
+        )
+
+    validity = source_condensates.temperature_validity_upper
+    selected_validity = None
+    if validity is not None:
+        selected_validity = (float(validity[graphite_index]),)
+    metadata = dict(source_condensates.metadata or {})
+    source_catalog_count = len(source.condensate_species)
+    metadata.update(
+        {
+            "model_scope": CONDENSATE_MODEL_SCOPE,
+            "condensate_catalog_mode": "reduced_explicit",
+            "reduced_condensate_catalog": True,
+            "selected_condensates": (GRAPHITE_SPECIES,),
+            "condensate_species_considered": (GRAPHITE_SPECIES,),
+            "source_condensate_catalog_count": source_catalog_count,
+            "full_fastchem4_condensate_species_count": source_catalog_count,
+            "excluded_condensate_species_count": source_catalog_count - 1,
+            "full_catalog_equilibrium_claimed": False,
+            "full_catalog_support_closure_checked": False,
+            "rainout": False,
+            "temperature_validity_upper": selected_validity,
+        }
+    )
+    reduced_condensates = ChemicalSetup(
+        formula_matrix=source.formula_matrix_cond[:, selected_index],
+        hvector_func=graphite_hvector,
+        elements=tuple(source.elements),
+        species=(GRAPHITE_SPECIES,),
+        element_vector_reference=source_condensates.element_vector_reference,
+        metadata=metadata,
+        temperature_validity_upper=selected_validity,
+    )
+    return build_condensate_chemical_setup(
+        gas_setup=source.gas_setup,
+        condensate_setup=reduced_condensates,
+    )
+
+
+def carbon_rich_reference_vector(setup: Any) -> jax.Array:
+    """Return the FastChem4 reference vector with C/O set exactly to two."""
+
+    if setup.gas_setup.element_vector_reference is None:
+        raise ValueError("FastChem4 setup did not provide a reference inventory.")
+    carbon_index = setup.elements.index("C")
+    oxygen_index = setup.elements.index("O")
+    element_vector = jnp.asarray(
+        setup.gas_setup.element_vector_reference,
+        dtype=jnp.float64,
+    )
+    return element_vector.at[carbon_index].set(
+        CARBON_TO_OXYGEN_RATIO * element_vector[oxygen_index]
+    )
+
+
+def scale_carbon_and_oxygen(
+    element_vector: Any,
+    carbon_index: int,
+    oxygen_index: int,
+    log_co_scale: Any,
+) -> jax.Array:
+    """Scale C and O together while preserving the carbon-rich C/O ratio."""
+
+    values = jnp.asarray(element_vector)
+    indices = jnp.asarray([carbon_index, oxygen_index], dtype=jnp.int32)
+    scale = jnp.power(jnp.asarray(10.0, dtype=values.dtype), log_co_scale)
+    return values.at[indices].set(values[indices] * scale)
+
+
+def _graphite_support_arrays(setup: Any, graphite_index: int):
+    support = jnp.asarray([graphite_index], dtype=jnp.int32)
+    formula_matrix_cond = setup.formula_matrix_cond[:, support]
+
+    def graphite_hvector(temperature):
+        return setup.condensate_setup.hvector_func(temperature)[support]
+
+    return support, formula_matrix_cond, graphite_hvector
+
+
+def _graphite_inactive_margin(
+    setup: Any,
+    graphite_index: int,
+    temperature: Any,
+    pressure_bar: Any,
+    gas_log_amounts: Any,
+    total_gas_log_amount: Any,
+) -> jax.Array:
+    """Return ``h_C(s) - A_C(s)^T lambda`` for a gas-only state."""
+
+    gas_source = (
+        setup.gas_setup.hvector_func(temperature)
+        + jnp.log(pressure_bar / REFERENCE_PRESSURE_BAR)
+        - total_gas_log_amount
+    )
+    potential = least_squares_element_potential(
+        formula_matrix=setup.formula_matrix,
+        gas_ln_n=gas_log_amounts,
+        gas_stationarity_source=gas_source,
+    )
+    condensate_column = setup.formula_matrix_cond[:, graphite_index]
+    return (
+        setup.condensate_setup.hvector_func(temperature)[graphite_index]
+        - condensate_column @ potential
+    )
+
+
+def _audit_graphite_candidate(
+    setup: Any,
+    graphite_index: int,
+    temperatures: Any,
+    pressures_bar: Any,
+    element_vectors: Any,
+    gas_log_amounts_init: Any,
+    gas_total_log_amounts_init: Any,
+    graphite_amounts_init: Any,
+    fixed_gas_log_amounts_init: Optional[Any] = None,
+    fixed_total_log_amounts_init: Optional[Any] = None,
+) -> tuple[Any, Any, Any, Any, Any]:
+    """Audit gas roots, graphite driving, and fixed-support roots by layer."""
+
+    _, formula_matrix_cond, graphite_hvector = _graphite_support_arrays(
+        setup, graphite_index
+    )
+
+    def gas_layer(temperature, pressure, inventory, q_init, qtot_init):
+        return minimize_gibbs_with_diagnostics(
+            ThermoState(
+                temperature,
+                jnp.log(pressure / REFERENCE_PRESSURE_BAR),
+                inventory,
+            ),
+            q_init,
+            qtot_init,
+            setup.formula_matrix,
+            setup.gas_setup.hvector_func,
+            epsilon_crit=GAS_RESIDUAL_TOLERANCE,
+            max_iter=GAS_MAX_ITERATIONS,
+        )
+
+    gas_log_amounts, gas_diagnostics = jax.vmap(gas_layer)(
+        temperatures,
+        pressures_bar,
+        element_vectors,
+        gas_log_amounts_init,
+        gas_total_log_amounts_init,
+    )
+    gas_total_log_amounts = jax.scipy.special.logsumexp(
+        gas_log_amounts, axis=1
+    )
+    margins = jax.vmap(
+        lambda temperature, pressure, q, qtot: _graphite_inactive_margin(
+            setup,
+            graphite_index,
+            temperature,
+            pressure,
+            q,
+            qtot,
+        )
+    )(
+        temperatures,
+        pressures_bar,
+        gas_log_amounts,
+        gas_total_log_amounts,
+    )
+
+    def condensate_layer(
+        temperature,
+        pressure,
+        inventory,
+        q_init,
+        qtot_init,
+        graphite_init,
+    ):
+        return minimize_gibbs_fixed_support_with_diagnostics(
+            ThermoState(
+                temperature,
+                jnp.log(pressure / REFERENCE_PRESSURE_BAR),
+                inventory,
+            ),
+            q_init,
+            graphite_init.reshape((1,)),
+            qtot_init,
+            setup.formula_matrix,
+            formula_matrix_cond,
+            setup.gas_setup.hvector_func,
+            graphite_hvector,
+            residual_crit=CONDENSATE_RESIDUAL_TOLERANCE,
+            max_iter=CONDENSATE_MAX_ITERATIONS,
+        )
+
+    fixed_q_init = (
+        gas_log_amounts
+        if fixed_gas_log_amounts_init is None
+        else jnp.asarray(fixed_gas_log_amounts_init)
+    )
+    fixed_qtot_init = (
+        gas_total_log_amounts
+        if fixed_total_log_amounts_init is None
+        else jnp.asarray(fixed_total_log_amounts_init)
+    )
+    fixed_result, fixed_diagnostics = jax.vmap(condensate_layer)(
+        temperatures,
+        pressures_bar,
+        element_vectors,
+        fixed_q_init,
+        fixed_qtot_init,
+        graphite_amounts_init,
+    )
+    return (
+        gas_log_amounts,
+        gas_diagnostics,
+        margins,
+        fixed_result,
+        fixed_diagnostics,
+    )
+
+
+def prepare_graphite_profile(
+    pressures_bar: Any,
+    *,
+    setup: Optional[Any] = None,
+) -> GraphiteProfilePlan:
+    """Discover and certify the nominal static graphite layer partition."""
+
+    pressure = jnp.asarray(pressures_bar, dtype=jnp.float64)
+    if pressure.ndim != 1 or pressure.shape[0] < 2:
+        raise ValueError("pressures_bar must be a one-dimensional profile.")
+    if not bool(jnp.all(jnp.isfinite(pressure) & (pressure > 0.0))):
+        raise ValueError("pressures_bar must contain finite positive values.")
+    if not bool(jnp.all(jnp.diff(pressure) > 0.0)):
+        raise ValueError("pressures_bar must be ordered from top to bottom.")
+
+    chemistry = graphite_only_chemical_setup(setup)
+    graphite_index = chemistry.condensate_species.index(GRAPHITE_SPECIES)
+    carbon_index = chemistry.elements.index("C")
+    oxygen_index = chemistry.elements.index("O")
+    co_species_index = chemistry.gas_species.index("C1O1")
+    element_vector = carbon_rich_reference_vector(chemistry)
+    nominal_temperature = powerlaw_temperature(
+        pressure, TRUTH_T0_K, TRUTH_ALPHA
+    )
+
+    gas_result, gas_diagnostics = solve_gas_profile(
+        chemistry.gas_setup,
+        nominal_temperature,
+        pressure,
+        element_vector,
+        Pref=REFERENCE_PRESSURE_BAR,
+        options=EquilibriumOptions(
+            epsilon_crit=GAS_RESIDUAL_TOLERANCE,
+            max_iter=GAS_MAX_ITERATIONS,
+            method="vmap_cold",
+        ),
+        return_diagnostics=True,
+    )
+    if not bool(jnp.all(gas_diagnostics["converged"])):
+        failed = np.flatnonzero(
+            ~np.asarray(jax.device_get(gas_diagnostics["converged"]), dtype=bool)
+        )
+        raise RuntimeError(
+            "Nominal gas-only preparation did not converge in layers "
+            f"{failed.tolist()}."
+        )
+    gas_total_log_amounts = jnp.log(gas_result.ntot)
+    seed_amount = min(
+        1.0e-3,
+        GRAPHITE_SEED_FRACTION * float(element_vector[carbon_index]),
+    )
+    graphite_seed = jnp.full(
+        (pressure.shape[0],), seed_amount, dtype=element_vector.dtype
+    )
+    element_vectors = jnp.broadcast_to(
+        element_vector, (pressure.shape[0], element_vector.shape[0])
+    )
+    (
+        gas_log_amounts,
+        audited_gas_diagnostics,
+        margins,
+        fixed_result,
+        fixed_diagnostics,
+    ) = _audit_graphite_candidate(
+        chemistry,
+        graphite_index,
+        nominal_temperature,
+        pressure,
+        element_vectors,
+        gas_result.ln_n,
+        gas_total_log_amounts,
+        graphite_seed,
+    )
+    gas_converged = jnp.asarray(audited_gas_diagnostics["converged"])
+    fixed_amounts = fixed_result.condensate_amounts[:, 0]
+    fixed_valid = (
+        fixed_diagnostics.converged
+        & jnp.isfinite(fixed_diagnostics.residual_norm)
+        & jnp.isfinite(fixed_amounts)
+        & (fixed_amounts > MIN_ACTIVE_GRAPHITE_AMOUNT)
+    )
+    activity_candidate = margins < 0.0
+    unresolved = activity_candidate & (~fixed_valid)
+    if not bool(jnp.all(gas_converged)) or bool(jnp.any(unresolved)):
+        failed = np.flatnonzero(
+            np.asarray(jax.device_get((~gas_converged) | unresolved), dtype=bool)
+        )
+        raise RuntimeError(
+            "Nominal graphite support preparation failed in layers "
+            f"{failed.tolist()}."
+        )
+    active_mask = np.asarray(
+        jax.device_get(activity_candidate & fixed_valid), dtype=bool
+    )
+    active_indices = tuple(int(index) for index in np.flatnonzero(active_mask))
+    inactive_indices = tuple(int(index) for index in np.flatnonzero(~active_mask))
+    if not active_indices or not inactive_indices:
+        raise RuntimeError(
+            "The demo requires both graphite-active and gas-only layers; "
+            f"found active={active_indices}, inactive={inactive_indices}."
+        )
+
+    hybrid_q = jnp.where(
+        jnp.asarray(active_mask)[:, None],
+        fixed_result.gas_log_amounts,
+        gas_log_amounts,
+    )
+    hybrid_qtot = jax.scipy.special.logsumexp(hybrid_q, axis=1)
+    graphite_init = jnp.where(
+        jnp.asarray(active_mask), fixed_amounts, graphite_seed
+    )
+    return GraphiteProfilePlan(
+        setup=chemistry,
+        pressures_bar=pressure,
+        nominal_temperatures=nominal_temperature,
+        reference_element_vector=element_vector,
+        carbon_index=carbon_index,
+        oxygen_index=oxygen_index,
+        co_species_index=co_species_index,
+        graphite_species_index=graphite_index,
+        active_indices=active_indices,
+        inactive_indices=inactive_indices,
+        gas_only_log_amounts=gas_log_amounts,
+        gas_only_total_log_amounts=jax.scipy.special.logsumexp(
+            gas_log_amounts, axis=1
+        ),
+        hybrid_log_amounts_init=hybrid_q,
+        hybrid_total_log_amounts_init=hybrid_qtot,
+        graphite_amounts_init=graphite_init,
+        graphite_seed_amount=seed_amount,
+        nominal_graphite_driving_margin=margins,
+        nominal_fixed_support_residual=fixed_diagnostics.residual_norm,
+    )
+
+
+def solve_hybrid_log_amounts(
+    plan: GraphiteProfilePlan,
+    temperatures: Any,
+    log_co_scale: Any,
+) -> jax.Array:
+    """Solve the frozen active partition with condensate and gas custom VJPs."""
+
+    temperature = jnp.asarray(temperatures)
+    if temperature.shape != plan.pressures_bar.shape:
+        raise ValueError("temperatures must have one value per prepared layer.")
+    inventory = scale_carbon_and_oxygen(
+        plan.reference_element_vector,
+        plan.carbon_index,
+        plan.oxygen_index,
+        log_co_scale,
+    )
+    _, formula_matrix_cond, graphite_hvector = _graphite_support_arrays(
+        plan.setup, plan.graphite_species_index
+    )
+    result = jnp.zeros_like(plan.hybrid_log_amounts_init)
+
+    active = jnp.asarray(plan.active_indices, dtype=jnp.int32)
+
+    def active_layer(temp, pressure, q_init, qtot_init, graphite_init):
+        solved = minimize_gibbs_fixed_support(
+            ThermoState(
+                temp,
+                jnp.log(pressure / REFERENCE_PRESSURE_BAR),
+                inventory,
+            ),
+            q_init,
+            graphite_init.reshape((1,)),
+            qtot_init,
+            plan.setup.formula_matrix,
+            formula_matrix_cond,
+            plan.setup.gas_setup.hvector_func,
+            graphite_hvector,
+            residual_crit=CONDENSATE_RESIDUAL_TOLERANCE,
+            max_iter=CONDENSATE_MAX_ITERATIONS,
+        )
+        return solved.gas_log_amounts
+
+    active_q = jax.vmap(active_layer)(
+        temperature[active],
+        plan.pressures_bar[active],
+        plan.hybrid_log_amounts_init[active],
+        plan.hybrid_total_log_amounts_init[active],
+        plan.graphite_amounts_init[active],
+    )
+    result = result.at[active].set(active_q)
+
+    inactive = jnp.asarray(plan.inactive_indices, dtype=jnp.int32)
+
+    def inactive_layer(temp, pressure, q_init, qtot_init):
+        return minimize_gibbs(
+            ThermoState(
+                temp,
+                jnp.log(pressure / REFERENCE_PRESSURE_BAR),
+                inventory,
+            ),
+            q_init,
+            qtot_init,
+            plan.setup.formula_matrix,
+            plan.setup.gas_setup.hvector_func,
+            epsilon_crit=GAS_RESIDUAL_TOLERANCE,
+            max_iter=GAS_MAX_ITERATIONS,
+        )
+
+    inactive_q = jax.vmap(inactive_layer)(
+        temperature[inactive],
+        plan.pressures_bar[inactive],
+        plan.gas_only_log_amounts[inactive],
+        plan.gas_only_total_log_amounts[inactive],
+    )
+    return result.at[inactive].set(inactive_q)
+
+
+def co_vmr_profile(
+    plan: GraphiteProfilePlan,
+    temperatures: Any,
+    log_co_scale: Any,
+) -> jax.Array:
+    """Return the CO volume-mixing-ratio profile from the hybrid solver."""
+
+    q = solve_hybrid_log_amounts(plan, temperatures, log_co_scale)
+    log_total = jax.scipy.special.logsumexp(q, axis=1)
+    return jnp.exp(q[:, plan.co_species_index] - log_total)
+
+
+def _prior_corners() -> tuple[tuple[float, float, float], ...]:
+    return tuple(
+        itertools.product(
+            T0_PRIOR_BOUNDS_K,
+            ALPHA_PRIOR_BOUNDS,
+            LOG_CO_SCALE_PRIOR_BOUNDS,
+        )
+    )
+
+
+def preflight_graphite_plan(plan: GraphiteProfilePlan) -> dict[str, Any]:
+    """Check support identity, primal convergence, and reverse-mode gradients."""
+
+    nominal_mask = plan.active_mask
+    condensate_metadata = plan.setup.condensate_setup.metadata or {}
+    graphite_validity = plan.setup.condensate_setup.temperature_validity_upper
+    graphite_temperature_upper = (
+        float(graphite_validity[0])
+        if graphite_validity is not None
+        else float("inf")
+    )
+    corner_rows: list[dict[str, Any]] = []
+    for t0_kelvin, alpha, log_co_scale in _prior_corners():
+        temperature = powerlaw_temperature(
+            plan.pressures_bar, t0_kelvin, alpha
+        )
+        inventory = scale_carbon_and_oxygen(
+            plan.reference_element_vector,
+            plan.carbon_index,
+            plan.oxygen_index,
+            log_co_scale,
+        )
+        inventories = jnp.broadcast_to(
+            inventory,
+            (
+                plan.pressures_bar.shape[0],
+                plan.reference_element_vector.shape[0],
+            ),
+        )
+        (
+            _gas_q,
+            gas_diagnostics,
+            margins,
+            fixed_result,
+            fixed_diagnostics,
+        ) = _audit_graphite_candidate(
+            plan.setup,
+            plan.graphite_species_index,
+            temperature,
+            plan.pressures_bar,
+            inventories,
+            plan.gas_only_log_amounts,
+            plan.gas_only_total_log_amounts,
+            plan.graphite_amounts_init,
+            fixed_gas_log_amounts_init=plan.hybrid_log_amounts_init,
+            fixed_total_log_amounts_init=plan.hybrid_total_log_amounts_init,
+        )
+        amounts = fixed_result.condensate_amounts[:, 0]
+        valid_fixed = (
+            fixed_diagnostics.converged
+            & jnp.isfinite(fixed_diagnostics.residual_norm)
+            & jnp.isfinite(amounts)
+            & (amounts > MIN_ACTIVE_GRAPHITE_AMOUNT)
+        )
+        corner_mask = np.asarray(
+            jax.device_get((margins < 0.0) & valid_fixed), dtype=bool
+        )
+        gas_ok = bool(jnp.all(gas_diagnostics["converged"]))
+        mask_ok = bool(np.array_equal(corner_mask, nominal_mask))
+        valid_fixed_host = np.asarray(jax.device_get(valid_fixed), dtype=bool)
+        active_fixed_ok = bool(np.all(valid_fixed_host[nominal_mask]))
+        fixed_residuals = np.asarray(
+            jax.device_get(fixed_diagnostics.residual_norm), dtype=float
+        )
+        active_residual_max = float(np.max(fixed_residuals[nominal_mask]))
+        active_amount_min = float(
+            np.min(np.asarray(jax.device_get(amounts))[nominal_mask])
+        )
+        inactive_margin_min = float(
+            np.min(np.asarray(jax.device_get(margins))[~nominal_mask])
+        )
+        gas_budget = jnp.einsum(
+            "ek,lk->le",
+            plan.setup.formula_matrix,
+            jnp.exp(fixed_result.gas_log_amounts),
+        )
+        condensate_budget = (
+            fixed_result.condensate_amounts @ plan.setup.formula_matrix_cond.T
+        )
+        budget_residual = gas_budget + condensate_budget - inventories
+        budget_scale = jnp.where(
+            jnp.abs(inventories) > 0.0,
+            jnp.abs(inventories),
+            jnp.ones_like(inventories),
+        )
+        scaled_budget_residual = jnp.max(
+            jnp.abs(budget_residual) / budget_scale,
+            axis=1,
+        )
+        active_budget_residual_max = float(
+            np.max(
+                np.asarray(jax.device_get(scaled_budget_residual))[nominal_mask]
+            )
+        )
+        temperature_valid = bool(
+            jnp.all(temperature <= graphite_temperature_upper)
+        )
+        corner_ok = (
+            gas_ok
+            and mask_ok
+            and active_fixed_ok
+            and active_residual_max <= CONDENSATE_RESIDUAL_TOLERANCE
+            and active_budget_residual_max <= CONDENSATE_RESIDUAL_TOLERANCE
+            and active_amount_min > MIN_ACTIVE_GRAPHITE_AMOUNT
+            and inactive_margin_min > MIN_INACTIVE_DRIVING_MARGIN
+            and temperature_valid
+        )
+        corner_rows.append(
+            {
+                "t0_kelvin": t0_kelvin,
+                "alpha": alpha,
+                "log_co_scale": log_co_scale,
+                "active_indices": np.flatnonzero(corner_mask).tolist(),
+                "gas_converged": gas_ok,
+                "active_fixed_support_converged": active_fixed_ok,
+                "support_matches_nominal": mask_ok,
+                "maximum_active_fixed_support_residual": active_residual_max,
+                "maximum_active_scaled_budget_residual": (
+                    active_budget_residual_max
+                ),
+                "minimum_active_graphite_amount": active_amount_min,
+                "minimum_inactive_driving_margin": inactive_margin_min,
+                "graphite_temperature_valid": temperature_valid,
+                "uses_frozen_nuts_initialization": True,
+                "passed": corner_ok,
+            }
+        )
+
+    def chemistry_summary(t0_kelvin, alpha, log_co_scale):
+        temperature = powerlaw_temperature(
+            plan.pressures_bar, t0_kelvin, alpha
+        )
+        vmr = co_vmr_profile(plan, temperature, log_co_scale)
+        return jnp.sum(jnp.log(jnp.clip(vmr, 1.0e-300)))
+
+    value, gradient = jax.value_and_grad(
+        chemistry_summary, argnums=(0, 1, 2)
+    )(
+        jnp.asarray(TRUTH_T0_K, dtype=jnp.float64),
+        jnp.asarray(TRUTH_ALPHA, dtype=jnp.float64),
+        jnp.asarray(TRUTH_LOG_CO_SCALE, dtype=jnp.float64),
+    )
+    gradient_values = tuple(float(item) for item in gradient)
+    gradient_finite = bool(
+        np.all(np.isfinite(np.asarray(gradient_values, dtype=float)))
+    )
+    report = {
+        "schema": "exogibbs_condensate_fixed_support_nuts_preflight_v1",
+        "case_name": CASE_NAME,
+        "local_fixed_support_contract": True,
+        "condensate_model_scope": CONDENSATE_MODEL_SCOPE,
+        "condensate_catalog_mode": "reduced_explicit",
+        "reduced_condensate_catalog": True,
+        "condensate_catalog_species": [GRAPHITE_SPECIES],
+        "full_fastchem4_condensate_species_count": condensate_metadata.get(
+            "full_fastchem4_condensate_species_count"
+        ),
+        "excluded_condensate_species_count": condensate_metadata.get(
+            "excluded_condensate_species_count"
+        ),
+        "full_catalog_equilibrium_claimed": False,
+        "full_catalog_support_closure_checked": False,
+        "full_fastchem4_catalog_support_closure_checked": False,
+        "differentiates_support_discovery": False,
+        "differentiates_rainout": False,
+        "rainout": False,
+        "carbon_to_oxygen_ratio": CARBON_TO_OXYGEN_RATIO,
+        "graphite_species": GRAPHITE_SPECIES,
+        "layer_count": int(plan.pressures_bar.shape[0]),
+        "active_indices": list(plan.active_indices),
+        "inactive_indices": list(plan.inactive_indices),
+        "prior_bounds": {
+            "t0_kelvin": list(T0_PRIOR_BOUNDS_K),
+            "alpha": list(ALPHA_PRIOR_BOUNDS),
+            "log_co_scale": list(LOG_CO_SCALE_PRIOR_BOUNDS),
+        },
+        "corner_checks": corner_rows,
+        "chemistry_log_co_vmr_sum": float(value),
+        "chemistry_reverse_mode_gradient": {
+            "t0_kelvin": gradient_values[0],
+            "alpha": gradient_values[1],
+            "log_co_scale": gradient_values[2],
+        },
+        "gradient_finite": gradient_finite,
+    }
+    report["passed"] = bool(
+        gradient_finite and all(row["passed"] for row in corner_rows)
+    )
+    if not report["passed"]:
+        failed = [row for row in corner_rows if not row["passed"]]
+        raise RuntimeError(
+            "Fixed-support preflight failed.  The requested layer grid or "
+            "prior box is not local to one graphite support. Failed corners: "
+            f"{failed}"
+        )
+    return report
+
+
+def build_condensate_model(
+    context: Any,
+    plan: GraphiteProfilePlan,
+    observation: Any,
+):
+    """Build the NumPyro model without importing NumPyro at module import."""
+
+    import numpyro
+    import numpyro.distributions as dist
+
+    def model():
+        t0_kelvin = numpyro.sample(
+            "T0",
+            dist.Uniform(*T0_PRIOR_BOUNDS_K),
+        )
+        alpha = numpyro.sample(
+            "alpha",
+            dist.Uniform(*ALPHA_PRIOR_BOUNDS),
+        )
+        log_co_scale = numpyro.sample(
+            "log_co_scale",
+            dist.Uniform(*LOG_CO_SCALE_PRIOR_BOUNDS),
+        )
+        temperature = powerlaw_temperature(
+            plan.pressures_bar, t0_kelvin, alpha
+        )
+        co_vmr = co_vmr_profile(plan, temperature, log_co_scale)
+        raw_flux = co_emission_flux(context, temperature, co_vmr)
+        normalized_flux = raw_flux / observation.flux_scale
+        numpyro.sample(
+            "spectrum",
+            dist.Normal(normalized_flux, observation.noise_std),
+            obs=observation.observed,
+        )
+
+    return model
+
+
+def _json_ready_plan_metadata(plan: GraphiteProfilePlan) -> dict[str, Any]:
+    condensate_metadata = plan.setup.condensate_setup.metadata or {}
+    return {
+        "condensate_model_scope": CONDENSATE_MODEL_SCOPE,
+        "condensate_catalog_mode": "reduced_explicit",
+        "reduced_condensate_catalog": True,
+        "support_species": GRAPHITE_SPECIES,
+        "active_indices": list(plan.active_indices),
+        "inactive_indices": list(plan.inactive_indices),
+        "pressures_bar": np.asarray(plan.pressures_bar, dtype=float).tolist(),
+        "nominal_temperatures_kelvin": np.asarray(
+            plan.nominal_temperatures, dtype=float
+        ).tolist(),
+        "nominal_graphite_inactive_margin": np.asarray(
+            plan.nominal_graphite_driving_margin, dtype=float
+        ).tolist(),
+        "nominal_fixed_support_residual": np.asarray(
+            plan.nominal_fixed_support_residual, dtype=float
+        ).tolist(),
+        "graphite_seed_amount": plan.graphite_seed_amount,
+        "gas_species_count": len(plan.setup.gas_species),
+        "condensate_catalog_count": len(plan.setup.condensate_species),
+        "source_condensate_catalog_count": condensate_metadata.get(
+            "source_condensate_catalog_count"
+        ),
+        "excluded_condensate_species_count": condensate_metadata.get(
+            "excluded_condensate_species_count"
+        ),
+        "full_catalog_equilibrium_claimed": False,
+        "full_catalog_support_closure_checked": False,
+        "element_count": len(plan.setup.elements),
+    }
+
+
+def _preflight_output_path(output_directory: Union[str, Path]) -> Path:
+    output = Path(output_directory)
+    output.mkdir(parents=True, exist_ok=True)
+    return output / f"{CASE_NAME}_preflight.json"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser shared with the gas retrieval demos."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    add_common_cli_arguments(
+        parser,
+        default_output_dir=Path("results") / "vjp_retrieval" / CASE_NAME,
+    )
+    # Eight layers leave a useful gap between the last graphite layer and the
+    # first gas-only layer.  Other grids are allowed only when preflight passes.
+    parser.set_defaults(nlayer=8)
+    parser.add_argument(
+        "--relative-noise",
+        type=float,
+        default=DEFAULT_RELATIVE_NOISE,
+        help="Gaussian mock-noise standard deviation relative to flux scale.",
+    )
+    return parser
+
+
+def _print_preflight_summary(report: Mapping[str, Any], path: Path) -> None:
+    print("Condensate fixed-support preflight passed.")
+    print(f"  graphite-active layers: {report['active_indices']}")
+    print(f"  gas-only layers: {report['inactive_indices']}")
+    print(f"  report: {path}")
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    """Run chemistry preflight and, unless requested otherwise, NUTS."""
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    settings = resolve_run_settings(args)
+    nlayer, nu_points = resolve_demo_shape(args)
+
+    context = None
+    if not args.preflight_only or args.co_database is not None:
+        context = build_spectral_context(
+            args.co_database,
+            nlayer=nlayer,
+            nu_points=nu_points,
+        )
+        pressures = jnp.asarray(context.art.pressure, dtype=jnp.float64)
+    else:
+        pressures = pressure_profile(nlayer)
+
+    plan = prepare_graphite_profile(pressures)
+    preflight = preflight_graphite_plan(plan)
+    preflight["plan"] = _json_ready_plan_metadata(plan)
+    if args.relative_noise <= 0.0:
+        raise ValueError("--relative-noise must be positive.")
+    if context is None:
+        preflight_path = _preflight_output_path(args.output_dir)
+        preflight_path.write_text(
+            json.dumps(preflight, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        _print_preflight_summary(preflight, preflight_path)
+        return
+
+    truth_temperature = powerlaw_temperature(
+        plan.pressures_bar, TRUTH_T0_K, TRUTH_ALPHA
+    )
+    truth_co_vmr = co_vmr_profile(
+        plan, truth_temperature, TRUTH_LOG_CO_SCALE
+    )
+    truth_flux = co_emission_flux(
+        context, truth_temperature, truth_co_vmr
+    )
+    observation = make_mock_observation(
+        truth_flux,
+        seed=settings.seed,
+        relative_noise=args.relative_noise,
+    )
+
+    def spectral_loss(t0_kelvin, alpha, log_co_scale):
+        temperature = powerlaw_temperature(
+            plan.pressures_bar, t0_kelvin, alpha
+        )
+        co_vmr = co_vmr_profile(plan, temperature, log_co_scale)
+        prediction = co_emission_flux(context, temperature, co_vmr)
+        prediction = prediction / observation.flux_scale
+        return jnp.mean(jnp.square(prediction - observation.observed))
+
+    spectral_loss_value, spectral_gradient = jax.value_and_grad(
+        spectral_loss, argnums=(0, 1, 2)
+    )(
+        jnp.asarray(TRUTH_T0_K, dtype=jnp.float64),
+        jnp.asarray(TRUTH_ALPHA, dtype=jnp.float64),
+        jnp.asarray(TRUTH_LOG_CO_SCALE, dtype=jnp.float64),
+    )
+    spectral_gradient_values = tuple(float(value) for value in spectral_gradient)
+    if not np.isfinite(float(spectral_loss_value)) or not np.all(
+        np.isfinite(np.asarray(spectral_gradient_values))
+    ):
+        raise RuntimeError(
+            "Reverse-mode ExoJAX spectrum preflight produced non-finite values."
+        )
+    preflight["spectral_loss"] = float(spectral_loss_value)
+    preflight["spectral_reverse_mode_gradient"] = {
+        "t0_kelvin": spectral_gradient_values[0],
+        "alpha": spectral_gradient_values[1],
+        "log_co_scale": spectral_gradient_values[2],
+    }
+    preflight_path = _preflight_output_path(args.output_dir)
+    preflight_path.write_text(
+        json.dumps(preflight, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    _print_preflight_summary(preflight, preflight_path)
+    if args.preflight_only:
+        write_run_outputs(
+            args.output_dir,
+            case_name=CASE_NAME,
+            context=context,
+            observation=observation,
+            metadata={"preflight": preflight},
+        )
+        return
+
+    model = build_condensate_model(context, plan, observation)
+    mcmc = run_reverse_mode_nuts(model, observation, settings)
+    write_run_outputs(
+        args.output_dir,
+        case_name=CASE_NAME,
+        context=context,
+        observation=observation,
+        mcmc=mcmc,
+        metadata={
+            "preflight": preflight,
+            "contract": (
+                "Reduced FastChem4-gas plus C(s)-only condensate model. Local "
+                "fixed support only; full-catalog phase closure, support "
+                "discovery, phase transitions, production lifecycle, and "
+                "rainout are outside AD."
+            ),
+        },
+    )
+    print(f"{CASE_NAME}: completed; outputs: {args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/retrievals/exojax_nuts_gas_grid.py
+++ b/examples/retrievals/exojax_nuts_gas_grid.py
@@ -1,0 +1,19 @@
+"""ExoJAX NUTS retrieval through the gas VJP with a grid initializer.
+
+The likelihood, priors, mock data, and reverse-mode NUTS settings are shared
+with ``exojax_nuts_gas_no_grid.py``.  The only algorithmic difference is the
+packaged FastChem ``GridEquilibriumInitializer`` supplied to each gas solve.
+The custom VJP stops initialization gradients, so converged spectra and
+posterior derivatives should agree while the primal iteration count drops.
+"""
+
+from _exojax_nuts_common import run_gas_demo
+
+
+if __name__ == "__main__":
+    raise SystemExit(
+        run_gas_demo(
+            use_grid_initializer=True,
+            case_name="gas_grid",
+        )
+    )

--- a/examples/retrievals/exojax_nuts_gas_no_grid.py
+++ b/examples/retrievals/exojax_nuts_gas_no_grid.py
@@ -1,0 +1,18 @@
+"""ExoJAX NUTS retrieval through the gas-equilibrium VJP, without a grid.
+
+This is the direct analogue of the retrieval section in ExoJAX's
+``equilibrium_chemistry.ipynb``: every atmospheric layer starts from the
+default uniform gas initialization.  Use ``--preflight-only`` before a long
+GPU run and ``--quick`` for a short end-to-end exercise.
+"""
+
+from _exojax_nuts_common import run_gas_demo
+
+
+if __name__ == "__main__":
+    raise SystemExit(
+        run_gas_demo(
+            use_grid_initializer=False,
+            case_name="gas_no_grid",
+        )
+    )

--- a/tests/unittests/equilibrium/condensate/fixed_support/zero_barrier_test.py
+++ b/tests/unittests/equilibrium/condensate/fixed_support/zero_barrier_test.py
@@ -414,27 +414,41 @@ def test_reduced_log_fallback_branches_layer_839_trace_support() -> None:
 
     assert result.accepted
     assert result.support_indices == (0,)
-    assert result.report["selected_numerical_formulation"] == (
-        "reduced_log_domain_support_search"
-    )
-    assert linear_supports == ((0, 1), (1,), ())
-    assert all(
-        amount < 0.0
-        for amount in result.report["attempts"][0][
-            "active_condensate_amounts"
-        ]
-    )
-    assert fallback["accepted"]
-    assert fallback["visited_supports"] == ((0, 1), (1,), (0,))
-    assert tuple(node["accepted"] for node in fallback["nodes"]) == (
-        False,
-        False,
-        True,
-    )
-    assert all(
-        not node["solve"]["greedy_drop_enabled"]
-        for node in fallback["nodes"]
-    )
+    selected = result.report["selected_numerical_formulation"]
+    # BLAS-level differences can reverse the order of two negative amounts
+    # near 1e-27.  Either route is valid if its own audit and closure pass.
+    assert selected in {
+        "capacity_scaled_linear_amounts",
+        "reduced_log_domain_support_search",
+    }
+    assert linear_supports[0] == (0, 1)
+    if selected == "reduced_log_domain_support_search":
+        assert linear_supports == ((0, 1), (1,), ())
+        assert all(
+            amount < 0.0
+            for amount in result.report["attempts"][0][
+                "active_condensate_amounts"
+            ]
+        )
+        assert fallback["accepted"]
+        assert fallback["visited_supports"] == ((0, 1), (1,), (0,))
+        assert tuple(node["accepted"] for node in fallback["nodes"]) == (
+            False,
+            False,
+            True,
+        )
+        assert all(
+            not node["solve"]["greedy_drop_enabled"]
+            for node in fallback["nodes"]
+        )
+    else:
+        assert linear_supports[-1] == (0,)
+        assert result.report["linear_amount_physical_audit"]["accepted"]
+        assert not fallback["attempted"]
+        assert not fallback["accepted"]
+        assert fallback["skip_reason"] == (
+            "linear_amount_physical_audit_accepted"
+        )
     assert reconstructed == pytest.approx(target, rel=1.0e-12)
     assert gas_inventory[1] / target[1] == pytest.approx(
         0.7947931234846488,
@@ -443,6 +457,42 @@ def test_reduced_log_fallback_branches_layer_839_trace_support() -> None:
     assert result.condensate_amounts[0] > 0.0
     assert result.condensate_amounts[1] == 0.0
     assert result.report["full_condensate_driving"][1] > 0.0
+
+    # Exercise the breadth-first fallback independently of the linear route.
+    branched = _solve_reduced_log_domain_support_branches(
+        gas_formula_matrix=gas_formula,
+        condensate_formula_matrix_full=condensate_formula,
+        target_inventory=target,
+        gas_standard_source=gamma,
+        condensate_standard_source_full=hcond,
+        gas_log_amounts_init=np.log(gas_init),
+        condensate_amounts_init=np.asarray(
+            [0.5 * target[1], 0.25 * target[1]],
+            dtype=np.float64,
+        ),
+        total_gas_log_amount_init=float(np.log(np.sum(gas_init))),
+        element_potential_init=np.zeros(3, dtype=np.float64),
+        support_indices=(0, 1),
+        condensate_valid_mask=np.ones(2, dtype=bool),
+        budget_scale=np.reciprocal(target),
+        stationarity_tolerance=1.0e-8,
+        budget_tolerance=1.0e-8,
+        total_density_tolerance=1.0e-8,
+        support_closure_tolerance=1.0e-8,
+        max_function_evaluations=400,
+    )
+    branch_report = branched["report"]
+
+    assert branched["accepted"]
+    assert branched["candidate"]["support_indices"] == (0,)
+    assert branch_report["visited_supports"] == ((0, 1), (1,), (0,))
+    assert tuple(
+        node["accepted"] for node in branch_report["nodes"]
+    ) == (False, False, True)
+    assert all(
+        not node["solve"]["greedy_drop_enabled"]
+        for node in branch_report["nodes"]
+    )
 
 
 def test_reduced_log_support_rejects_active_phase_at_amount_floor() -> None:

--- a/tests/unittests/examples/vjp_retrieval_common_test.py
+++ b/tests/unittests/examples/vjp_retrieval_common_test.py
@@ -1,0 +1,105 @@
+"""Dependency-light contracts for the shared gas VJP retrieval demos."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+from pathlib import Path
+import sys
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+EXAMPLE_DIRECTORY = REPOSITORY_ROOT / "examples" / "retrievals"
+COMMON_PATH = EXAMPLE_DIRECTORY / "_exojax_nuts_common.py"
+
+
+def _load_common():
+    spec = importlib.util.spec_from_file_location(
+        "exogibbs_vjp_retrieval_common_test_module",
+        COMMON_PATH,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def common():
+    return _load_common()
+
+
+def test_database_guard_requires_complete_local_sources(common, tmp_path):
+    database = tmp_path / "CO" / "12C-16O" / "Li2015"
+    database.mkdir(parents=True)
+    prefix = "12C-16O__Li2015"
+
+    with pytest.raises(FileNotFoundError, match="offline demo"):
+        common.require_local_co_database(database)
+
+    for suffix in (".def", ".pf", ".states.bz2", ".trans.bz2"):
+        (database / f"{prefix}{suffix}").write_text("local fixture\n")
+
+    assert common.require_local_co_database(database) == database.resolve()
+
+
+def test_mock_observation_is_normalized_and_deterministic(common):
+    flux = jnp.asarray([2.0, 4.0, 6.0, 8.0])
+    first = common.make_mock_observation(
+        flux,
+        seed=3,
+        relative_noise=1.0e-3,
+    )
+    second = common.make_mock_observation(
+        flux,
+        seed=3,
+        relative_noise=1.0e-3,
+    )
+
+    assert float(first.flux_scale) == pytest.approx(5.0)
+    np.testing.assert_allclose(first.truth, flux / 5.0)
+    np.testing.assert_allclose(first.observed, second.observed)
+
+
+def test_quick_mode_bounds_sampling_and_problem_shape(common):
+    args = argparse.Namespace(
+        num_warmup=500,
+        num_samples=1000,
+        max_tree_depth=10,
+        seed=7,
+        no_progress_bar=True,
+        quick=True,
+        nlayer=24,
+        nu_points=1024,
+    )
+
+    settings = common.resolve_run_settings(args)
+
+    assert settings.num_warmup == 5
+    assert settings.num_samples == 10
+    assert settings.max_tree_depth == 4
+    assert not settings.progress_bar
+    assert common.resolve_demo_shape(args) == (8, 256)
+
+
+def test_gas_wrappers_differ_only_in_initializer_selection():
+    no_grid = (
+        EXAMPLE_DIRECTORY / "exojax_nuts_gas_no_grid.py"
+    ).read_text(encoding="utf-8")
+    grid = (
+        EXAMPLE_DIRECTORY / "exojax_nuts_gas_grid.py"
+    ).read_text(encoding="utf-8")
+    common_source = COMMON_PATH.read_text(encoding="utf-8")
+
+    assert "use_grid_initializer=False" in no_grid
+    assert "use_grid_initializer=True" in grid
+    assert "forward_mode_differentiation=False" in common_source
+    assert "initializer=initializer" in common_source
+    assert "return_diagnostics=True" in common_source
+    assert "jax.value_and_grad" in common_source

--- a/tests/unittests/examples/vjp_retrieval_condensate_test.py
+++ b/tests/unittests/examples/vjp_retrieval_condensate_test.py
@@ -1,0 +1,234 @@
+"""Focused, dependency-light tests for the condensate NUTS example."""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from exogibbs.equilibrium.condensate.fixed_support.types import (
+    DifferentiableFixedSupportResult,
+)
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+EXAMPLE_PATH = (
+    REPOSITORY_ROOT
+    / "examples"
+    / "retrievals"
+    / "exojax_nuts_condensate_fixed_support.py"
+)
+
+
+@pytest.fixture(scope="module")
+def condensate_example():
+    spec = importlib.util.spec_from_file_location(
+        "exojax_nuts_condensate_fixed_support_test_module",
+        EXAMPLE_PATH,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_example_is_main_guarded_and_states_local_contract():
+    source = EXAMPLE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(EXAMPLE_PATH))
+
+    compile(source, str(EXAMPLE_PATH), "exec")
+    assert "minimize_gibbs_fixed_support" in source
+    assert "minimize_gibbs(" in source
+    assert "does not differentiate" in source
+    assert "rainout" in source
+    assert "C/O = 2" in source
+    assert "full-catalog equilibrium is not supported" in source
+    assert "fixed_gas_log_amounts_init=plan.hybrid_log_amounts_init" in source
+
+    guarded_main = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.If)
+        and isinstance(node.test, ast.Compare)
+        and any(
+            isinstance(statement, ast.Expr)
+            and isinstance(statement.value, ast.Call)
+            and isinstance(statement.value.func, ast.Name)
+            and statement.value.func.id == "main"
+            for statement in node.body
+        )
+    ]
+    assert len(guarded_main) == 1
+
+
+def test_pressure_and_temperature_profiles_match_exojax_convention(
+    condensate_example,
+):
+    module = condensate_example
+    pressure = module.pressure_profile(8)
+    temperature = module.powerlaw_temperature(pressure, 1160.0, 0.03)
+
+    np.testing.assert_allclose(pressure, np.logspace(-3.0, 1.0, 8))
+    np.testing.assert_allclose(temperature, 1160.0 * pressure**0.03)
+    assert float(pressure[0]) == pytest.approx(1.0e-3)
+    assert float(pressure[-1]) == pytest.approx(10.0)
+    assert bool(jnp.all(jnp.diff(pressure) > 0.0))
+
+
+def test_carbon_oxygen_scale_is_ratio_preserving_and_differentiable(
+    condensate_example,
+):
+    module = condensate_example
+    reference = jnp.asarray([2.0, 1.0, 7.0])
+
+    def total(log_scale):
+        scaled = module.scale_carbon_and_oxygen(
+            reference,
+            carbon_index=0,
+            oxygen_index=1,
+            log_co_scale=log_scale,
+        )
+        return jnp.sum(scaled[:2])
+
+    scaled = module.scale_carbon_and_oxygen(reference, 0, 1, 0.25)
+    gradient = jax.grad(total)(0.0)
+
+    assert float(scaled[0] / scaled[1]) == pytest.approx(2.0)
+    assert float(gradient) == pytest.approx(3.0 * np.log(10.0))
+
+
+def test_condensate_model_declares_a_graphite_only_reduced_catalog(
+    condensate_example,
+):
+    module = condensate_example
+    setup = module.graphite_only_chemical_setup()
+    metadata = setup.condensate_setup.metadata
+
+    assert setup.condensate_species == (module.GRAPHITE_SPECIES,)
+    assert setup.formula_matrix_cond.shape[1] == 1
+    assert metadata["model_scope"] == module.CONDENSATE_MODEL_SCOPE
+    assert metadata["condensate_catalog_mode"] == "reduced_explicit"
+    assert metadata["reduced_condensate_catalog"] is True
+    assert metadata["source_condensate_catalog_count"] > 1
+    assert metadata["excluded_condensate_species_count"] == (
+        metadata["source_condensate_catalog_count"] - 1
+    )
+    assert metadata["full_catalog_equilibrium_claimed"] is False
+    assert metadata["full_catalog_support_closure_checked"] is False
+    assert setup.condensate_setup.temperature_validity_upper == (6000.0,)
+    assert metadata["temperature_validity_upper"] == (6000.0,)
+    assert np.asarray(setup.condensate_setup.hvector_func(1160.0)).shape == (1,)
+
+
+def test_hybrid_solver_uses_static_condensate_and_gas_partitions(
+    condensate_example,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    module = condensate_example
+    setup = SimpleNamespace(
+        formula_matrix=jnp.eye(2),
+        formula_matrix_cond=jnp.asarray([[1.0], [0.0]]),
+        gas_setup=SimpleNamespace(
+            hvector_func=lambda temperature: jnp.zeros((2,)),
+        ),
+        condensate_setup=SimpleNamespace(
+            hvector_func=lambda temperature: jnp.zeros((1,)),
+        ),
+    )
+    q_init = jnp.zeros((3, 2))
+    plan = module.GraphiteProfilePlan(
+        setup=setup,
+        pressures_bar=jnp.asarray([0.1, 1.0, 10.0]),
+        nominal_temperatures=jnp.asarray([1000.0, 1100.0, 1200.0]),
+        reference_element_vector=jnp.asarray([2.0, 1.0]),
+        carbon_index=0,
+        oxygen_index=1,
+        co_species_index=0,
+        graphite_species_index=0,
+        active_indices=(0,),
+        inactive_indices=(1, 2),
+        gas_only_log_amounts=q_init,
+        gas_only_total_log_amounts=jnp.zeros((3,)),
+        hybrid_log_amounts_init=q_init,
+        hybrid_total_log_amounts_init=jnp.zeros((3,)),
+        graphite_amounts_init=jnp.ones((3,)),
+        graphite_seed_amount=1.0e-3,
+        nominal_graphite_driving_margin=jnp.zeros((3,)),
+        nominal_fixed_support_residual=jnp.zeros((3,)),
+    )
+
+    def fake_fixed_support(
+        state,
+        gas_log_amounts_init,
+        condensate_amounts_init,
+        total_gas_log_amount_init,
+        gas_formula_matrix,
+        condensate_formula_matrix,
+        gas_hvector_func,
+        condensate_hvector_func,
+        **kwargs,
+    ):
+        del (
+            state,
+            total_gas_log_amount_init,
+            gas_formula_matrix,
+            condensate_formula_matrix,
+            gas_hvector_func,
+            condensate_hvector_func,
+            kwargs,
+        )
+        return DifferentiableFixedSupportResult(
+            gas_log_amounts=gas_log_amounts_init + 10.0,
+            condensate_amounts=condensate_amounts_init,
+        )
+
+    def fake_gas(
+        state,
+        gas_log_amounts_init,
+        total_gas_log_amount_init,
+        gas_formula_matrix,
+        gas_hvector_func,
+        **kwargs,
+    ):
+        del (
+            state,
+            total_gas_log_amount_init,
+            gas_formula_matrix,
+            gas_hvector_func,
+            kwargs,
+        )
+        return gas_log_amounts_init + 20.0
+
+    monkeypatch.setattr(
+        module, "minimize_gibbs_fixed_support", fake_fixed_support
+    )
+    monkeypatch.setattr(module, "minimize_gibbs", fake_gas)
+
+    result = module.solve_hybrid_log_amounts(
+        plan,
+        jnp.asarray([1000.0, 1100.0, 1200.0]),
+        0.0,
+    )
+
+    np.testing.assert_allclose(result[0], np.full((2,), 10.0))
+    np.testing.assert_allclose(result[1:], np.full((2, 2), 20.0))
+
+
+def test_condensate_cli_defaults_to_preflighted_eight_layer_grid(
+    condensate_example,
+):
+    args = condensate_example.build_parser().parse_args(["--preflight-only"])
+
+    assert args.preflight_only
+    assert args.nlayer == 8
+    assert args.co_database is None
+    assert "vjp_retrieval" in str(args.output_dir)


### PR DESCRIPTION
## Motivation

ExoGibbs provides custom VJPs for gas equilibrium and fixed-support condensate equilibrium, but the repository did not yet include an end-to-end ExoJAX/NUTS demonstration of those gradients.

## What changed

- add executable ExoJAX emission-retrieval demos for gas equilibrium with and without the packaged grid initializer
- add an experimental graphite-only fixed-support condensate retrieval that combines condensate and gas VJPs across a frozen layer partition
- add shared offline database validation, mock-spectrum generation, reverse-mode NUTS, preflight checks, and output helpers
- add a CUDA/tcsh launcher for preflight and production-sized demo runs
- add notebook sources and generated RST tutorials, including reference GPU results
- add deterministic unit tests for the shared runner and condensate preflight contracts

## User impact

Users can now follow runnable examples showing how ExoGibbs equilibrium VJPs enter an ExoJAX likelihood sampled with reverse-mode NumPyro NUTS. The grid-initialized gas example documents an 18.28x reference-run speedup while preserving the converged spectrum, VJP, and posterior.

The condensate example is intentionally local and reduced: it uses eight layers, a graphite-only condensate catalog, frozen support and warm starts, and does not claim full-catalog phase closure, support discovery, phase transitions, or rainout inside AD.

## Validation

- `pytest -q tests/unittests/examples` — 10 passed
- notebook-to-RST converter `--check` — passed
- strict Docutils parsing for all three generated RST tutorials — passed
- `csh -n benchmarks/vjp_retrieval/run_exojax_nuts_gpu.csh` — passed
- reference CUDA runs completed for gas no-grid, gas grid, and graphite fixed-support cases with zero divergences
