### PR TITLE
equilibrium: add condensate grid initializer

### DIFF
--- a/benchmarks/vjp_retrieval/README.md
+++ b/benchmarks/vjp_retrieval/README.md
@@ -1,13 +1,16 @@
 # ExoJAX NUTS VJP GPU runs
 
 `run_exojax_nuts_gpu.csh` is a scheduler-independent tcsh launcher for the
-three retrieval demonstrations:
+four retrieval demonstrations:
 
 - `gas_no_grid`: gas equilibrium with the default initialization;
 - `gas_grid`: the same model with `GridEquilibriumInitializer`;
 - `condensate_fixed_support`: a locally differentiable, fixed-support model
   with the full FastChem4 gas catalog but an explicit `C(s)`-only reduced
-  condensate catalog.
+  condensate catalog;
+- `condensate_grid`: the same fixed-support model with a shared gas-only grid
+  and one local fixed-graphite grid per active layer supplying runtime initial
+  values at every NUTS evaluation.
 
 ExoJAX, NumPyro, and a CUDA-enabled JAX installation are optional runtime
 dependencies and are not installed by ExoGibbs itself. The demos were
@@ -41,17 +44,29 @@ production job:
 
 ```tcsh
 benchmarks/vjp_retrieval/run_exojax_nuts_gpu.csh \
-  condensate_fixed_support /data/exojax/CO/12C-16O/Li2015 --quick
+  condensate_grid /data/exojax/CO/12C-16O/Li2015 --quick
 ```
 
 The quick configuration is only an end-to-end smoke test. Its five warmup
 steps are too few for scientific inference; in particular, short gas-case
 runs can consist entirely of divergent transitions.
 
-The condensate case demonstrates the fixed-support VJP mechanics only. It
-does not claim equilibrium or support closure against the other FastChem4
-condensates. Full-catalog support discovery and its production-scale NUTS
-practicality require a separate A100 study.
+The condensate cases demonstrate the fixed-support VJP mechanics only. They
+do not claim equilibrium or support closure against the other FastChem4
+condensates. Each active layer has a local singleton-pressure grid that stores
+converged fixed-support gas states and graphite amounts for the retrieval's
+exact C/O composition rule and interpolates them together at runtime. Inactive
+layers use a shared canonical uniform-metals physical-metallicity grid, which
+is an approximate initialization source for the sampled C/O-only inventory.
+Only the nominal support and layer partition remain frozen. At all eight prior
+corners, the frozen baseline must converge, the grid and baseline CO VMR
+profiles must agree, and the grid must not increase the maximum fixed-support
+iteration count. The grid-side reverse-mode gradient is checked for
+finiteness at the truth point; no second baseline gradient is computed. Grid
+construction happens before NUTS and its time is recorded separately. No
+speedup should be inferred without comparing both cases on the same hardware.
+Full-catalog support discovery and its production-scale NUTS practicality
+require a separate study.
 
 Outputs are written under `results/vjp_retrieval/<case>/`, which is ignored by
 Git. Set `EXOGIBBS_VJP_OUTPUT_ROOT` to choose a different output root. The

--- a/benchmarks/vjp_retrieval/run_exojax_nuts_gpu.csh
+++ b/benchmarks/vjp_retrieval/run_exojax_nuts_gpu.csh
@@ -9,7 +9,7 @@ endif
 
 if ( $#argv < 1 ) then
   echo "usage: $0 CASE [CO_DATABASE] [demo options]"
-  echo "CASE: gas_no_grid | gas_grid | condensate_fixed_support"
+  echo "CASE: gas_no_grid | gas_grid | condensate_fixed_support | condensate_grid"
   echo "CO_DATABASE may instead be set with EXOJAX_CO_DATABASE."
   exit 2
 endif
@@ -26,9 +26,12 @@ case gas_grid:
 case condensate_fixed_support:
   set RUNNER = examples/retrievals/exojax_nuts_condensate_fixed_support.py
   breaksw
+case condensate_grid:
+  set RUNNER = examples/retrievals/exojax_nuts_condensate_grid.py
+  breaksw
 default:
   echo "ERROR: unknown CASE '$CASE_NAME'"
-  echo "expected gas_no_grid, gas_grid, or condensate_fixed_support"
+  echo "expected gas_no_grid, gas_grid, condensate_fixed_support, or condensate_grid"
   exit 2
 endsw
 
@@ -92,9 +95,12 @@ echo "case:        $CASE_NAME"
 echo "runner:      $RUNNER"
 echo "CO database: $CO_DATABASE"
 echo "output:      $OUTDIR"
-if ( "$CASE_NAME" == "condensate_fixed_support" ) then
+if ( "$CASE_NAME" == "condensate_fixed_support" || "$CASE_NAME" == "condensate_grid" ) then
   echo "model:       FastChem4 gas + reduced C(s)-only condensate catalog"
   echo "             (not full-catalog condensate equilibrium)"
+endif
+if ( "$CASE_NAME" == "condensate_grid" ) then
+  echo "initializer: runtime FastChem4 fixed-support condensate grids"
 endif
 date
 

--- a/documents/index.rst
+++ b/documents/index.rst
@@ -42,6 +42,7 @@ Contents
    ipynb/exojax_nuts_gas_no_grid
    ipynb/exojax_nuts_gas_grid
    ipynb/exojax_nuts_condensate_fixed_support
+   ipynb/exojax_nuts_condensate_grid
 
 .. toctree::
    :maxdepth: 1

--- a/documents/ipynb/convert_vjp_retrieval_notebooks.py
+++ b/documents/ipynb/convert_vjp_retrieval_notebooks.py
@@ -27,6 +27,7 @@ NOTEBOOK_STEMS = (
     "exojax_nuts_gas_no_grid",
     "exojax_nuts_gas_grid",
     "exojax_nuts_condensate_fixed_support",
+    "exojax_nuts_condensate_grid",
 )
 GENERATED_HEADER = (
     ".. This file is generated from the sibling .ipynb by "

--- a/documents/ipynb/exojax_nuts_condensate_grid.ipynb
+++ b/documents/ipynb/exojax_nuts_condensate_grid.ipynb
@@ -1,0 +1,323 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "title",
+   "metadata": {},
+   "source": [
+    "# ExoJAX NUTS with the condensate VJP: grid initialization"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "overview",
+   "metadata": {},
+   "source": [
+    "This tutorial is the grid-initialized counterpart to `exojax_nuts_condensate_fixed_support`. The executable source is `examples/retrievals/exojax_nuts_condensate_grid.py`; it shares the carbon-rich C/O = 2 chemistry, narrow priors, deterministic mock spectrum, frozen graphite support, and reverse-mode NUTS settings with `examples/retrievals/exojax_nuts_condensate_fixed_support.py`. The runtime solver uses one local fixed-support graphite grid per active layer and one shared gas-equilibrium grid for inactive layers.\n",
+    "\n",
+    "For each active layer, its `FixedSupportCondensateEquilibriumGrid` stores converged fixed-support states: gas log amounts, the gas total, and the graphite amount. The corresponding `GridCondensateEquilibriumInitializer` interpolates all three values at the same coordinate. Only the graphite support and active/inactive layer partition are frozen from the nominal calculation; the graphite amount used to initialize each runtime solve is interpolated dynamically. The inactive layers use the separate shared gas grid. Before sampling, all eight prior corners must retain the nominal support, the frozen baseline must converge, the grid and baseline CO VMR profiles must agree, and the grid must not increase the maximum fixed-support iteration count. The grid-side reverse-mode gradient must be finite at the truth point.\n",
+    "\n",
+    "This remains a local fixed-support demonstration with the full FastChem4 gas catalog and an explicit reduced condensate catalog containing only `C(s)`. It does not differentiate support discovery, phase transitions, the production condensate lifecycle, or rainout, and it makes no full-catalog phase-stability or support-closure claim."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "grid-heading",
+   "metadata": {},
+   "source": [
+    "## Precompute the gas and fixed-support grids\n",
+    "\n",
+    "First, `prepare_graphite_profile` discovers and certifies the nominal graphite support without a grid. The grid helper then constructs one `FixedSupportCondensateEquilibriumGrid` per active layer. Each local grid uses that layer's four prior-corner temperatures, a singleton pressure axis at the fixed layer pressure, and three composition points. Keeping the active grids local avoids evaluating a rectangular cross-product of temperatures and pressures whose off-layer points need not retain graphite support. Each local grid is wrapped in `GridCondensateEquilibriumInitializer`. A small example-level composite keeps those initializers together with the shared canonical gas-grid initializer used by inactive layers. Grid construction is completed before inference, and its wall time is returned separately from NUTS timing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "grid-build",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataclasses import replace\n",
+    "\n",
+    "from jax import config\n",
+    "config.update(\"jax_enable_x64\", True)\n",
+    "\n",
+    "import jax\n",
+    "import jax.numpy as jnp\n",
+    "\n",
+    "from examples.retrievals.exojax_nuts_condensate_fixed_support import (\n",
+    "    TRUTH_ALPHA,\n",
+    "    TRUTH_LOG_CO_SCALE,\n",
+    "    TRUTH_T0_K,\n",
+    "    build_graphite_grid_initializer,\n",
+    "    co_vmr_profile,\n",
+    "    graphite_only_chemical_setup,\n",
+    "    interpolate_graphite_grid_initial_values,\n",
+    "    powerlaw_temperature,\n",
+    "    preflight_graphite_plan,\n",
+    "    prepare_graphite_profile,\n",
+    "    pressure_profile,\n",
+    "    scale_carbon_and_oxygen,\n",
+    ")\n",
+    "\n",
+    "pressures_bar = pressure_profile(8)\n",
+    "chemistry = graphite_only_chemical_setup()\n",
+    "base_plan = prepare_graphite_profile(pressures_bar, setup=chemistry)\n",
+    "grid_initializer, grid_build_seconds = build_graphite_grid_initializer(\n",
+    "    base_plan\n",
+    ")\n",
+    "plan = replace(\n",
+    "    base_plan,\n",
+    "    grid_initializer=grid_initializer,\n",
+    "    grid_build_seconds=grid_build_seconds,\n",
+    ")\n",
+    "gas_grid = grid_initializer.gas_initializer.grid\n",
+    "fixed_grids = tuple(\n",
+    "    initializer.grid\n",
+    "    for initializer in grid_initializer.fixed_initializers\n",
+    ")\n",
+    "(\n",
+    "    gas_grid.outputs.ln_n.shape,\n",
+    "    tuple(grid.gas_grid.outputs.ln_n.shape for grid in fixed_grids),\n",
+    "    tuple(grid.condensate_amounts.shape for grid in fixed_grids),\n",
+    "    grid_build_seconds,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "composition-coordinate",
+   "metadata": {},
+   "source": [
+    "The two grid paths use different composition constructions. Each active-layer local fixed-support grid is built with `scale_carbon_and_oxygen`, exactly the elemental-inventory map used inside NUTS: carbon and oxygen are scaled together while C/O remains two. Its stored gas log amounts, gas total, and graphite amount are therefore converged states for the retrieval's composition family. The shared gas grid reuses `build_equilibrium_grid` and its canonical physical-`log10(Z/Zsun)` coordinate, which uniformly scales metals. For the retrieval's C/O-only sampled inventory, that shared grid supplies an approximate numerical seed. The gas-only equilibrium kernel still receives the exact sampled elemental vector and determines the converged physical state from it."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "support-heading",
+   "metadata": {},
+   "source": [
+    "## Freeze and certify graphite support\n",
+    "\n",
+    "The base plan freezes only the nominal graphite support and the resulting active/inactive layer partition. It does not freeze the graphite amount used by the grid-enabled runtime solver. `preflight_graphite_plan` checks all eight corners of the three-parameter prior box with the same lookup path used during NUTS: the support must match the nominal mask, the frozen-baseline solves must converge, and the grid and baseline CO VMR profiles must agree. At every corner, the grid-initialized maximum fixed-support iteration count must also be no greater than the frozen-baseline count. Separately, the preflight checks that the grid-side reverse-mode gradient is finite at the truth point; it does not compute a second baseline gradient. The corner iteration assertion checks the intended initialization behavior but is not a wall-time speedup claim."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "support-preflight",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "preflight = preflight_graphite_plan(\n",
+    "    plan, case_name=\"condensate_grid\"\n",
+    ")\n",
+    "(\n",
+    "    preflight[\"passed\"],\n",
+    "    preflight[\"active_indices\"],\n",
+    "    preflight[\"inactive_indices\"],\n",
+    "    preflight[\"gradient_finite\"],\n",
+    "    preflight[\"grid_no_grid_equivalence\"],\n",
+    "    preflight[\"grid_bounds\"],\n",
+    "    preflight[\"grid_build_seconds\"],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "runtime-heading",
+   "metadata": {},
+   "source": [
+    "## Interpolate at every NUTS evaluation\n",
+    "\n",
+    "For each sampled temperature profile and elemental vector, every active layer interpolates the converged gas log amounts, gas total, and graphite amount together from its corresponding local fixed-support grid. Those three dynamically selected values initialize the fixed-support condensate kernel. Inactive layers interpolate gas log amounts and the gas total from the shared gas grid and pass them to the gas-only kernel. The nominal support mask only selects which lookup and solver each layer uses."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "runtime-lookup",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "temperature = powerlaw_temperature(\n",
+    "    plan.pressures_bar, TRUTH_T0_K, TRUTH_ALPHA\n",
+    ")\n",
+    "inventory = scale_carbon_and_oxygen(\n",
+    "    plan.reference_element_vector,\n",
+    "    plan.carbon_index,\n",
+    "    plan.oxygen_index,\n",
+    "    TRUTH_LOG_CO_SCALE,\n",
+    ")\n",
+    "initial_values = interpolate_graphite_grid_initial_values(\n",
+    "    plan, temperature, inventory\n",
+    ")\n",
+    "(\n",
+    "    initial_values.gas_log_amounts.shape,\n",
+    "    initial_values.fixed_gas_log_amounts.shape,\n",
+    "    initial_values.graphite_amounts.shape,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "vjp-heading",
+   "metadata": {},
+   "source": [
+    "## Reverse-mode check\n",
+    "\n",
+    "The gas and fixed-support custom VJPs stop gradients through all numerical initialization values, including the interpolated graphite amount. Grid values can depend on the sampled parameters in the forward pass, but posterior derivatives are implicit derivatives of the converged equilibrium state, not derivatives through the initializer. Support remains a static, nondifferentiable contract. The preflight checks the grid-side gradient for finiteness at the truth point. It does not repeat the gradient calculation for the frozen baseline; the eight corners are used for baseline convergence, CO VMR primal equivalence, support, and iteration checks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "grid-vjp",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def chemistry_summary(t0_kelvin, alpha, log_co_scale):\n",
+    "    temperatures = powerlaw_temperature(\n",
+    "        plan.pressures_bar, t0_kelvin, alpha\n",
+    "    )\n",
+    "    co_vmr = co_vmr_profile(plan, temperatures, log_co_scale)\n",
+    "    return jnp.sum(jnp.log(jnp.clip(co_vmr, 1.0e-300)))\n",
+    "\n",
+    "summary, gradient = jax.value_and_grad(\n",
+    "    chemistry_summary, argnums=(0, 1, 2)\n",
+    ")(TRUTH_T0_K, TRUTH_ALPHA, TRUTH_LOG_CO_SCALE)\n",
+    "summary, gradient"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nuts-heading",
+   "metadata": {},
+   "source": [
+    "## Reverse-mode NUTS\n",
+    "\n",
+    "Forward-mode differentiation is disabled because the equilibrium kernels expose first-order custom VJPs. The shared gas grid and all local fixed-support grids are constructed outside this sampler, and `grid_build_seconds` is reported separately from sampling time. No speedup is assumed: a performance claim requires completed grid and non-grid runs with equivalent converged results on the same hardware."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "nuts-call",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from numpyro.infer import MCMC, NUTS\n",
+    "\n",
+    "def build_reverse_mode_mcmc(model):\n",
+    "    kernel = NUTS(\n",
+    "        model,\n",
+    "        forward_mode_differentiation=False,\n",
+    "        max_tree_depth=10,\n",
+    "    )\n",
+    "    return MCMC(\n",
+    "        kernel, num_warmup=500, num_samples=1000, num_chains=1\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "run-heading",
+   "metadata": {},
+   "source": [
+    "## Run the complete demo\n",
+    "\n",
+    "A chemistry-only preflight builds the shared gas grid and all local fixed-support grids. At all prior corners it checks frozen-baseline convergence, support, grid/baseline CO VMR primal equivalence, and maximum fixed-support iteration counts. It then checks the grid-side reverse-mode gradient for finiteness at the truth point, without opening an ExoJAX database. The command is guarded so opening this notebook does not start the calculation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "preflight-run",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import subprocess\n",
+    "import sys\n",
+    "\n",
+    "RUN_CHEMISTRY_PREFLIGHT = False\n",
+    "preflight_command = [\n",
+    "    sys.executable,\n",
+    "    \"examples/retrievals/exojax_nuts_condensate_grid.py\",\n",
+    "    \"--preflight-only\",\n",
+    "    \"--nlayer\", \"8\",\n",
+    "    \"--output-dir\",\n",
+    "    \"results/vjp_retrieval/condensate_grid_preflight\",\n",
+    "]\n",
+    "if RUN_CHEMISTRY_PREFLIGHT:\n",
+    "    subprocess.run(preflight_command, check=True)\n",
+    "preflight_command"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "quick-heading",
+   "metadata": {},
+   "source": [
+    "For a guarded end-to-end smoke run, point `EXOJAX_CO_DATABASE` at the exact existing `CO/12C-16O/Li2015` directory. The demo never downloads database files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "quick-run",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "RUN_QUICK = False\n",
+    "co_database = Path(\n",
+    "    os.environ.get(\n",
+    "        \"EXOJAX_CO_DATABASE\", \"/path/to/CO/12C-16O/Li2015\"\n",
+    "    )\n",
+    ")\n",
+    "quick_command = [\n",
+    "    sys.executable,\n",
+    "    \"examples/retrievals/exojax_nuts_condensate_grid.py\",\n",
+    "    \"--co-database\", str(co_database),\n",
+    "    \"--output-dir\",\n",
+    "    \"results/vjp_retrieval/condensate_grid_quick\",\n",
+    "    \"--quick\",\n",
+    "    \"--no-progress-bar\",\n",
+    "]\n",
+    "if RUN_QUICK:\n",
+    "    subprocess.run(quick_command, check=True)\n",
+    "quick_command"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "production-run",
+   "metadata": {},
+   "source": [
+    "The CUDA-only launcher first runs the spectral preflight, then requests 500 warmup steps and 1000 samples with seed 0:\n",
+    "\n",
+    "```tcsh\n",
+    "benchmarks/vjp_retrieval/run_exojax_nuts_gpu.csh \\\n",
+    "  condensate_grid /path/to/CO/12C-16O/Li2015\n",
+    "```\n",
+    "\n",
+    "The five-warmup `--quick` mode is only an end-to-end smoke test. No performance gain is claimed without completed grid and non-grid runs on the same hardware. Compare solver iterations and NUTS time separately, keep `grid_build_seconds` outside the sampling time, require agreement of converged spectra, and confirm that the grid-side reverse-mode gradient is finite before interpreting a timing comparison."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/documents/ipynb/exojax_nuts_condensate_grid.rst
+++ b/documents/ipynb/exojax_nuts_condensate_grid.rst
@@ -1,0 +1,300 @@
+.. This file is generated from the sibling .ipynb by convert_vjp_retrieval_notebooks.py.
+.. Do not edit this RST file directly.
+
+ExoJAX NUTS with the condensate VJP: grid initialization
+========================================================
+
+This tutorial is the grid-initialized counterpart to
+``exojax_nuts_condensate_fixed_support``. The executable source is
+``examples/retrievals/exojax_nuts_condensate_grid.py``; it shares the
+carbon-rich C/O = 2 chemistry, narrow priors, deterministic mock
+spectrum, frozen graphite support, and reverse-mode NUTS settings with
+``examples/retrievals/exojax_nuts_condensate_fixed_support.py``. The
+runtime solver uses one local fixed-support graphite grid per active
+layer and one shared gas-equilibrium grid for inactive layers.
+
+For each active layer, its ``FixedSupportCondensateEquilibriumGrid``
+stores converged fixed-support states: gas log amounts, the gas total,
+and the graphite amount. The corresponding
+``GridCondensateEquilibriumInitializer`` interpolates all three values
+at the same coordinate. Only the graphite support and active/inactive
+layer partition are frozen from the nominal calculation; the graphite
+amount used to initialize each runtime solve is interpolated
+dynamically. The inactive layers use the separate shared gas grid.
+Before sampling, all eight prior corners must retain the nominal
+support, the frozen baseline must converge, the grid and baseline CO VMR
+profiles must agree, and the grid must not increase the maximum
+fixed-support iteration count. The grid-side reverse-mode gradient must
+be finite at the truth point.
+
+This remains a local fixed-support demonstration with the full FastChem4
+gas catalog and an explicit reduced condensate catalog containing only
+``C(s)``. It does not differentiate support discovery, phase
+transitions, the production condensate lifecycle, or rainout, and it
+makes no full-catalog phase-stability or support-closure claim.
+
+Precompute the gas and fixed-support grids
+------------------------------------------
+
+First, ``prepare_graphite_profile`` discovers and certifies the nominal
+graphite support without a grid. The grid helper then constructs one
+``FixedSupportCondensateEquilibriumGrid`` per active layer. Each local
+grid uses that layer’s four prior-corner temperatures, a singleton
+pressure axis at the fixed layer pressure, and three composition points.
+Keeping the active grids local avoids evaluating a rectangular
+cross-product of temperatures and pressures whose off-layer points need
+not retain graphite support. Each local grid is wrapped in
+``GridCondensateEquilibriumInitializer``. A small example-level
+composite keeps those initializers together with the shared canonical
+gas-grid initializer used by inactive layers. Grid construction is
+completed before inference, and its wall time is returned separately
+from NUTS timing.
+
+.. code:: python
+
+    from dataclasses import replace
+
+    from jax import config
+    config.update("jax_enable_x64", True)
+
+    import jax
+    import jax.numpy as jnp
+
+    from examples.retrievals.exojax_nuts_condensate_fixed_support import (
+        TRUTH_ALPHA,
+        TRUTH_LOG_CO_SCALE,
+        TRUTH_T0_K,
+        build_graphite_grid_initializer,
+        co_vmr_profile,
+        graphite_only_chemical_setup,
+        interpolate_graphite_grid_initial_values,
+        powerlaw_temperature,
+        preflight_graphite_plan,
+        prepare_graphite_profile,
+        pressure_profile,
+        scale_carbon_and_oxygen,
+    )
+
+    pressures_bar = pressure_profile(8)
+    chemistry = graphite_only_chemical_setup()
+    base_plan = prepare_graphite_profile(pressures_bar, setup=chemistry)
+    grid_initializer, grid_build_seconds = build_graphite_grid_initializer(
+        base_plan
+    )
+    plan = replace(
+        base_plan,
+        grid_initializer=grid_initializer,
+        grid_build_seconds=grid_build_seconds,
+    )
+    gas_grid = grid_initializer.gas_initializer.grid
+    fixed_grids = tuple(
+        initializer.grid
+        for initializer in grid_initializer.fixed_initializers
+    )
+    (
+        gas_grid.outputs.ln_n.shape,
+        tuple(grid.gas_grid.outputs.ln_n.shape for grid in fixed_grids),
+        tuple(grid.condensate_amounts.shape for grid in fixed_grids),
+        grid_build_seconds,
+    )
+
+The two grid paths use different composition constructions. Each
+active-layer local fixed-support grid is built with
+``scale_carbon_and_oxygen``, exactly the elemental-inventory map used
+inside NUTS: carbon and oxygen are scaled together while C/O remains
+two. Its stored gas log amounts, gas total, and graphite amount are
+therefore converged states for the retrieval’s composition family. The
+shared gas grid reuses ``build_equilibrium_grid`` and its canonical
+physical-``log10(Z/Zsun)`` coordinate, which uniformly scales metals.
+For the retrieval’s C/O-only sampled inventory, that shared grid
+supplies an approximate numerical seed. The gas-only equilibrium kernel
+still receives the exact sampled elemental vector and determines the
+converged physical state from it.
+
+Freeze and certify graphite support
+-----------------------------------
+
+The base plan freezes only the nominal graphite support and the
+resulting active/inactive layer partition. It does not freeze the
+graphite amount used by the grid-enabled runtime solver.
+``preflight_graphite_plan`` checks all eight corners of the
+three-parameter prior box with the same lookup path used during NUTS:
+the support must match the nominal mask, the frozen-baseline solves must
+converge, and the grid and baseline CO VMR profiles must agree. At every
+corner, the grid-initialized maximum fixed-support iteration count must
+also be no greater than the frozen-baseline count. Separately, the
+preflight checks that the grid-side reverse-mode gradient is finite at
+the truth point; it does not compute a second baseline gradient. The
+corner iteration assertion checks the intended initialization behavior
+but is not a wall-time speedup claim.
+
+.. code:: python
+
+    preflight = preflight_graphite_plan(
+        plan, case_name="condensate_grid"
+    )
+    (
+        preflight["passed"],
+        preflight["active_indices"],
+        preflight["inactive_indices"],
+        preflight["gradient_finite"],
+        preflight["grid_no_grid_equivalence"],
+        preflight["grid_bounds"],
+        preflight["grid_build_seconds"],
+    )
+
+Interpolate at every NUTS evaluation
+------------------------------------
+
+For each sampled temperature profile and elemental vector, every active
+layer interpolates the converged gas log amounts, gas total, and
+graphite amount together from its corresponding local fixed-support
+grid. Those three dynamically selected values initialize the
+fixed-support condensate kernel. Inactive layers interpolate gas log
+amounts and the gas total from the shared gas grid and pass them to the
+gas-only kernel. The nominal support mask only selects which lookup and
+solver each layer uses.
+
+.. code:: python
+
+    temperature = powerlaw_temperature(
+        plan.pressures_bar, TRUTH_T0_K, TRUTH_ALPHA
+    )
+    inventory = scale_carbon_and_oxygen(
+        plan.reference_element_vector,
+        plan.carbon_index,
+        plan.oxygen_index,
+        TRUTH_LOG_CO_SCALE,
+    )
+    initial_values = interpolate_graphite_grid_initial_values(
+        plan, temperature, inventory
+    )
+    (
+        initial_values.gas_log_amounts.shape,
+        initial_values.fixed_gas_log_amounts.shape,
+        initial_values.graphite_amounts.shape,
+    )
+
+Reverse-mode check
+------------------
+
+The gas and fixed-support custom VJPs stop gradients through all
+numerical initialization values, including the interpolated graphite
+amount. Grid values can depend on the sampled parameters in the forward
+pass, but posterior derivatives are implicit derivatives of the
+converged equilibrium state, not derivatives through the initializer.
+Support remains a static, nondifferentiable contract. The preflight
+checks the grid-side gradient for finiteness at the truth point. It does
+not repeat the gradient calculation for the frozen baseline; the eight
+corners are used for baseline convergence, CO VMR primal equivalence,
+support, and iteration checks.
+
+.. code:: python
+
+    def chemistry_summary(t0_kelvin, alpha, log_co_scale):
+        temperatures = powerlaw_temperature(
+            plan.pressures_bar, t0_kelvin, alpha
+        )
+        co_vmr = co_vmr_profile(plan, temperatures, log_co_scale)
+        return jnp.sum(jnp.log(jnp.clip(co_vmr, 1.0e-300)))
+
+    summary, gradient = jax.value_and_grad(
+        chemistry_summary, argnums=(0, 1, 2)
+    )(TRUTH_T0_K, TRUTH_ALPHA, TRUTH_LOG_CO_SCALE)
+    summary, gradient
+
+Reverse-mode NUTS
+-----------------
+
+Forward-mode differentiation is disabled because the equilibrium kernels
+expose first-order custom VJPs. The shared gas grid and all local
+fixed-support grids are constructed outside this sampler, and
+``grid_build_seconds`` is reported separately from sampling time. No
+speedup is assumed: a performance claim requires completed grid and
+non-grid runs with equivalent converged results on the same hardware.
+
+.. code:: python
+
+    from numpyro.infer import MCMC, NUTS
+
+    def build_reverse_mode_mcmc(model):
+        kernel = NUTS(
+            model,
+            forward_mode_differentiation=False,
+            max_tree_depth=10,
+        )
+        return MCMC(
+            kernel, num_warmup=500, num_samples=1000, num_chains=1
+        )
+
+Run the complete demo
+---------------------
+
+A chemistry-only preflight builds the shared gas grid and all local
+fixed-support grids. At all prior corners it checks frozen-baseline
+convergence, support, grid/baseline CO VMR primal equivalence, and
+maximum fixed-support iteration counts. It then checks the grid-side
+reverse-mode gradient for finiteness at the truth point, without opening
+an ExoJAX database. The command is guarded so opening this notebook does
+not start the calculation.
+
+.. code:: python
+
+    from pathlib import Path
+    import subprocess
+    import sys
+
+    RUN_CHEMISTRY_PREFLIGHT = False
+    preflight_command = [
+        sys.executable,
+        "examples/retrievals/exojax_nuts_condensate_grid.py",
+        "--preflight-only",
+        "--nlayer", "8",
+        "--output-dir",
+        "results/vjp_retrieval/condensate_grid_preflight",
+    ]
+    if RUN_CHEMISTRY_PREFLIGHT:
+        subprocess.run(preflight_command, check=True)
+    preflight_command
+
+For a guarded end-to-end smoke run, point ``EXOJAX_CO_DATABASE`` at the
+exact existing ``CO/12C-16O/Li2015`` directory. The demo never downloads
+database files.
+
+.. code:: python
+
+    import os
+
+    RUN_QUICK = False
+    co_database = Path(
+        os.environ.get(
+            "EXOJAX_CO_DATABASE", "/path/to/CO/12C-16O/Li2015"
+        )
+    )
+    quick_command = [
+        sys.executable,
+        "examples/retrievals/exojax_nuts_condensate_grid.py",
+        "--co-database", str(co_database),
+        "--output-dir",
+        "results/vjp_retrieval/condensate_grid_quick",
+        "--quick",
+        "--no-progress-bar",
+    ]
+    if RUN_QUICK:
+        subprocess.run(quick_command, check=True)
+    quick_command
+
+The CUDA-only launcher first runs the spectral preflight, then requests
+500 warmup steps and 1000 samples with seed 0:
+
+.. code:: tcsh
+
+   benchmarks/vjp_retrieval/run_exojax_nuts_gpu.csh \
+     condensate_grid /path/to/CO/12C-16O/Li2015
+
+The five-warmup ``--quick`` mode is only an end-to-end smoke test. No
+performance gain is claimed without completed grid and non-grid runs on
+the same hardware. Compare solver iterations and NUTS time separately,
+keep ``grid_build_seconds`` outside the sampling time, require agreement
+of converged spectra, and confirm that the grid-side reverse-mode
+gradient is finite before interpreting a timing comparison.

--- a/examples/retrievals/exojax_nuts_condensate_fixed_support.py
+++ b/examples/retrievals/exojax_nuts_condensate_fixed_support.py
@@ -33,11 +33,12 @@ The full run is intended for a GPU.  This example never downloads a database.
 from __future__ import annotations
 
 import argparse
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 import itertools
 import json
 from pathlib import Path
 import sys
+import time
 from typing import Any, Mapping, Optional, Sequence, Union
 
 import jax
@@ -63,8 +64,14 @@ from _exojax_nuts_common import (  # noqa: E402
     write_run_outputs,
 )
 from exogibbs.api.gas import (  # noqa: E402
+    EquilibriumInitRequest,
     EquilibriumOptions,
+    GridEquilibriumInitializer,
     solve_profile as solve_gas_profile,
+)
+from exogibbs.api.condensate import (  # noqa: E402
+    CondensateEquilibriumInitRequest,
+    GridCondensateEquilibriumInitializer,
 )
 from exogibbs.equilibrium.condensate.acceptance import (  # noqa: E402
     least_squares_element_potential,
@@ -108,6 +115,39 @@ MIN_ACTIVE_GRAPHITE_AMOUNT = 1.0e-8
 MIN_INACTIVE_DRIVING_MARGIN = 2.0e-2
 DEFAULT_RELATIVE_NOISE = 2.0e-3
 CONDENSATE_MODEL_SCOPE = "fastchem4_gas_plus_graphite_only"
+GRID_PRESET_NAME = "fastchem4_graphite"
+GRID_COMPOSITION_POINTS = 3
+GRID_EQUIVALENCE_RTOL = 1.0e-8
+GRID_EQUIVALENCE_ATOL = 1.0e-10
+FIXED_GRID_COMPOSITION_AXIS_DEFINITION = (
+    "Physical log10(Z/Zsun) coordinate obtained by scaling only C and O "
+    "together from the carbon-rich retrieval reference inventory."
+)
+
+
+@dataclass(frozen=True)
+class GraphiteGridInitializer:
+    """Gas and fixed-graphite states tabulated over the local prior box."""
+
+    gas_initializer: GridEquilibriumInitializer
+    fixed_initializers: tuple[GridCondensateEquilibriumInitializer, ...]
+
+    @property
+    def grid(self):
+        """Return the shared gas grid for metadata reporting."""
+
+        return self.gas_initializer.grid
+
+
+@dataclass(frozen=True)
+class GraphiteGridProfileInitialValues:
+    """Interpolated gas-only and fixed-graphite profile initial values."""
+
+    gas_log_amounts: Any
+    gas_total_log_amounts: Any
+    fixed_gas_log_amounts: Any
+    fixed_total_log_amounts: Any
+    graphite_amounts: Any
 
 
 @dataclass(frozen=True)
@@ -132,6 +172,8 @@ class GraphiteProfilePlan:
     graphite_seed_amount: float
     nominal_graphite_driving_margin: Any
     nominal_fixed_support_residual: Any
+    grid_initializer: Optional[GraphiteGridInitializer] = None
+    grid_build_seconds: Optional[float] = None
 
     @property
     def active_mask(self) -> np.ndarray:
@@ -183,6 +225,21 @@ def graphite_only_chemical_setup(
         if full_setup is None
         else full_setup
     )
+    if source.gas_setup.element_vector_reference is None:
+        raise ValueError("FastChem4 setup did not provide a reference inventory.")
+    carbon_index = source.elements.index("C")
+    oxygen_index = source.elements.index("O")
+    reference = jnp.asarray(
+        source.gas_setup.element_vector_reference,
+        dtype=jnp.float64,
+    )
+    carbon_rich_reference = reference.at[carbon_index].set(
+        CARBON_TO_OXYGEN_RATIO * reference[oxygen_index]
+    )
+    gas_setup = replace(
+        source.gas_setup,
+        element_vector_reference=carbon_rich_reference,
+    )
     graphite_index = source.condensate_species.index(GRAPHITE_SPECIES)
     source_condensates = source.condensate_setup
     selected_index = jnp.asarray([graphite_index], dtype=jnp.int32)
@@ -221,12 +278,12 @@ def graphite_only_chemical_setup(
         hvector_func=graphite_hvector,
         elements=tuple(source.elements),
         species=(GRAPHITE_SPECIES,),
-        element_vector_reference=source_condensates.element_vector_reference,
+        element_vector_reference=carbon_rich_reference,
         metadata=metadata,
         temperature_validity_upper=selected_validity,
     )
     return build_condensate_chemical_setup(
-        gas_setup=source.gas_setup,
+        gas_setup=gas_setup,
         condensate_setup=reduced_condensates,
     )
 
@@ -259,6 +316,303 @@ def scale_carbon_and_oxygen(
     indices = jnp.asarray([carbon_index, oxygen_index], dtype=jnp.int32)
     scale = jnp.power(jnp.asarray(10.0, dtype=values.dtype), log_co_scale)
     return values.at[indices].set(values[indices] * scale)
+
+
+def _prior_temperature_axis(pressures_bar: Any) -> jax.Array:
+    """Return the sorted union of profile temperatures at all prior corners."""
+
+    temperatures = np.asarray(
+        [
+            float(value)
+            for t0_kelvin, alpha in itertools.product(
+                T0_PRIOR_BOUNDS_K,
+                ALPHA_PRIOR_BOUNDS,
+            )
+            for value in powerlaw_temperature(
+                pressures_bar,
+                t0_kelvin,
+                alpha,
+            )
+        ],
+        dtype=np.float64,
+    )
+    return jnp.asarray(np.unique(temperatures), dtype=jnp.float64)
+
+
+def _gas_grid_temperature_axis(pressures_bar: Any) -> jax.Array:
+    """Return a compact gas-grid axis spanning all profile prior corners."""
+
+    corner_axis = np.asarray(
+        _prior_temperature_axis(pressures_bar),
+        dtype=np.float64,
+    )
+    return jnp.linspace(
+        np.nextafter(corner_axis[0], -np.inf),
+        np.nextafter(corner_axis[-1], np.inf),
+        4,
+        dtype=jnp.float64,
+    )
+
+
+def build_graphite_grid_initializer(
+    plan: GraphiteProfilePlan,
+) -> tuple[GraphiteGridInitializer, float]:
+    """Precompute gas-only and fixed-graphite grids for the local prior."""
+
+    from exogibbs.api import (
+        EquilibriumGrid,
+        EquilibriumGridMetadata,
+        EquilibriumGridOutputs,
+        build_equilibrium_grid,
+        compute_physical_log10_z_over_z_sun,
+    )
+    from exogibbs.api.condensate import (
+        FixedSupportCondensateEquilibriumGrid,
+    )
+
+    setup = plan.setup
+    reference = plan.reference_element_vector
+    log_co_scale_axis = jnp.linspace(
+        LOG_CO_SCALE_PRIOR_BOUNDS[0],
+        LOG_CO_SCALE_PRIOR_BOUNDS[1],
+        GRID_COMPOSITION_POINTS,
+        dtype=jnp.float64,
+    )
+    composition_axis = jnp.asarray(
+        [
+            compute_physical_log10_z_over_z_sun(
+                setup.gas_setup,
+                scale_carbon_and_oxygen(
+                    reference,
+                    plan.carbon_index,
+                    plan.oxygen_index,
+                    log_co_scale,
+                ),
+            )
+            for log_co_scale in log_co_scale_axis
+        ],
+        dtype=jnp.float64,
+    )
+    gas_temperature_axis = _gas_grid_temperature_axis(plan.pressures_bar)
+
+    started = time.perf_counter()
+    gas_grid = build_equilibrium_grid(
+        GRID_PRESET_NAME,
+        gas_temperature_axis,
+        plan.pressures_bar,
+        composition_axis,
+        setup_builder=lambda: setup.gas_setup,
+        options=EquilibriumOptions(
+            epsilon_crit=GAS_RESIDUAL_TOLERANCE,
+            max_iter=GAS_MAX_ITERATIONS,
+        ),
+        verify_exogibbs_against_fastchem=False,
+    )
+    gas_initializer = GridEquilibriumInitializer(
+        grid=gas_grid,
+        preset_name=GRID_PRESET_NAME,
+    )
+    _, formula_matrix_cond, graphite_hvector = _graphite_support_arrays(
+        setup,
+        plan.graphite_species_index,
+    )
+    condensate_metadata = replace(
+        EquilibriumGridMetadata.from_setup(
+            setup.condensate_setup,
+            preset_name=GRID_PRESET_NAME,
+            source="exogibbs",
+            verify_exogibbs_against_fastchem=False,
+        ),
+            composition_axis_definition=(
+                FIXED_GRID_COMPOSITION_AXIS_DEFINITION
+            ),
+    )
+    fixed_initializers = []
+    for layer_index in plan.active_indices:
+        central_pressure = float(plan.pressures_bar[layer_index])
+        fixed_pressure_axis = jnp.asarray(
+            [central_pressure],
+            dtype=jnp.float64,
+        )
+        fixed_temperature_axis = _prior_temperature_axis(
+            jnp.asarray([central_pressure], dtype=jnp.float64)
+        )
+        fixed_q_slices = []
+        fixed_m_slices = []
+        for temperature in fixed_temperature_axis:
+            fixed_q_composition = []
+            fixed_m_composition = []
+            for composition_position, log_co_scale in enumerate(
+                log_co_scale_axis
+            ):
+                inventory = scale_carbon_and_oxygen(
+                    reference,
+                    plan.carbon_index,
+                    plan.oxygen_index,
+                    log_co_scale,
+                )
+                gas_initial = gas_initializer(
+                    EquilibriumInitRequest(
+                        setup=setup.gas_setup,
+                        T=temperature,
+                        P=central_pressure,
+                        b=inventory,
+                        K=len(setup.gas_species),
+                        explicit_log10_z_over_z_sun=(
+                            composition_axis[composition_position]
+                        ),
+                    )
+                )
+                fixed, diagnostics = (
+                    minimize_gibbs_fixed_support_with_diagnostics(
+                        ThermoState(
+                            temperature,
+                            jnp.log(
+                                central_pressure / REFERENCE_PRESSURE_BAR
+                            ),
+                            inventory,
+                        ),
+                        gas_initial.ln_nk,
+                        plan.graphite_amounts_init[
+                            layer_index
+                        ].reshape((1,)),
+                        gas_initial.ln_ntot,
+                        setup.formula_matrix,
+                        formula_matrix_cond,
+                        setup.gas_setup.hvector_func,
+                        graphite_hvector,
+                        residual_crit=CONDENSATE_RESIDUAL_TOLERANCE,
+                        max_iter=CONDENSATE_MAX_ITERATIONS,
+                    )
+                )
+                amount = fixed.condensate_amounts[0]
+                if not bool(
+                    diagnostics.converged
+                    & jnp.isfinite(diagnostics.residual_norm)
+                    & jnp.isfinite(amount)
+                    & (amount > MIN_ACTIVE_GRAPHITE_AMOUNT)
+                ):
+                    raise RuntimeError(
+                        "Fixed-graphite grid construction did not converge at "
+                        f"T={float(temperature)}, P={central_pressure}, "
+                        f"log_co_scale={float(log_co_scale)}."
+                    )
+                fixed_q_composition.append(fixed.gas_log_amounts)
+                fixed_m_composition.append(fixed.condensate_amounts)
+            fixed_q_slices.append(
+                jnp.stack(fixed_q_composition, axis=0)[None, ...]
+            )
+            fixed_m_slices.append(
+                jnp.stack(fixed_m_composition, axis=0)[None, ...]
+            )
+
+        fixed_q = jnp.stack(fixed_q_slices, axis=0)
+        fixed_m = jnp.stack(fixed_m_slices, axis=0)
+        fixed_n = jnp.exp(fixed_q)
+        fixed_ntot = jnp.sum(fixed_n, axis=-1)
+        fixed_gas_grid = EquilibriumGrid(
+            temperature_axis=fixed_temperature_axis,
+            pressure_axis=fixed_pressure_axis,
+            log10_z_over_z_sun_axis=composition_axis,
+            outputs=EquilibriumGridOutputs(
+                ln_n=fixed_q,
+                n=fixed_n,
+                x=fixed_n / jnp.clip(fixed_ntot[..., None], 1.0e-300),
+                ntot=fixed_ntot,
+            ),
+            metadata=replace(
+                gas_grid.metadata,
+                composition_axis_definition=(
+                    FIXED_GRID_COMPOSITION_AXIS_DEFINITION
+                ),
+            ),
+        )
+        fixed_grid = FixedSupportCondensateEquilibriumGrid(
+            gas_grid=fixed_gas_grid,
+            condensate_amounts=fixed_m,
+            support_indices=(plan.graphite_species_index,),
+            condensate_setup_metadata=condensate_metadata,
+        )
+        fixed_initializers.append(
+            GridCondensateEquilibriumInitializer(
+                grid=fixed_grid,
+                preset_name=GRID_PRESET_NAME,
+            )
+        )
+        jax.block_until_ready(fixed_m)
+    elapsed = time.perf_counter() - started
+    return GraphiteGridInitializer(
+        gas_initializer=gas_initializer,
+        fixed_initializers=tuple(fixed_initializers),
+    ), elapsed
+
+
+def interpolate_graphite_grid_initial_values(
+    plan: GraphiteProfilePlan,
+    temperatures: Any,
+    element_vector: Any,
+) -> GraphiteGridProfileInitialValues:
+    """Interpolate gas-only and fixed-graphite states for the profile."""
+
+    if plan.grid_initializer is None:
+        raise ValueError("The profile plan does not have a grid initializer.")
+
+    def interpolate_layer(temperature, pressure):
+        initial = plan.grid_initializer.gas_initializer(
+            EquilibriumInitRequest(
+                setup=plan.setup.gas_setup,
+                T=temperature,
+                P=pressure,
+                b=element_vector,
+                K=len(plan.setup.gas_species),
+            )
+        )
+        return initial.ln_nk, initial.ln_ntot
+
+    gas_q, gas_qtot = jax.vmap(interpolate_layer)(
+        jnp.asarray(temperatures),
+        plan.pressures_bar,
+    )
+    active = jnp.asarray(plan.active_indices, dtype=jnp.int32)
+    if len(plan.grid_initializer.fixed_initializers) != len(
+        plan.active_indices
+    ):
+        raise ValueError(
+            "The fixed grid initializer count must match active_indices."
+        )
+    fixed_values = []
+    for initializer, layer_index in zip(
+        plan.grid_initializer.fixed_initializers,
+        plan.active_indices,
+    ):
+        initial = initializer(
+            CondensateEquilibriumInitRequest(
+                setup=plan.setup,
+                T=jnp.asarray(temperatures)[layer_index],
+                P=plan.pressures_bar[layer_index],
+                b=element_vector,
+            )
+        )
+        fixed_values.append(
+            (
+                initial.gas_ln_n,
+                jnp.log(jnp.clip(initial.gas_ntot, 1.0e-300)),
+                initial.support_amounts[0],
+            )
+        )
+    fixed_q_active = jnp.stack([value[0] for value in fixed_values])
+    fixed_qtot_active = jnp.stack([value[1] for value in fixed_values])
+    graphite_active = jnp.stack([value[2] for value in fixed_values])
+    fixed_q = gas_q.at[active].set(fixed_q_active)
+    fixed_qtot = gas_qtot.at[active].set(fixed_qtot_active)
+    graphite = plan.graphite_amounts_init.at[active].set(graphite_active)
+    return GraphiteGridProfileInitialValues(
+        gas_log_amounts=gas_q,
+        gas_total_log_amounts=gas_qtot,
+        fixed_gas_log_amounts=fixed_q,
+        fixed_total_log_amounts=fixed_qtot,
+        graphite_amounts=graphite,
+    )
 
 
 def _graphite_support_arrays(setup: Any, graphite_index: int):
@@ -413,6 +767,8 @@ def prepare_graphite_profile(
     pressures_bar: Any,
     *,
     setup: Optional[Any] = None,
+    grid_initializer: Optional[GraphiteGridInitializer] = None,
+    grid_build_seconds: Optional[float] = None,
 ) -> GraphiteProfilePlan:
     """Discover and certify the nominal static graphite layer partition."""
 
@@ -424,7 +780,7 @@ def prepare_graphite_profile(
     if not bool(jnp.all(jnp.diff(pressure) > 0.0)):
         raise ValueError("pressures_bar must be ordered from top to bottom.")
 
-    chemistry = graphite_only_chemical_setup(setup)
+    chemistry = graphite_only_chemical_setup() if setup is None else setup
     graphite_index = chemistry.condensate_species.index(GRAPHITE_SPECIES)
     carbon_index = chemistry.elements.index("C")
     oxygen_index = chemistry.elements.index("O")
@@ -541,6 +897,8 @@ def prepare_graphite_profile(
         graphite_seed_amount=seed_amount,
         nominal_graphite_driving_margin=margins,
         nominal_fixed_support_residual=fixed_diagnostics.residual_norm,
+        grid_initializer=grid_initializer,
+        grid_build_seconds=grid_build_seconds,
     )
 
 
@@ -563,6 +921,19 @@ def solve_hybrid_log_amounts(
     _, formula_matrix_cond, graphite_hvector = _graphite_support_arrays(
         plan.setup, plan.graphite_species_index
     )
+    if plan.grid_initializer is None:
+        gas_log_amounts_init = plan.hybrid_log_amounts_init
+        total_gas_log_amounts_init = plan.hybrid_total_log_amounts_init
+        graphite_amounts_init = plan.graphite_amounts_init
+    else:
+        grid_initial = interpolate_graphite_grid_initial_values(
+            plan,
+            temperature,
+            inventory,
+        )
+        gas_log_amounts_init = grid_initial.fixed_gas_log_amounts
+        total_gas_log_amounts_init = grid_initial.fixed_total_log_amounts
+        graphite_amounts_init = grid_initial.graphite_amounts
     result = jnp.zeros_like(plan.hybrid_log_amounts_init)
 
     active = jnp.asarray(plan.active_indices, dtype=jnp.int32)
@@ -589,9 +960,9 @@ def solve_hybrid_log_amounts(
     active_q = jax.vmap(active_layer)(
         temperature[active],
         plan.pressures_bar[active],
-        plan.hybrid_log_amounts_init[active],
-        plan.hybrid_total_log_amounts_init[active],
-        plan.graphite_amounts_init[active],
+        gas_log_amounts_init[active],
+        total_gas_log_amounts_init[active],
+        graphite_amounts_init[active],
     )
     result = result.at[active].set(active_q)
 
@@ -615,8 +986,8 @@ def solve_hybrid_log_amounts(
     inactive_q = jax.vmap(inactive_layer)(
         temperature[inactive],
         plan.pressures_bar[inactive],
-        plan.gas_only_log_amounts[inactive],
-        plan.gas_only_total_log_amounts[inactive],
+        gas_log_amounts_init[inactive],
+        total_gas_log_amounts_init[inactive],
     )
     return result.at[inactive].set(inactive_q)
 
@@ -643,7 +1014,11 @@ def _prior_corners() -> tuple[tuple[float, float, float], ...]:
     )
 
 
-def preflight_graphite_plan(plan: GraphiteProfilePlan) -> dict[str, Any]:
+def preflight_graphite_plan(
+    plan: GraphiteProfilePlan,
+    *,
+    case_name: str = CASE_NAME,
+) -> dict[str, Any]:
     """Check support identity, primal convergence, and reverse-mode gradients."""
 
     nominal_mask = plan.active_mask
@@ -655,6 +1030,11 @@ def preflight_graphite_plan(plan: GraphiteProfilePlan) -> dict[str, Any]:
         else float("inf")
     )
     corner_rows: list[dict[str, Any]] = []
+    maximum_corner_co_vmr_difference = 0.0
+    maximum_grid_fixed_iterations = 0
+    maximum_baseline_fixed_iterations = 0
+    all_grid_primal_equivalent = True
+    all_fixed_iterations_not_greater = True
     for t0_kelvin, alpha, log_co_scale in _prior_corners():
         temperature = powerlaw_temperature(
             plan.pressures_bar, t0_kelvin, alpha
@@ -672,8 +1052,33 @@ def preflight_graphite_plan(plan: GraphiteProfilePlan) -> dict[str, Any]:
                 plan.reference_element_vector.shape[0],
             ),
         )
+        if plan.grid_initializer is None:
+            gas_log_amounts_init = plan.gas_only_log_amounts
+            gas_total_log_amounts_init = plan.gas_only_total_log_amounts
+            fixed_gas_log_amounts_init = plan.hybrid_log_amounts_init
+            fixed_total_log_amounts_init = (
+                plan.hybrid_total_log_amounts_init
+            )
+            graphite_amounts_init = plan.graphite_amounts_init
+        else:
+            grid_initial = interpolate_graphite_grid_initial_values(
+                plan,
+                temperature,
+                inventory,
+            )
+            gas_log_amounts_init = grid_initial.gas_log_amounts
+            gas_total_log_amounts_init = (
+                grid_initial.gas_total_log_amounts
+            )
+            fixed_gas_log_amounts_init = (
+                grid_initial.fixed_gas_log_amounts
+            )
+            fixed_total_log_amounts_init = (
+                grid_initial.fixed_total_log_amounts
+            )
+            graphite_amounts_init = grid_initial.graphite_amounts
         (
-            _gas_q,
+            gas_q,
             gas_diagnostics,
             margins,
             fixed_result,
@@ -684,12 +1089,122 @@ def preflight_graphite_plan(plan: GraphiteProfilePlan) -> dict[str, Any]:
             temperature,
             plan.pressures_bar,
             inventories,
-            plan.gas_only_log_amounts,
-            plan.gas_only_total_log_amounts,
-            plan.graphite_amounts_init,
-            fixed_gas_log_amounts_init=plan.hybrid_log_amounts_init,
-            fixed_total_log_amounts_init=plan.hybrid_total_log_amounts_init,
+            gas_log_amounts_init,
+            gas_total_log_amounts_init,
+            graphite_amounts_init,
+            fixed_gas_log_amounts_init=fixed_gas_log_amounts_init,
+            fixed_total_log_amounts_init=fixed_total_log_amounts_init,
         )
+        baseline_maximum_active_fixed_support_iterations = None
+        baseline_converged = None
+        co_vmr_absolute_difference = None
+        grid_primal_equivalent = True
+        fixed_iterations_not_greater = True
+        if plan.grid_initializer is not None:
+            (
+                baseline_gas_q,
+                baseline_gas_diagnostics,
+                _baseline_margins,
+                baseline_fixed_result,
+                baseline_fixed_diagnostics,
+            ) = _audit_graphite_candidate(
+                plan.setup,
+                plan.graphite_species_index,
+                temperature,
+                plan.pressures_bar,
+                inventories,
+                plan.gas_only_log_amounts,
+                plan.gas_only_total_log_amounts,
+                plan.graphite_amounts_init,
+                fixed_gas_log_amounts_init=plan.hybrid_log_amounts_init,
+                fixed_total_log_amounts_init=(
+                    plan.hybrid_total_log_amounts_init
+                ),
+            )
+            active_mask_array = jnp.asarray(nominal_mask)[:, None]
+            grid_hybrid_q = jnp.where(
+                active_mask_array,
+                fixed_result.gas_log_amounts,
+                gas_q,
+            )
+            baseline_hybrid_q = jnp.where(
+                active_mask_array,
+                baseline_fixed_result.gas_log_amounts,
+                baseline_gas_q,
+            )
+
+            def co_vmr(log_amounts):
+                log_total = jax.scipy.special.logsumexp(
+                    log_amounts,
+                    axis=1,
+                )
+                return jnp.exp(
+                    log_amounts[:, plan.co_species_index] - log_total
+                )
+
+            grid_co_vmr = co_vmr(grid_hybrid_q)
+            baseline_co_vmr = co_vmr(baseline_hybrid_q)
+            co_vmr_absolute_difference = float(
+                jnp.max(jnp.abs(grid_co_vmr - baseline_co_vmr))
+            )
+            grid_primal_equivalent = bool(
+                jnp.allclose(
+                    grid_co_vmr,
+                    baseline_co_vmr,
+                    rtol=GRID_EQUIVALENCE_RTOL,
+                    atol=GRID_EQUIVALENCE_ATOL,
+                )
+            )
+            grid_fixed_iterations = np.asarray(
+                jax.device_get(fixed_diagnostics.iterations)
+            )[nominal_mask]
+            baseline_fixed_iterations = np.asarray(
+                jax.device_get(baseline_fixed_diagnostics.iterations)
+            )[nominal_mask]
+            baseline_fixed_converged = np.asarray(
+                jax.device_get(baseline_fixed_diagnostics.converged),
+                dtype=bool,
+            )[nominal_mask]
+            baseline_fixed_residuals = np.asarray(
+                jax.device_get(baseline_fixed_diagnostics.residual_norm),
+                dtype=float,
+            )[nominal_mask]
+            baseline_converged = bool(
+                jnp.all(baseline_gas_diagnostics["converged"])
+                and np.all(baseline_fixed_converged)
+                and np.all(np.isfinite(baseline_fixed_residuals))
+                and np.max(baseline_fixed_residuals)
+                <= CONDENSATE_RESIDUAL_TOLERANCE
+            )
+            grid_primal_equivalent = (
+                grid_primal_equivalent and baseline_converged
+            )
+            fixed_iterations_not_greater = bool(
+                np.max(grid_fixed_iterations)
+                <= np.max(baseline_fixed_iterations)
+            )
+            baseline_maximum_active_fixed_support_iterations = int(
+                np.max(baseline_fixed_iterations)
+            )
+            maximum_corner_co_vmr_difference = max(
+                maximum_corner_co_vmr_difference,
+                co_vmr_absolute_difference,
+            )
+            maximum_grid_fixed_iterations = max(
+                maximum_grid_fixed_iterations,
+                int(np.max(grid_fixed_iterations)),
+            )
+            maximum_baseline_fixed_iterations = max(
+                maximum_baseline_fixed_iterations,
+                baseline_maximum_active_fixed_support_iterations,
+            )
+            all_grid_primal_equivalent = (
+                all_grid_primal_equivalent and grid_primal_equivalent
+            )
+            all_fixed_iterations_not_greater = (
+                all_fixed_iterations_not_greater
+                and fixed_iterations_not_greater
+            )
         amounts = fixed_result.condensate_amounts[:, 0]
         valid_fixed = (
             fixed_diagnostics.converged
@@ -749,6 +1264,8 @@ def preflight_graphite_plan(plan: GraphiteProfilePlan) -> dict[str, Any]:
             and active_amount_min > MIN_ACTIVE_GRAPHITE_AMOUNT
             and inactive_margin_min > MIN_INACTIVE_DRIVING_MARGIN
             and temperature_valid
+            and grid_primal_equivalent
+            and fixed_iterations_not_greater
         )
         corner_rows.append(
             {
@@ -766,7 +1283,30 @@ def preflight_graphite_plan(plan: GraphiteProfilePlan) -> dict[str, Any]:
                 "minimum_active_graphite_amount": active_amount_min,
                 "minimum_inactive_driving_margin": inactive_margin_min,
                 "graphite_temperature_valid": temperature_valid,
-                "uses_frozen_nuts_initialization": True,
+                "uses_frozen_nuts_initialization": (
+                    plan.grid_initializer is None
+                ),
+                "maximum_gas_iterations": int(
+                    jnp.max(gas_diagnostics["n_iter"])
+                ),
+                "maximum_active_fixed_support_iterations": int(
+                    np.max(
+                        np.asarray(jax.device_get(fixed_diagnostics.iterations))[
+                            nominal_mask
+                        ]
+                    )
+                ),
+                "baseline_maximum_active_fixed_support_iterations": (
+                    baseline_maximum_active_fixed_support_iterations
+                ),
+                "baseline_converged": baseline_converged,
+                "maximum_grid_no_grid_co_vmr_absolute_difference": (
+                    co_vmr_absolute_difference
+                ),
+                "grid_no_grid_primal_equivalent": grid_primal_equivalent,
+                "fixed_support_iterations_not_greater": (
+                    fixed_iterations_not_greater
+                ),
                 "passed": corner_ok,
             }
         )
@@ -789,9 +1329,40 @@ def preflight_graphite_plan(plan: GraphiteProfilePlan) -> dict[str, Any]:
     gradient_finite = bool(
         np.all(np.isfinite(np.asarray(gradient_values, dtype=float)))
     )
+    grid_no_grid_equivalence = (
+        None
+        if plan.grid_initializer is None
+        else {
+            "relative_tolerance": GRID_EQUIVALENCE_RTOL,
+            "absolute_tolerance": GRID_EQUIVALENCE_ATOL,
+            "maximum_corner_co_vmr_absolute_difference": (
+                maximum_corner_co_vmr_difference
+            ),
+            "maximum_grid_fixed_support_iterations": (
+                maximum_grid_fixed_iterations
+            ),
+            "maximum_baseline_fixed_support_iterations": (
+                maximum_baseline_fixed_iterations
+            ),
+            "all_corner_primals_equivalent": all_grid_primal_equivalent,
+            "all_fixed_support_iterations_not_greater": (
+                all_fixed_iterations_not_greater
+            ),
+            "passed": bool(
+                all_grid_primal_equivalent
+                and all_fixed_iterations_not_greater
+            ),
+        }
+    )
     report = {
         "schema": "exogibbs_condensate_fixed_support_nuts_preflight_v1",
-        "case_name": CASE_NAME,
+        "case_name": case_name,
+        "initializer": (
+            "runtime_fastchem4_gas_and_fixed_graphite_grids"
+            if plan.grid_initializer is not None
+            else "frozen_nominal_state"
+        ),
+        "grid_build_seconds": plan.grid_build_seconds,
         "local_fixed_support_contract": True,
         "condensate_model_scope": CONDENSATE_MODEL_SCOPE,
         "condensate_catalog_mode": "reduced_explicit",
@@ -827,9 +1398,36 @@ def preflight_graphite_plan(plan: GraphiteProfilePlan) -> dict[str, Any]:
             "log_co_scale": gradient_values[2],
         },
         "gradient_finite": gradient_finite,
+        "grid_no_grid_equivalence": grid_no_grid_equivalence,
     }
+    if plan.grid_initializer is not None:
+        grid = plan.grid_initializer.grid
+        report["grid_bounds"] = {
+            "temperature_kelvin": [
+                float(jnp.min(grid.temperature_axis)),
+                float(jnp.max(grid.temperature_axis)),
+            ],
+            "pressure_bar": [
+                float(jnp.min(grid.pressure_axis)),
+                float(jnp.max(grid.pressure_axis)),
+            ],
+            "log10_z_over_z_sun": [
+                float(jnp.min(grid.log10_z_over_z_sun_axis)),
+                float(jnp.max(grid.log10_z_over_z_sun_axis)),
+            ],
+        }
+        report["grid_composition_note"] = (
+            "Local fixed-support grids use the retrieval's exact C/O scaling "
+            "rule. The shared gas grid uses canonical uniform-metal scaling "
+            "as an approximate seed at the same physical log10(Z/Zsun)."
+        )
     report["passed"] = bool(
-        gradient_finite and all(row["passed"] for row in corner_rows)
+        gradient_finite
+        and all(row["passed"] for row in corner_rows)
+        and (
+            grid_no_grid_equivalence is None
+            or grid_no_grid_equivalence["passed"]
+        )
     )
     if not report["passed"]:
         failed = [row for row in corner_rows if not row["passed"]]
@@ -910,22 +1508,38 @@ def _json_ready_plan_metadata(plan: GraphiteProfilePlan) -> dict[str, Any]:
         "full_catalog_equilibrium_claimed": False,
         "full_catalog_support_closure_checked": False,
         "element_count": len(plan.setup.elements),
+        "initializer": (
+            "runtime_fastchem4_gas_and_fixed_graphite_grids"
+            if plan.grid_initializer is not None
+            else "frozen_nominal_state"
+        ),
+        "grid_build_seconds": plan.grid_build_seconds,
     }
 
 
-def _preflight_output_path(output_directory: Union[str, Path]) -> Path:
+def _preflight_output_path(
+    output_directory: Union[str, Path],
+    *,
+    case_name: str = CASE_NAME,
+) -> Path:
     output = Path(output_directory)
     output.mkdir(parents=True, exist_ok=True)
-    return output / f"{CASE_NAME}_preflight.json"
+    return output / f"{case_name}_preflight.json"
 
 
-def build_parser() -> argparse.ArgumentParser:
+def build_parser(*, case_name: str = CASE_NAME) -> argparse.ArgumentParser:
     """Build the command-line parser shared with the gas retrieval demos."""
 
-    parser = argparse.ArgumentParser(description=__doc__)
+    description = __doc__
+    if case_name != CASE_NAME:
+        description = (
+            "Run the local graphite fixed-support retrieval with a runtime "
+            "FastChem4 fixed-support grid initializer."
+        )
+    parser = argparse.ArgumentParser(description=description)
     add_common_cli_arguments(
         parser,
-        default_output_dir=Path("results") / "vjp_retrieval" / CASE_NAME,
+        default_output_dir=Path("results") / "vjp_retrieval" / case_name,
     )
     # Eight layers leave a useful gap between the last graphite layer and the
     # first gas-only layer.  Other grids are allowed only when preflight passes.
@@ -946,10 +1560,15 @@ def _print_preflight_summary(report: Mapping[str, Any], path: Path) -> None:
     print(f"  report: {path}")
 
 
-def main(argv: Optional[Sequence[str]] = None) -> None:
-    """Run chemistry preflight and, unless requested otherwise, NUTS."""
+def run_condensate_demo(
+    *,
+    use_grid_initializer: bool,
+    case_name: str,
+    argv: Optional[Sequence[str]] = None,
+) -> None:
+    """Run one fixed-support retrieval with optional grid initialization."""
 
-    parser = build_parser()
+    parser = build_parser(case_name=case_name)
     args = parser.parse_args(argv)
     settings = resolve_run_settings(args)
     nlayer, nu_points = resolve_demo_shape(args)
@@ -965,13 +1584,32 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
     else:
         pressures = pressure_profile(nlayer)
 
-    plan = prepare_graphite_profile(pressures)
-    preflight = preflight_graphite_plan(plan)
+    chemistry = graphite_only_chemical_setup()
+    plan = prepare_graphite_profile(
+        pressures,
+        setup=chemistry,
+    )
+    if use_grid_initializer:
+        (
+            grid_initializer,
+            grid_build_seconds,
+        ) = build_graphite_grid_initializer(
+            plan,
+        )
+        plan = replace(
+            plan,
+            grid_initializer=grid_initializer,
+            grid_build_seconds=grid_build_seconds,
+        )
+    preflight = preflight_graphite_plan(plan, case_name=case_name)
     preflight["plan"] = _json_ready_plan_metadata(plan)
     if args.relative_noise <= 0.0:
         raise ValueError("--relative-noise must be positive.")
     if context is None:
-        preflight_path = _preflight_output_path(args.output_dir)
+        preflight_path = _preflight_output_path(
+            args.output_dir,
+            case_name=case_name,
+        )
         preflight_path.write_text(
             json.dumps(preflight, indent=2, sort_keys=True) + "\n",
             encoding="utf-8",
@@ -1023,7 +1661,10 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         "alpha": spectral_gradient_values[1],
         "log_co_scale": spectral_gradient_values[2],
     }
-    preflight_path = _preflight_output_path(args.output_dir)
+    preflight_path = _preflight_output_path(
+        args.output_dir,
+        case_name=case_name,
+    )
     preflight_path.write_text(
         json.dumps(preflight, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
@@ -1032,7 +1673,7 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
     if args.preflight_only:
         write_run_outputs(
             args.output_dir,
-            case_name=CASE_NAME,
+            case_name=case_name,
             context=context,
             observation=observation,
             metadata={"preflight": preflight},
@@ -1043,7 +1684,7 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
     mcmc = run_reverse_mode_nuts(model, observation, settings)
     write_run_outputs(
         args.output_dir,
-        case_name=CASE_NAME,
+        case_name=case_name,
         context=context,
         observation=observation,
         mcmc=mcmc,
@@ -1057,7 +1698,17 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
             ),
         },
     )
-    print(f"{CASE_NAME}: completed; outputs: {args.output_dir}")
+    print(f"{case_name}: completed; outputs: {args.output_dir}")
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    """Run the frozen-nominal fixed-support tutorial."""
+
+    run_condensate_demo(
+        use_grid_initializer=False,
+        case_name=CASE_NAME,
+        argv=argv,
+    )
 
 
 if __name__ == "__main__":

--- a/examples/retrievals/exojax_nuts_condensate_grid.py
+++ b/examples/retrievals/exojax_nuts_condensate_grid.py
@@ -1,0 +1,18 @@
+"""ExoJAX NUTS retrieval with a fixed-support condensate grid initializer.
+
+The chemistry, fixed graphite support, priors, mock data, and reverse-mode
+NUTS settings are shared with ``exojax_nuts_condensate_fixed_support.py``.
+This wrapper additionally precomputes a shared gas grid and local graphite
+fixed-support grids, then interpolates gas and condensate initial values at
+every NUTS evaluation.  Support discovery, phase transitions, the production
+lifecycle, and rainout remain outside AD.
+"""
+
+from exojax_nuts_condensate_fixed_support import run_condensate_demo
+
+
+if __name__ == "__main__":
+    run_condensate_demo(
+        use_grid_initializer=True,
+        case_name="condensate_grid",
+    )

--- a/src/exogibbs/api/condensate.py
+++ b/src/exogibbs/api/condensate.py
@@ -2,6 +2,8 @@
 
 from exogibbs.equilibrium.condensate.initialization import (
     DefaultCondensateEquilibriumInitializer,
+    FixedSupportCondensateEquilibriumGrid,
+    GridCondensateEquilibriumInitializer,
 )
 from exogibbs.equilibrium.condensate.setup import (
     CondensateChemicalSetup,
@@ -47,6 +49,8 @@ __all__ = (
     "CondensateFixedSupportV2Preset",
     "CondensateProfileMethod",
     "DefaultCondensateEquilibriumInitializer",
+    "FixedSupportCondensateEquilibriumGrid",
+    "GridCondensateEquilibriumInitializer",
     "build_condensate_chemical_setup",
     "solve",
     "solve_profile",

--- a/src/exogibbs/equilibrium/condensate/initialization.py
+++ b/src/exogibbs/equilibrium/condensate/initialization.py
@@ -1,12 +1,27 @@
 """Initialization policies for condensate equilibrium."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Optional
 
+import jax.numpy as jnp
+
+from exogibbs.equilibrium.condensate.setup import CondensateChemicalSetup
 from exogibbs.equilibrium.condensate.types import (
+    Array,
     CondensateEquilibriumInit,
     CondensateEquilibriumInitializer,
     CondensateEquilibriumInitRequest,
+)
+from exogibbs.equilibrium.gas.grid.initialization import (
+    _resolve_equilibrium_grid_initialization_composition,
+)
+from exogibbs.equilibrium.gas.grid.interpolation import (
+    _interpolate_equilibrium_grid_field,
+    _validate_equilibrium_grid_metadata_compatibility,
+)
+from exogibbs.equilibrium.gas.grid.types import (
+    EquilibriumGrid,
+    EquilibriumGridMetadata,
 )
 
 
@@ -25,6 +40,170 @@ class DefaultCondensateEquilibriumInitializer:
         return CondensateEquilibriumInit()
 
 
+@dataclass(frozen=True)
+class FixedSupportCondensateEquilibriumGrid:
+    """Fixed-support condensate states on a gas-grid coordinate system.
+
+    ``gas_grid`` stores the gas components of fixed-support condensate
+    solutions. ``condensate_amounts`` stores linear amounts with shape
+    ``(T, P, Z, support)``. The support is identical at every grid point;
+    full-catalog phase grids are outside this container's contract.
+    """
+
+    gas_grid: EquilibriumGrid
+    condensate_amounts: Array
+    support_indices: tuple[int, ...]
+    condensate_setup_metadata: EquilibriumGridMetadata
+
+
+def _validate_fixed_support_condensate_grid(
+    grid: FixedSupportCondensateEquilibriumGrid,
+    setup: CondensateChemicalSetup,
+    preset_name: str,
+    expected_composition_axis_name: str,
+) -> tuple[int, ...]:
+    """Validate fixed support, field shape, and condensate setup metadata."""
+
+    if not isinstance(grid.gas_grid, EquilibriumGrid):
+        raise TypeError(
+            "Fixed-support condensate grid gas_grid must be an "
+            "EquilibriumGrid."
+        )
+    if not isinstance(
+        grid.condensate_setup_metadata,
+        EquilibriumGridMetadata,
+    ):
+        raise TypeError(
+            "Fixed-support condensate grid condensate_setup_metadata must be "
+            "an EquilibriumGridMetadata."
+        )
+    support_indices = tuple(int(index) for index in grid.support_indices)
+    if not support_indices:
+        raise ValueError(
+            "Fixed-support condensate grid support must not be empty."
+        )
+    if len(set(support_indices)) != len(support_indices):
+        raise ValueError(
+            "Fixed-support condensate grid support indices must be unique."
+        )
+    metadata = grid.condensate_setup_metadata
+    _validate_equilibrium_grid_metadata_compatibility(
+        metadata,
+        setup.condensate_setup,
+        preset_name,
+        expected_composition_axis_name=expected_composition_axis_name,
+        grid_label="Fixed-support condensate grid",
+    )
+    stored_species = metadata.preset_species
+    if stored_species is None:
+        raise ValueError(
+            "Fixed-support condensate grid metadata must store condensate "
+            "species."
+        )
+    if tuple(setup.condensate_species) != tuple(stored_species):
+        raise ValueError(
+            "Fixed-support condensate grid condensate species mismatch: "
+            "metadata does not match the runtime combined setup."
+        )
+    if any(
+        index < 0 or index >= len(stored_species)
+        for index in support_indices
+    ):
+        raise ValueError(
+            "Fixed-support condensate grid contains an out-of-range support "
+            "index."
+        )
+    amounts = jnp.asarray(grid.condensate_amounts)
+    gas_grid = grid.gas_grid
+    expected_shape = (
+        gas_grid.temperature_axis.shape[0],
+        gas_grid.pressure_axis.shape[0],
+        gas_grid.log10_z_over_z_sun_axis.shape[0],
+        len(support_indices),
+    )
+    if amounts.shape != expected_shape:
+        raise ValueError(
+            "Fixed-support condensate grid amounts shape mismatch: expected "
+            f"{expected_shape}, got {amounts.shape}."
+        )
+    return support_indices
+
+
+@dataclass(frozen=True)
+class GridCondensateEquilibriumInitializer:
+    """Initialize gas and condensate fields from a fixed-support grid.
+
+    Interpolated support amounts are also scattered into the full runtime
+    condensate catalog. Non-grid fields from explicit or previous state are
+    retained.
+    """
+
+    grid: FixedSupportCondensateEquilibriumGrid
+    preset_name: str
+    expected_composition_axis_name: str = "log10(Z/Zsun)"
+
+    def __call__(
+        self,
+        request: CondensateEquilibriumInitRequest,
+    ) -> CondensateEquilibriumInit:
+        if not isinstance(
+            self.grid,
+            FixedSupportCondensateEquilibriumGrid,
+        ):
+            raise TypeError(
+                "GridCondensateEquilibriumInitializer requires a "
+                "FixedSupportCondensateEquilibriumGrid."
+            )
+        support_indices = _validate_fixed_support_condensate_grid(
+            self.grid,
+            request.setup,
+            self.preset_name,
+            self.expected_composition_axis_name,
+        )
+        gas_grid = self.grid.gas_grid
+        composition = _resolve_equilibrium_grid_initialization_composition(
+            gas_grid,
+            setup=request.setup.gas_setup,
+            preset_name=self.preset_name,
+            element_vector=request.b,
+            explicit_log10_z_over_z_sun=(
+                request.explicit_log10_z_over_z_sun
+            ),
+            expected_composition_axis_name=self.expected_composition_axis_name,
+            initializer_name=type(self).__name__,
+        )
+        from exogibbs.equilibrium.gas.grid.service import (
+            interpolate_equilibrium_grid,
+        )
+
+        gas_state = interpolate_equilibrium_grid(
+            gas_grid,
+            temperature=request.T,
+            pressure=request.P,
+            log10_z_over_z_sun=composition,
+        )
+        support_amounts = _interpolate_equilibrium_grid_field(
+            gas_grid,
+            self.grid.condensate_amounts,
+            request.T,
+            request.P,
+            composition,
+        )
+        condensate_amounts = jnp.zeros(
+            (len(request.setup.condensate_species),),
+            dtype=support_amounts.dtype,
+        ).at[jnp.asarray(support_indices)].set(support_amounts)
+        base = DefaultCondensateEquilibriumInitializer()(request)
+        return replace(
+            base,
+            gas_ln_n=jnp.asarray(gas_state.ln_n),
+            gas_ntot=jnp.asarray(gas_state.ntot),
+            condensate_amounts=condensate_amounts,
+            support_indices=support_indices,
+            support_amounts=jnp.asarray(support_amounts),
+        )
+
+
 DEFAULT_CONDENSATE_INITIALIZER = DefaultCondensateEquilibriumInitializer()
 
 
@@ -40,5 +219,7 @@ def resolve_condensate_initial_guess(
 
 __all__ = (
     "DefaultCondensateEquilibriumInitializer",
+    "FixedSupportCondensateEquilibriumGrid",
+    "GridCondensateEquilibriumInitializer",
     "resolve_condensate_initial_guess",
 )

--- a/src/exogibbs/equilibrium/condensate/lifecycle.py
+++ b/src/exogibbs/equilibrium/condensate/lifecycle.py
@@ -60,7 +60,7 @@ from exogibbs.equilibrium.condensate.types import (
     ExperimentalCondensateProfileFixedSupportBatchPlan,
     HeadV2LayerState,
 )
-from exogibbs.equilibrium.gas.types import ThermoState
+from exogibbs.equilibrium.gas.types import EquilibriumInit, ThermoState
 
 
 _ExperimentalProfileFixedSupportBatchPlan = (
@@ -174,6 +174,31 @@ def _ln_normalized_pressure(pressure: float, reference_pressure: float) -> Array
     return jnp.log(jnp.asarray(pressure) / jnp.asarray(reference_pressure))
 
 
+def _gas_init_from_condensate_init(
+    init: CondensateEquilibriumInit | None,
+    *,
+    gas_species_count: int,
+) -> EquilibriumInit | None:
+    """Return a valid gas-solver seed from a condensate initializer."""
+
+    if init is None or init.gas_ln_n is None or init.gas_ntot is None:
+        return None
+    gas_ln_n = jnp.asarray(init.gas_ln_n, dtype=jnp.float64)
+    gas_ntot = jnp.asarray(init.gas_ntot, dtype=jnp.float64)
+    if (
+        gas_ln_n.shape != (gas_species_count,)
+        or gas_ntot.ndim != 0
+        or not bool(jnp.all(jnp.isfinite(gas_ln_n)))
+        or not bool(jnp.isfinite(gas_ntot))
+        or float(gas_ntot) <= 0.0
+    ):
+        return None
+    return EquilibriumInit(
+        ln_nk=gas_ln_n,
+        ln_ntot=jnp.log(gas_ntot),
+    )
+
+
 def _solver_log_state_from_condensate_init(
     init: CondensateEquilibriumInit | None,
     *,
@@ -261,6 +286,7 @@ def _native_activity_expanded_profile_support_payload(
     activity_gas_ln_n: Sequence[float] | Array | None = None,
     activity_gas_ntot: Sequence[float] | Array | float | None = None,
     activity_gas_stationarity_source: Sequence[float] | Array | None = None,
+    gas_equilibrium_init: EquilibriumInit | None = None,
 ) -> tuple[tuple[int, ...], tuple[float, ...], Mapping[str, Any]]:
     from exogibbs.equilibrium.gas.solve import equilibrium
     from exogibbs.equilibrium.gas.types import EquilibriumOptions
@@ -307,6 +333,7 @@ def _native_activity_expanded_profile_support_payload(
             float(P),
             jnp.asarray(b, dtype=jnp.float64),
             Pref=Pref,
+            init=gas_equilibrium_init,
             options=EquilibriumOptions(),
             return_diagnostics=False,
         )
@@ -787,6 +814,7 @@ def _run_head_v2_profile(
     ]
     pending: dict[int, _HeadV2LayerState] = {}
     gas_only_layers: set[int] = set()
+    initial_guesses: list[CondensateEquilibriumInit] = []
     for layer_index in range(n_layers):
         initial_guess = _resolve_condensate_initial_guess(
             initializer,
@@ -800,6 +828,11 @@ def _run_head_v2_profile(
                 user_init=explicit_inits[layer_index],
                 previous_solution=None,
             ),
+        )
+        initial_guesses.append(initial_guess)
+        gas_equilibrium_init = _gas_init_from_condensate_init(
+            initial_guess,
+            gas_species_count=len(setup.gas_species),
         )
         if support_indices is not None:
             if support_amounts_init is None:
@@ -857,6 +890,7 @@ def _run_head_v2_profile(
             activity_gas_ln_n=None,
             activity_gas_ntot=None,
             activity_gas_stationarity_source=None,
+            gas_equilibrium_init=gas_equilibrium_init,
         )
         base_amount_by_index = {
             int(index): float(amount)
@@ -1136,12 +1170,17 @@ def _run_head_v2_profile(
             "production_preset_promoted": True,
         }
         if layer_index in gas_only_layers:
+            gas_equilibrium_init = _gas_init_from_condensate_init(
+                initial_guesses[layer_index],
+                gas_species_count=len(setup.gas_species),
+            )
             gas_result = equilibrium(
                 setup.gas_setup,
                 float(temperatures[layer_index]),
                 float(pressures[layer_index]),
                 jnp.asarray(b, dtype=jnp.float64),
                 Pref=Pref,
+                init=gas_equilibrium_init,
                 options=EquilibriumOptions(),
                 return_diagnostics=False,
             )

--- a/src/exogibbs/equilibrium/condensate/solve.py
+++ b/src/exogibbs/equilibrium/condensate/solve.py
@@ -10,6 +10,8 @@ from exogibbs.equilibrium.condensate import lifecycle as _lifecycle
 from exogibbs.equilibrium.condensate import acceptance as _acceptance
 from exogibbs.equilibrium.condensate.initialization import (
     DefaultCondensateEquilibriumInitializer,
+    FixedSupportCondensateEquilibriumGrid,
+    GridCondensateEquilibriumInitializer,
 )
 from exogibbs.equilibrium.condensate.policy import (
     validate_condensate_options as _validate_options,
@@ -74,6 +76,7 @@ def condensate_equilibrium(
     support_indices: Optional[Sequence[int]] = None,
     support_amounts_init: Optional[Sequence[float]] = None,
     init: Optional[CondensateEquilibriumInit] = None,
+    initializer: Optional[CondensateEquilibriumInitializer] = None,
     options: Optional[CondensateEquilibriumOptions] = None,
 ) -> CondensateEquilibriumResult:
     """Compute one layer through the production fixed-support v2 route."""
@@ -93,7 +96,7 @@ def condensate_equilibrium(
         b=b,
         Pref=Pref,
         explicit_inits=(init,),
-        initializer=None,
+        initializer=initializer,
         support_indices=support_indices,
         support_amounts_init=support_amounts_init,
         options=opts,
@@ -206,6 +209,8 @@ __all__ = (
     "CondensateProfileMethod",
     "DefaultCondensateEquilibriumInitializer",
     "ExperimentalCondensateProfileFixedSupportBatchPlan",
+    "FixedSupportCondensateEquilibriumGrid",
+    "GridCondensateEquilibriumInitializer",
     "build_condensate_chemical_setup",
     "build_condensate_equilibrium_result_from_solver_payload",
     "condensate_equilibrium",

--- a/src/exogibbs/equilibrium/condensate/types.py
+++ b/src/exogibbs/equilibrium/condensate/types.py
@@ -116,6 +116,7 @@ class CondensateEquilibriumInitRequest:
     layer_index: Optional[int] = None
     user_init: Optional[CondensateEquilibriumInit] = None
     previous_solution: Optional[CondensateEquilibriumInit] = None
+    explicit_log10_z_over_z_sun: Optional[float] = None
 
 
 @runtime_checkable

--- a/src/exogibbs/equilibrium/gas/grid/initialization.py
+++ b/src/exogibbs/equilibrium/gas/grid/initialization.py
@@ -1,7 +1,9 @@
 """Grid-backed initialization for gas equilibrium."""
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
+
+import jax.numpy as jnp
 
 from exogibbs.equilibrium.gas.types import (
     EquilibriumInit,
@@ -10,6 +12,47 @@ from exogibbs.equilibrium.gas.types import (
 
 if TYPE_CHECKING:
     from exogibbs.equilibrium.gas.grid.service import EquilibriumGrid
+    from exogibbs.equilibrium.gas.grid.types import Array
+    from exogibbs.thermo.models import ChemicalSetup
+
+
+def _resolve_equilibrium_grid_initialization_composition(
+    grid: "EquilibriumGrid",
+    *,
+    setup: "ChemicalSetup",
+    preset_name: str,
+    element_vector,
+    explicit_log10_z_over_z_sun: Optional[float],
+    expected_composition_axis_name: str,
+    initializer_name: str,
+) -> "Array":
+    """Validate an initializer grid and resolve its composition query."""
+
+    from exogibbs.equilibrium.gas.grid.service import (
+        compute_physical_log10_z_over_z_sun,
+        validate_equilibrium_grid_compatibility,
+    )
+
+    validate_equilibrium_grid_compatibility(
+        grid,
+        setup,
+        preset_name,
+        expected_composition_axis_name=expected_composition_axis_name,
+    )
+    if explicit_log10_z_over_z_sun is not None:
+        log10_z_over_z_sun = explicit_log10_z_over_z_sun
+    else:
+        try:
+            log10_z_over_z_sun = compute_physical_log10_z_over_z_sun(
+                setup,
+                element_vector,
+            )
+        except (ValueError, KeyError) as exc:
+            raise ValueError(
+                f"{initializer_name} could not infer physical "
+                f"log10(Z/Zsun) from request.b: {exc}"
+            ) from exc
+    return jnp.asarray(log10_z_over_z_sun)
 
 
 @dataclass(frozen=True)
@@ -22,35 +65,25 @@ class GridEquilibriumInitializer:
 
     def __call__(self, request: EquilibriumInitRequest) -> EquilibriumInit:
         from exogibbs.equilibrium.gas.grid.service import (
-            compute_physical_log10_z_over_z_sun,
             interpolate_equilibrium_grid,
-            validate_equilibrium_grid_compatibility,
         )
 
-        validate_equilibrium_grid_compatibility(
+        composition = _resolve_equilibrium_grid_initialization_composition(
             self.grid,
-            request.setup,
-            self.preset_name,
+            setup=request.setup,
+            preset_name=self.preset_name,
+            element_vector=request.b,
+            explicit_log10_z_over_z_sun=(
+                request.explicit_log10_z_over_z_sun
+            ),
             expected_composition_axis_name=self.expected_composition_axis_name,
+            initializer_name=type(self).__name__,
         )
-        if request.explicit_log10_z_over_z_sun is not None:
-            log10_z_over_z_sun = request.explicit_log10_z_over_z_sun
-        else:
-            try:
-                log10_z_over_z_sun = compute_physical_log10_z_over_z_sun(
-                    request.setup,
-                    request.b,
-                )
-            except (ValueError, KeyError) as exc:
-                raise ValueError(
-                    "GridEquilibriumInitializer could not infer physical "
-                    f"log10(Z/Zsun) from request.b: {exc}"
-                ) from exc
         interpolated = interpolate_equilibrium_grid(
             self.grid,
             temperature=request.T,
             pressure=request.P,
-            log10_z_over_z_sun=log10_z_over_z_sun,
+            log10_z_over_z_sun=composition,
         )
         return interpolated.to_equilibrium_init()
 

--- a/src/exogibbs/equilibrium/gas/grid/interpolation.py
+++ b/src/exogibbs/equilibrium/gas/grid/interpolation.py
@@ -14,6 +14,7 @@ from exogibbs.equilibrium.gas.grid.types import (
     EquilibriumGrid,
     EquilibriumGridInterpolationOptions,
     EquilibriumGridInterpolationResult,
+    EquilibriumGridMetadata,
 )
 from exogibbs.thermo.models import ChemicalSetup
 from exogibbs.utils.elements import element_mass
@@ -133,42 +134,60 @@ def validate_equilibrium_grid_compatibility(
     It raises ``ValueError`` on the first mismatch and returns ``None`` on success.
     Verification-related metadata is intentionally not part of compatibility.
     """
-    if grid.metadata.preset_name != preset_name:
+    _validate_equilibrium_grid_metadata_compatibility(
+        grid.metadata,
+        setup,
+        preset_name,
+        expected_composition_axis_name=expected_composition_axis_name,
+    )
+
+
+def _validate_equilibrium_grid_metadata_compatibility(
+    metadata: EquilibriumGridMetadata,
+    setup: ChemicalSetup,
+    preset_name: str,
+    *,
+    expected_composition_axis_name: str = _COMPOSITION_AXIS_NAME,
+    grid_label: str = "Equilibrium grid",
+) -> None:
+    """Validate grid metadata against a runtime chemical setup."""
+
+    if metadata.preset_name != preset_name:
         raise ValueError(
-            f"Equilibrium grid preset mismatch: grid uses '{grid.metadata.preset_name}' "
+            f"{grid_label} preset mismatch: grid uses '{metadata.preset_name}' "
             f"but runtime requested '{preset_name}'."
         )
-    if grid.metadata.preset_elements != (
+    if metadata.preset_elements != (
         tuple(setup.elements) if setup.elements is not None else None
     ):
         raise ValueError(
-            "Equilibrium grid elements mismatch: grid metadata does not match "
+            f"{grid_label} elements mismatch: grid metadata does not match "
             "the runtime setup.elements ordering/content."
         )
-    if grid.metadata.preset_species != (
+    if metadata.preset_species != (
         tuple(setup.species) if setup.species is not None else None
     ):
         raise ValueError(
-            "Equilibrium grid species mismatch: grid metadata does not match "
+            f"{grid_label} species mismatch: grid metadata does not match "
             "the runtime setup.species ordering/content."
         )
     if not _setup_metadata_matches(
-        grid.metadata.preset_setup_metadata,
+        metadata.preset_setup_metadata,
         setup.metadata,
     ):
         raise ValueError(
-            "Equilibrium grid setup metadata mismatch: a field stored by the "
+            f"{grid_label} setup metadata mismatch: a field stored by the "
             "grid is missing or different in the runtime setup.metadata."
         )
-    if grid.metadata.composition_axis_name != expected_composition_axis_name:
+    if metadata.composition_axis_name != expected_composition_axis_name:
         raise ValueError(
-            "Equilibrium grid composition axis mismatch: "
+            f"{grid_label} composition axis mismatch: "
             f"expected '{expected_composition_axis_name}' but grid stores "
-            f"'{grid.metadata.composition_axis_name}'."
+            f"'{metadata.composition_axis_name}'."
         )
-    if not grid.metadata.matches_setup(setup, preset_name):
+    if not metadata.matches_setup(setup, preset_name):
         raise ValueError(
-            "Equilibrium grid preset signature mismatch: the stored preset/setup "
+            f"{grid_label} preset signature mismatch: the stored preset/setup "
             "signature is not compatible with the runtime setup."
         )
 
@@ -216,6 +235,28 @@ def _interpolate_grid_field(
     return interpolated
 
 
+def _interpolate_equilibrium_grid_field(
+    grid: EquilibriumGrid,
+    field: Array,
+    temperature: float,
+    pressure: float,
+    log10_z_over_z_sun: float,
+    *,
+    options: Optional[EquilibriumGridInterpolationOptions] = None,
+) -> Array:
+    """Interpolate one field on an equilibrium grid."""
+
+    active_options = options or EquilibriumGridInterpolationOptions()
+    return _interpolate_grid_field(
+        grid,
+        field,
+        _as_scalar_query(temperature, "temperature"),
+        _as_scalar_query(pressure, "pressure"),
+        _as_scalar_query(log10_z_over_z_sun, "log10_z_over_z_sun"),
+        active_options,
+    )
+
+
 def interpolate_equilibrium_grid(
     grid: EquilibriumGrid,
     temperature: float,
@@ -231,7 +272,10 @@ def interpolate_equilibrium_grid(
     active_options = options or EquilibriumGridInterpolationOptions()
     temperature_query = _as_scalar_query(temperature, "temperature")
     pressure_query = _as_scalar_query(pressure, "pressure")
-    composition_query = _as_scalar_query(log10_z_over_z_sun, "log10_z_over_z_sun")
+    composition_query = _as_scalar_query(
+        log10_z_over_z_sun,
+        "log10_z_over_z_sun",
+    )
     return EquilibriumGridInterpolationResult(
         ln_n=_interpolate_grid_field(
             grid,

--- a/src/exogibbs/utils/interpolation.py
+++ b/src/exogibbs/utils/interpolation.py
@@ -23,6 +23,10 @@ def interp1d(xq: Array, x: Array, y: Array, method: str = "linear") -> Array:
 def _bracket(axis: Array, query: Array, extrap: Union[bool, float, Tuple[object, ...]]):
     axis = jnp.asarray(axis)
     query = jnp.asarray(query)
+    if axis.shape[0] == 1:
+        index = jnp.asarray(0, dtype=jnp.int32)
+        outside = (query != axis[0]) if extrap is False else jnp.asarray(False)
+        return index, index, jnp.zeros_like(query), outside
     upper = jnp.searchsorted(axis, query, side="right")
     upper = jnp.clip(upper, 1, axis.shape[0] - 1)
     lower = upper - 1

--- a/tests/unittests/api/condensate_equilibrium_profile_test.py
+++ b/tests/unittests/api/condensate_equilibrium_profile_test.py
@@ -460,6 +460,69 @@ def test_head_v2_empty_initial_support_uses_gas_only_outcome(
     )
 
 
+def test_head_v2_grid_like_gas_init_seeds_exact_gas_solves(
+    monkeypatch,
+):
+    setup = _fake_setup()
+    seed_ln_n = jnp.log(jnp.asarray([0.25, 0.75], dtype=jnp.float64))
+    exact_ln_n = jnp.log(jnp.asarray([0.5, 0.5], dtype=jnp.float64))
+    gas_inits = []
+    activity_gas_states = []
+
+    def fake_gas_equilibrium(*args, **kwargs):
+        gas_inits.append(kwargs.get("init"))
+        return SimpleNamespace(
+            ln_n=exact_ln_n,
+            ntot=jnp.asarray(1.0, dtype=jnp.float64),
+        )
+
+    monkeypatch.setattr(
+        "exogibbs.equilibrium.gas.solve.equilibrium",
+        fake_gas_equilibrium,
+    )
+
+    def fake_element_potential(*, gas_ln_n, **kwargs):
+        activity_gas_states.append(gas_ln_n)
+        return jnp.zeros((2,), dtype=jnp.float64)
+
+    monkeypatch.setattr(
+        _lifecycle,
+        "_least_squares_element_potential",
+        fake_element_potential,
+    )
+    monkeypatch.setattr(
+        (
+            "exogibbs.condensates.support_selection_policy."
+            "select_activity_driven_support_candidates"
+        ),
+        lambda **kwargs: SimpleNamespace(
+            positive_support_indices=(),
+            as_dict=lambda: {},
+        ),
+    )
+    initial = CondensateEquilibriumInit(
+        gas_ln_n=seed_ln_n,
+        gas_ntot=jnp.asarray(1.0, dtype=jnp.float64),
+    )
+
+    result = condmod.condensate_equilibrium_profile(
+        setup,
+        T=np.asarray([1000.0]),
+        P=np.asarray([1.0]),
+        b=jnp.asarray([0.5, 0.5], dtype=jnp.float64),
+        init=(initial,),
+    )
+
+    assert result.layers[0].converged
+    assert len(gas_inits) == 2
+    for gas_init in gas_inits:
+        assert gas_init is not None
+        np.testing.assert_allclose(gas_init.ln_nk, seed_ln_n)
+        assert float(gas_init.ln_ntot) == pytest.approx(0.0)
+    assert len(activity_gas_states) == 1
+    np.testing.assert_allclose(activity_gas_states[0], exact_ln_n)
+
+
 def test_head_v2_independent_kkt_gate_rejects_failed_component():
     kkt = {
         "gas_stationarity": 1.0e-9,

--- a/tests/unittests/api/condensate_equilibrium_test.py
+++ b/tests/unittests/api/condensate_equilibrium_test.py
@@ -95,6 +95,29 @@ def test_build_condensate_chemical_setup_validates_element_order() -> None:
     assert setup.condensate_species == ("H2O_s",)
 
 
+def test_one_layer_solver_forwards_initializer(monkeypatch) -> None:
+    _gas, _condensate, setup = _setup_pair()
+    initializer = object()
+    captured = {}
+
+    def fake_profile(**kwargs):
+        captured.update(kwargs)
+        return type("Profile", (), {"layers": ("layer",)})()
+
+    monkeypatch.setattr(condmod, "_run_head_v2_profile", fake_profile)
+
+    result = condmod.condensate_equilibrium(
+        setup,
+        T=1000.0,
+        P=1.0,
+        b=jnp.asarray([1.0, 1.0]),
+        initializer=initializer,
+    )
+
+    assert result == "layer"
+    assert captured["initializer"] is initializer
+
+
 def test_condensate_chemical_setup_rejects_element_order_mismatch() -> None:
     gas, condensate, _setup = _setup_pair()
     invalid = ChemicalSetup(

--- a/tests/unittests/equilibrium/condensate/initialization_test.py
+++ b/tests/unittests/equilibrium/condensate/initialization_test.py
@@ -1,0 +1,426 @@
+"""Condensate equilibrium initialization policies."""
+
+from dataclasses import replace
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+from exogibbs.api.condensate import (
+    FixedSupportCondensateEquilibriumGrid,
+    GridCondensateEquilibriumInitializer,
+)
+from exogibbs.api.condensate_equilibrium import (
+    FixedSupportCondensateEquilibriumGrid as CompatibilityFixedSupportGrid,
+    GridCondensateEquilibriumInitializer as CompatibilityGridInitializer,
+)
+from exogibbs.equilibrium.condensate.setup import CondensateChemicalSetup
+from exogibbs.equilibrium.condensate.types import (
+    CondensateEquilibriumInit,
+    CondensateEquilibriumInitRequest,
+)
+from exogibbs.equilibrium.gas.grid.service import (
+    EquilibriumGrid,
+    EquilibriumGridInterpolationResult,
+    EquilibriumGridMetadata,
+    EquilibriumGridOutputs,
+    compute_physical_log10_z_over_z_sun,
+)
+from exogibbs.thermo.models import ChemicalSetup
+
+
+def _condensate_setup() -> CondensateChemicalSetup:
+    elements = ("H", "He", "O", "e-")
+    gas_species = ("H2", "H2O")
+    condensate_species = ("O[s]", "H2O[s]", "O2[s]")
+    gas_formula_matrix = jnp.zeros((len(elements), len(gas_species)))
+    condensate_formula_matrix = jnp.zeros(
+        (len(elements), len(condensate_species))
+    )
+    gas_setup = ChemicalSetup(
+        formula_matrix=gas_formula_matrix,
+        hvector_func=lambda temperature: jnp.zeros((len(gas_species),)),
+        elements=elements,
+        species=gas_species,
+        element_vector_reference=jnp.asarray([1.0, 0.1, 0.01, 0.0]),
+        metadata={"source": "test", "dataset": "gas"},
+    )
+    condensate_setup = ChemicalSetup(
+        formula_matrix=condensate_formula_matrix,
+        hvector_func=lambda temperature: jnp.zeros(
+            (len(condensate_species),)
+        ),
+        elements=elements,
+        species=condensate_species,
+        metadata={"source": "test", "dataset": "condensates"},
+    )
+    return CondensateChemicalSetup(
+        gas_setup=gas_setup,
+        condensate_setup=condensate_setup,
+        formula_matrix=gas_formula_matrix,
+        formula_matrix_cond=condensate_formula_matrix,
+        gas_species=gas_species,
+        condensate_species=condensate_species,
+        elements=elements,
+    )
+
+
+def _gas_grid(
+    setup: CondensateChemicalSetup,
+    *,
+    species=None,
+) -> EquilibriumGrid:
+    gas_species = tuple(species or setup.gas_species)
+    species_count = len(gas_species)
+    return EquilibriumGrid(
+        temperature_axis=jnp.asarray([500.0, 1500.0]),
+        pressure_axis=jnp.asarray([0.1, 1.0]),
+        log10_z_over_z_sun_axis=jnp.asarray([-1.0, 1.0]),
+        outputs=EquilibriumGridOutputs(
+            ln_n=jnp.zeros((2, 2, 2, species_count)),
+            n=jnp.ones((2, 2, 2, species_count)),
+            x=jnp.full(
+                (2, 2, 2, species_count),
+                1.0 / species_count,
+            ),
+            ntot=jnp.ones((2, 2, 2)),
+        ),
+        metadata=EquilibriumGridMetadata(
+            preset_name="test",
+            preset_setup_metadata=setup.gas_setup.metadata,
+            preset_elements=setup.gas_setup.elements,
+            preset_species=gas_species,
+            source="exogibbs",
+            verify_exogibbs_against_fastchem=False,
+        ),
+    )
+
+
+def _fixed_support_grid(
+    setup: CondensateChemicalSetup,
+    *,
+    gas_grid=None,
+    condensate_amounts=None,
+    support_indices=(0, 2),
+    condensate_setup_metadata=None,
+) -> FixedSupportCondensateEquilibriumGrid:
+    active_gas_grid = gas_grid or _gas_grid(setup)
+    if condensate_amounts is None:
+        values = jnp.asarray([0.2, 0.4])[: len(support_indices)]
+        condensate_amounts = jnp.broadcast_to(
+            values,
+            (2, 2, 2, len(support_indices)),
+        )
+    if condensate_setup_metadata is None:
+        condensate_setup_metadata = EquilibriumGridMetadata.from_setup(
+            setup.condensate_setup,
+            preset_name="test",
+            source="exogibbs",
+            verify_exogibbs_against_fastchem=False,
+        )
+    return FixedSupportCondensateEquilibriumGrid(
+        gas_grid=active_gas_grid,
+        condensate_amounts=condensate_amounts,
+        support_indices=tuple(support_indices),
+        condensate_setup_metadata=condensate_setup_metadata,
+    )
+
+
+def test_grid_condensate_initializer_maps_linear_total_and_preserves_user_init(
+    monkeypatch,
+):
+    setup = _condensate_setup()
+    grid = _fixed_support_grid(setup)
+    captured = {}
+
+    def fake_interpolate(
+        grid_in,
+        temperature,
+        pressure,
+        log10_z_over_z_sun,
+        *,
+        options=None,
+    ):
+        captured.update(
+            grid=grid_in,
+            temperature=temperature,
+            pressure=pressure,
+            composition=log10_z_over_z_sun,
+            options=options,
+        )
+        return EquilibriumGridInterpolationResult(
+            ln_n=jnp.asarray([-3.0, -4.0]),
+            x=jnp.asarray([0.75, 0.25]),
+            ntot=jnp.asarray(2.5),
+        )
+
+    monkeypatch.setattr(
+        "exogibbs.equilibrium.gas.grid.service.interpolate_equilibrium_grid",
+        fake_interpolate,
+    )
+    user_init = CondensateEquilibriumInit(
+        gas_ln_n=jnp.asarray([8.0, 9.0]),
+        gas_ntot=jnp.asarray(10.0),
+        condensate_amounts=jnp.asarray([0.9, 0.8, 0.7]),
+        support_indices=(1,),
+        support_amounts=(0.8,),
+        element_potential=jnp.arange(4.0),
+        rho=jnp.asarray([0.3, 0.4]),
+        barrier_epsilon=jnp.asarray(1.0e-4),
+    )
+    initializer = GridCondensateEquilibriumInitializer(
+        grid=grid,
+        preset_name="test",
+    )
+
+    result = initializer(
+        CondensateEquilibriumInitRequest(
+            setup=setup,
+            T=900.0,
+            P=0.3,
+            b=jnp.asarray([1.0, 0.1, 0.02, 0.0]),
+            user_init=user_init,
+            explicit_log10_z_over_z_sun=0.25,
+        )
+    )
+
+    assert captured["grid"] is grid.gas_grid
+    assert captured["temperature"] == 900.0
+    assert captured["pressure"] == 0.3
+    assert captured["composition"] == 0.25
+    assert captured["options"] is None
+    assert jnp.allclose(result.gas_ln_n, jnp.asarray([-3.0, -4.0]))
+    assert jnp.isclose(result.gas_ntot, 2.5)
+    assert jnp.allclose(
+        result.condensate_amounts,
+        jnp.asarray([0.2, 0.0, 0.4]),
+    )
+    assert result.support_indices == (0, 2)
+    assert jnp.allclose(result.support_amounts, jnp.asarray([0.2, 0.4]))
+    assert jnp.allclose(result.element_potential, user_init.element_potential)
+    assert jnp.allclose(result.rho, user_init.rho)
+    assert jnp.isclose(result.barrier_epsilon, user_init.barrier_epsilon)
+
+
+def test_grid_condensate_initializer_infers_coordinate_and_preserves_previous(
+    monkeypatch,
+):
+    setup = _condensate_setup()
+    grid = _fixed_support_grid(setup)
+    element_vector = jnp.asarray([1.0, 0.1, 0.02, 0.0])
+    captured = {}
+
+    def fake_interpolate(
+        grid_in,
+        temperature,
+        pressure,
+        log10_z_over_z_sun,
+        *,
+        options=None,
+    ):
+        del grid_in, temperature, pressure, options
+        captured["composition"] = log10_z_over_z_sun
+        return EquilibriumGridInterpolationResult(
+            ln_n=jnp.asarray([-1.0, -2.0]),
+            x=jnp.asarray([0.6, 0.4]),
+            ntot=jnp.asarray(1.5),
+        )
+
+    monkeypatch.setattr(
+        "exogibbs.equilibrium.gas.grid.service.interpolate_equilibrium_grid",
+        fake_interpolate,
+    )
+    previous = CondensateEquilibriumInit(
+        condensate_amounts=jnp.asarray([0.9, 0.8, 0.7]),
+        support_indices=(1,),
+        support_amounts=(0.8,),
+        element_potential=jnp.arange(4.0),
+        rho=jnp.asarray([0.3, 0.4]),
+        barrier_epsilon=jnp.asarray(1.0e-4),
+    )
+
+    result = GridCondensateEquilibriumInitializer(grid, "test")(
+        CondensateEquilibriumInitRequest(
+            setup=setup,
+            T=1000.0,
+            P=0.5,
+            b=element_vector,
+            previous_solution=previous,
+        )
+    )
+
+    expected = compute_physical_log10_z_over_z_sun(
+        setup.gas_setup,
+        element_vector,
+    )
+    assert jnp.isclose(captured["composition"], expected)
+    assert jnp.allclose(result.gas_ln_n, jnp.asarray([-1.0, -2.0]))
+    assert jnp.isclose(result.gas_ntot, 1.5)
+    assert jnp.allclose(
+        result.condensate_amounts,
+        jnp.asarray([0.2, 0.0, 0.4]),
+    )
+    assert result.support_indices == (0, 2)
+    assert jnp.allclose(result.support_amounts, jnp.asarray([0.2, 0.4]))
+    assert jnp.allclose(result.element_potential, previous.element_potential)
+    assert jnp.allclose(result.rho, previous.rho)
+    assert jnp.isclose(result.barrier_epsilon, previous.barrier_epsilon)
+
+
+def test_grid_condensate_initializer_rejects_incompatible_gas_grid():
+    setup = _condensate_setup()
+    grid = _fixed_support_grid(
+        setup,
+        gas_grid=_gas_grid(setup, species=("H2",)),
+    )
+    request = CondensateEquilibriumInitRequest(
+        setup=setup,
+        T=1000.0,
+        P=0.5,
+        b=jnp.asarray([1.0, 0.1, 0.02, 0.0]),
+        explicit_log10_z_over_z_sun=0.0,
+    )
+
+    with pytest.raises(ValueError, match="species mismatch"):
+        GridCondensateEquilibriumInitializer(grid, "test")(request)
+
+
+def test_grid_condensate_initializer_requires_fixed_support_grid():
+    setup = _condensate_setup()
+    request = CondensateEquilibriumInitRequest(
+        setup=setup,
+        T=1000.0,
+        P=0.5,
+        b=jnp.asarray([1.0, 0.1, 0.02, 0.0]),
+        explicit_log10_z_over_z_sun=0.0,
+    )
+
+    with pytest.raises(TypeError, match="FixedSupportCondensateEquilibriumGrid"):
+        GridCondensateEquilibriumInitializer(_gas_grid(setup), "test")(
+            request
+        )
+
+
+def test_grid_condensate_initializer_rejects_condensate_setup_mismatch():
+    setup = _condensate_setup()
+    grid = _fixed_support_grid(setup)
+    incompatible_condensate_setup = replace(
+        setup.condensate_setup,
+        metadata={"source": "different", "dataset": "condensates"},
+    )
+    incompatible_setup = replace(
+        setup,
+        condensate_setup=incompatible_condensate_setup,
+    )
+    request = CondensateEquilibriumInitRequest(
+        setup=incompatible_setup,
+        T=1000.0,
+        P=0.5,
+        b=jnp.asarray([1.0, 0.1, 0.02, 0.0]),
+        explicit_log10_z_over_z_sun=0.0,
+    )
+
+    with pytest.raises(ValueError, match="setup metadata mismatch"):
+        GridCondensateEquilibriumInitializer(grid, "test")(request)
+
+
+def test_grid_condensate_initializer_rejects_condensate_species_mismatch():
+    setup = _condensate_setup()
+    grid = _fixed_support_grid(setup)
+    reordered_species = ("H2O[s]", "O[s]", "O2[s]")
+    incompatible_setup = replace(
+        setup,
+        condensate_setup=replace(
+            setup.condensate_setup,
+            species=reordered_species,
+        ),
+        condensate_species=reordered_species,
+    )
+    request = CondensateEquilibriumInitRequest(
+        setup=incompatible_setup,
+        T=1000.0,
+        P=0.5,
+        b=jnp.asarray([1.0, 0.1, 0.02, 0.0]),
+        explicit_log10_z_over_z_sun=0.0,
+    )
+
+    with pytest.raises(ValueError, match="species mismatch"):
+        GridCondensateEquilibriumInitializer(grid, "test")(request)
+
+
+def test_grid_condensate_initializer_rejects_amount_shape_mismatch():
+    setup = _condensate_setup()
+    grid = _fixed_support_grid(
+        setup,
+        condensate_amounts=jnp.ones((2, 2, 2, 3)),
+    )
+    request = CondensateEquilibriumInitRequest(
+        setup=setup,
+        T=1000.0,
+        P=0.5,
+        b=jnp.asarray([1.0, 0.1, 0.02, 0.0]),
+        explicit_log10_z_over_z_sun=0.0,
+    )
+
+    with pytest.raises(ValueError, match="amounts shape mismatch"):
+        GridCondensateEquilibriumInitializer(grid, "test")(request)
+
+
+def test_grid_condensate_initializer_is_trace_safe():
+    setup = _condensate_setup()
+    temperatures = jnp.asarray([500.0, 1500.0])
+    pressures = jnp.asarray([0.1, 1.0])
+    compositions = jnp.asarray([-1.0, 1.0])
+    temperature_values = temperatures[:, None, None, None]
+    condensate_amounts = jnp.broadcast_to(
+        temperature_values / 1000.0,
+        (2, 2, 2, 2),
+    )
+    grid = _fixed_support_grid(
+        setup,
+        condensate_amounts=condensate_amounts,
+    )
+    initializer = GridCondensateEquilibriumInitializer(grid, "test")
+
+    @jax.jit
+    def lookup(temperature, pressure, composition):
+        result = initializer(
+            CondensateEquilibriumInitRequest(
+                setup=setup,
+                T=temperature,
+                P=pressure,
+                b=jnp.asarray([1.0, 0.1, 0.02, 0.0]),
+                explicit_log10_z_over_z_sun=composition,
+            )
+        )
+        return (
+            result.gas_ln_n,
+            result.gas_ntot,
+            result.condensate_amounts,
+            result.support_amounts,
+        )
+
+    gas_ln_n, gas_ntot, condensates, support_amounts = lookup(
+        jnp.asarray(1000.0),
+        jnp.asarray(0.5),
+        jnp.asarray(0.0),
+    )
+
+    assert jnp.allclose(gas_ln_n, jnp.zeros((2,)))
+    assert jnp.isclose(gas_ntot, 1.0)
+    assert jnp.allclose(condensates, jnp.asarray([1.0, 0.0, 1.0]))
+    assert jnp.allclose(support_amounts, jnp.asarray([1.0, 1.0]))
+    slope = jax.grad(
+        lambda temperature: jnp.sum(
+            lookup(temperature, 0.5, 0.0)[3]
+        )
+    )(1000.0)
+    assert jnp.isclose(slope, 2.0e-3)
+
+
+def test_grid_condensate_initializer_is_exported_by_compatibility_api():
+    assert CompatibilityGridInitializer is GridCondensateEquilibriumInitializer
+    assert (
+        CompatibilityFixedSupportGrid
+        is FixedSupportCondensateEquilibriumGrid
+    )

--- a/tests/unittests/equilibrium/gas/grid/service_test.py
+++ b/tests/unittests/equilibrium/gas/grid/service_test.py
@@ -905,6 +905,35 @@ def test_interpolate_equilibrium_grid_returns_species_ordered_state():
     assert jnp.isclose(init.ln_ntot, jnp.log(result.ntot))
 
 
+def test_interpolate_equilibrium_grid_supports_singleton_axes():
+    grid = EquilibriumGrid(
+        temperature_axis=jnp.asarray([1000.0]),
+        pressure_axis=jnp.asarray([1.0]),
+        log10_z_over_z_sun_axis=jnp.asarray([0.0]),
+        outputs=EquilibriumGridOutputs(
+            ln_n=jnp.asarray([[[[-2.0, -3.0]]]]),
+            n=jnp.asarray([[[[0.2, 0.1]]]]),
+            x=jnp.asarray([[[[2.0 / 3.0, 1.0 / 3.0]]]]),
+            ntot=jnp.asarray([[[0.3]]]),
+        ),
+        metadata=EquilibriumGridMetadata(
+            preset_name="fake",
+            preset_setup_metadata={"source": "test"},
+            preset_elements=("H",),
+            preset_species=("A", "B"),
+            source="exogibbs",
+            verify_exogibbs_against_fastchem=False,
+        ),
+    )
+
+    result = interpolate_equilibrium_grid(grid, 1000.0, 1.0, 0.0)
+
+    assert jnp.allclose(result.ln_n, jnp.asarray([-2.0, -3.0]))
+    assert jnp.isclose(result.ntot, 0.3)
+    with pytest.raises(ValueError, match="outside"):
+        interpolate_equilibrium_grid(grid, 1000.0, 2.0, 0.0)
+
+
 def test_equilibrium_grid_interpolate_method_works_after_netcdf_roundtrip(tmp_path):
     grid = EquilibriumGrid(
         temperature_axis=jnp.asarray([1000.0, 2000.0]),

--- a/tests/unittests/examples/vjp_retrieval_condensate_test.py
+++ b/tests/unittests/examples/vjp_retrieval_condensate_test.py
@@ -16,6 +16,8 @@ import pytest
 from exogibbs.equilibrium.condensate.fixed_support.types import (
     DifferentiableFixedSupportResult,
 )
+from exogibbs.equilibrium.condensate.types import CondensateEquilibriumInit
+from exogibbs.equilibrium.gas.types import EquilibriumInit
 
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
@@ -24,6 +26,12 @@ EXAMPLE_PATH = (
     / "examples"
     / "retrievals"
     / "exojax_nuts_condensate_fixed_support.py"
+)
+GRID_EXAMPLE_PATH = (
+    REPOSITORY_ROOT
+    / "examples"
+    / "retrievals"
+    / "exojax_nuts_condensate_grid.py"
 )
 
 
@@ -52,7 +60,7 @@ def test_example_is_main_guarded_and_states_local_contract():
     assert "rainout" in source
     assert "C/O = 2" in source
     assert "full-catalog equilibrium is not supported" in source
-    assert "fixed_gas_log_amounts_init=plan.hybrid_log_amounts_init" in source
+    assert "fixed_gas_log_amounts_init=fixed_gas_log_amounts_init" in source
 
     guarded_main = [
         node
@@ -68,6 +76,18 @@ def test_example_is_main_guarded_and_states_local_contract():
         )
     ]
     assert len(guarded_main) == 1
+
+
+def test_condensate_grid_wrapper_selects_shared_grid_runner():
+    source = GRID_EXAMPLE_PATH.read_text(encoding="utf-8")
+    common_source = EXAMPLE_PATH.read_text(encoding="utf-8")
+
+    compile(source, str(GRID_EXAMPLE_PATH), "exec")
+    assert "use_grid_initializer=True" in source
+    assert "run_condensate_demo" in source
+    assert "use_grid_initializer=False" in common_source
+    assert "interpolate_graphite_grid_initial_values" in common_source
+    assert "GridCondensateEquilibriumInitializer" in common_source
 
 
 def test_pressure_and_temperature_profiles_match_exojax_convention(
@@ -127,6 +147,71 @@ def test_condensate_model_declares_a_graphite_only_reduced_catalog(
     assert setup.condensate_setup.temperature_validity_upper == (6000.0,)
     assert metadata["temperature_validity_upper"] == (6000.0,)
     assert np.asarray(setup.condensate_setup.hvector_func(1160.0)).shape == (1,)
+    carbon = setup.elements.index("C")
+    oxygen = setup.elements.index("O")
+    reference = setup.gas_setup.element_vector_reference
+    assert float(reference[carbon] / reference[oxygen]) == pytest.approx(2.0)
+
+
+def test_grid_initial_values_are_interpolated_for_each_layer(
+    condensate_example,
+):
+    module = condensate_example
+
+    class FakeGasGridInitializer:
+        def __call__(self, request):
+            return EquilibriumInit(
+                ln_nk=jnp.asarray([request.T, request.P]),
+                ln_ntot=jnp.log(jnp.asarray(2.0)),
+            )
+
+    class FakeFixedGridInitializer:
+        def __call__(self, request):
+            return CondensateEquilibriumInit(
+                gas_ln_n=jnp.asarray([-request.T, -request.P]),
+                gas_ntot=jnp.asarray(3.0),
+                support_indices=(0,),
+                support_amounts=jnp.asarray([request.P]),
+            )
+
+    plan = SimpleNamespace(
+        grid_initializer=SimpleNamespace(
+            gas_initializer=FakeGasGridInitializer(),
+            fixed_initializers=(
+                FakeFixedGridInitializer(),
+                FakeFixedGridInitializer(),
+            ),
+        ),
+        setup=SimpleNamespace(
+            gas_setup=SimpleNamespace(),
+            gas_species=("A", "B"),
+        ),
+        pressures_bar=jnp.asarray([0.1, 1.0, 10.0]),
+        active_indices=(0, 2),
+        graphite_amounts_init=jnp.ones((3,)),
+    )
+    temperatures = jnp.asarray([900.0, 1000.0, 1100.0])
+
+    initial = module.interpolate_graphite_grid_initial_values(
+        plan,
+        temperatures,
+        jnp.asarray([1.0, 0.1]),
+    )
+
+    np.testing.assert_allclose(initial.gas_log_amounts[:, 0], temperatures)
+    np.testing.assert_allclose(
+        initial.gas_log_amounts[:, 1], plan.pressures_bar
+    )
+    np.testing.assert_allclose(initial.gas_total_log_amounts, np.log(2.0))
+    np.testing.assert_allclose(
+        initial.fixed_gas_log_amounts[:, 0],
+        [-900.0, 1000.0, -1100.0],
+    )
+    np.testing.assert_allclose(
+        initial.fixed_total_log_amounts,
+        [np.log(3.0), np.log(2.0), np.log(3.0)],
+    )
+    np.testing.assert_allclose(initial.graphite_amounts, [0.1, 1.0, 10.0])
 
 
 def test_hybrid_solver_uses_static_condensate_and_gas_partitions(


### PR DESCRIPTION
## Summary

- add a public fixed-support condensate equilibrium grid and initializer that interpolate the gas state and condensate amounts from the same grid point
- reuse gas-grid composition, metadata, and interpolation helpers, including singleton-axis interpolation for layer-local pressure grids
- propagate valid condensate initializer gas seeds through the production profile lifecycle
- add the `exojax_nuts_condensate_grid` example, generated tutorial, GPU launcher case, and targeted regression tests

## Motivation

Gas-only retrievals can use a grid initializer, while the condensate retrieval previously relied on one frozen nominal state. This adds parameter-dependent numerical initial values for condensate solves while keeping phase support static and outside automatic differentiation.

## Contract and impact

The new grid represents one fixed condensate support. It validates gas and condensate setup metadata and interpolates gas log amounts, gas total amount, and active condensate amounts together. Support discovery, phase transitions, full-catalog support closure, and rainout remain outside this contract.

The tutorial uses a shared gas grid for inactive layers and one local graphite fixed-support grid per active layer. Its preflight checks all eight prior corners for support stability, converged grid/no-grid primal equivalence, and fixed-support iteration non-regression.

## Validation

- `JAX_PLATFORMS=cpu pytest -q tests/unittests`: 407 passed
- focused initializer, interpolation, lifecycle, and example tests: 57 passed after the final wording update
- notebook converter `--check`, notebook JSON validation, `compileall`, `tcsh -n`, and `git diff --check`: passed
- CUDA NUTS run: 1,000 samples, 0 divergences, maximum fixed-support iterations reduced from 4 to 0, maximum corner CO VMR difference `7.90e-12`

The measured eight-layer tutorial runtime was 173.75 s with the grid versus 170.96 s for the frozen baseline, so this PR does not claim a wall-time speedup for that case.