### PR TITLE
benchmarks: add documented example timing matrix

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -4,6 +4,8 @@ Current benchmark runners:
 
 - `python -m benchmarks.run_single_layer`
 - `python -m benchmarks.run_profile`
+- `python -m benchmarks.documented_examples.run`
+- `python -m benchmarks.documented_examples.ldwarf_repeated`
 - `python -m benchmarks.fastchem4.run_production_comparison` (requires an
   external FastChem v4.0.3 standalone executable)
 
@@ -11,6 +13,8 @@ The fixed-support v2 production-profile gate and frozen pre-promotion evidence
 are documented in `benchmarks/fixed_support_v2/README.md`.
 The independent production comparison with FastChem 4 is documented in
 `benchmarks/fastchem4/README.md`.
+The CPU/GPU and compiler-option timing matrix for all documentation examples
+is documented in `benchmarks/documented_examples/README.md`.
 
 Run from the repository root with `PYTHONPATH=src`.
 

--- a/benchmarks/documented_examples/README.md
+++ b/benchmarks/documented_examples/README.md
@@ -1,0 +1,219 @@
+# Documented example benchmarks
+
+This suite measures the ExoGibbs solver workloads behind every entry in the
+`EXAMPLES` toctree in `documents/index.rst`. It is a performance regression
+surface, not a replacement for the scientific comparisons in those examples.
+
+The registered workloads are:
+
+- Visscher (2006) / Morley (2012) KCl and Na2S scans;
+- Visscher (2010) silicate phase competition;
+- Ito (2025) propagated rainout;
+- reduced Fe-FeS local equilibrium and rainout;
+- the full-catalog L-dwarf condensate and gas profiles.
+
+`manifest.py` is deliberately explicit. The unit tests compare it with the
+documentation toctree, so adding a documentation example requires adding one
+benchmark adapter rather than silently leaving the new workload unmeasured.
+
+## Quick check
+
+Run one layer of a small case on CPU:
+
+```console
+PYTHONPATH=src:. python -m benchmarks.documented_examples.run \
+  --case fe_fes_rainout_demo \
+  --platform cpu \
+  --optimization default \
+  --smoke-layers 1 \
+  --output-directory results/documented_example_benchmarks/smoke
+```
+
+Smoke results are marked `scope.kind = "smoke"` and must not be used as
+release baselines.
+
+## Repeated L-dwarf forward benchmark
+
+The optional repeated benchmark separates one cold nominal full-catalog
+L-dwarf profile from ten synchronized evaluations with deterministic, smooth,
+small T-P perturbations:
+
+```console
+PYTHONPATH=src:. python -m benchmarks.documented_examples.ldwarf_repeated \
+  --platform gpu \
+  --optimization default \
+  --output results/documented_example_benchmarks/ldwarf_repeated_gpu.json
+```
+
+Setup and the cold call are excluded from the reported steady mean, median,
+and p95. The ten raw evaluation records are written beside the JSON as
+`*.evaluations.csv`. Later executable shapes and compilation are retained and
+flagged; they are never silently subtracted from the warm measurements.
+The recorded `.lower(...).compile()` boundary can remain slightly nonzero on
+an in-memory cache hit; a genuinely new warm executable is identified from a
+shape signature not observed by the cold call.
+Use `--optimization disable_most_optimizations` with a different output path
+to measure the same ten inputs under the compile-light JAX mode.
+
+This measures the public full-catalog production forward path, including
+support discovery, host lifecycle work, and zero-barrier refinement. It omits
+the comparison figure's separate gas-only profile. It is useful as a
+NUTS-like forward-throughput probe, but it is not a JIT-compiled
+value-and-gradient, spectral likelihood, or NUTS-transition benchmark.
+
+## Full benchmark matrix
+
+Run the complete GPU sequence (five documented workloads under both compiler
+modes, followed by the two L-dwarf cold-plus-ten-warm runs) with:
+
+```console
+csh benchmarks/documented_examples/run_all_gpu.csh
+```
+
+An optional output directory may be supplied as the only argument.
+
+The default command runs all five cases in separate CPU/GPU processes with
+both compiler modes:
+
+```console
+PYTHONPATH=src:. python -m benchmarks.documented_examples.run \
+  --output-directory results/documented_example_benchmarks/baseline
+```
+
+For a stable baseline, run the workstation otherwise idle and use at least
+three repetitions:
+
+```console
+PYTHONPATH=src:. python -m benchmarks.documented_examples.run \
+  --repeat 3 \
+  --output-directory results/documented_example_benchmarks/baseline
+```
+
+The two compiler modes are:
+
+- `default`: `jax_disable_most_optimizations = false`;
+- `disable_most_optimizations`: the JAX option is explicitly enabled before
+  JAX is imported.
+
+The second mode sets XLA's backend optimization level to zero in JAX versions
+that support it. It can shorten compilation while producing a slower
+executable, so compare compile and execution time together. A worker records
+`unsupported` instead of silently falling back when the installed JAX does
+not expose this option.
+
+CPU, GPU, and compiler modes are separate processes. The suite disables JAX's
+persistent compilation cache so that each worker measures cold compilation.
+Warm reuse inside one documented workload remains visible: JSON records the
+first and repeated compilation time for each PD-IPM solve executable shape.
+The suite also pins each worker to this checkout's `src/exogibbs` tree and
+records both its import path and source-tree fingerprint.
+
+## Timing definitions
+
+Each worker writes a detailed JSON result. The suite also writes
+`summary.json`, `summary.csv`, `summary.md`, and a long-form
+`phase_budgets.csv`. The additive budget is worker/suite schema v2; v1
+artifacts predate this breakdown and must be regenerated for budget analysis.
+
+- `workload_wall_seconds`: example/workload imports, setup, and all measured
+  solver phases. It starts after worker startup, JAX import, device
+  initialization, and environment preflight.
+- `solver_phase_wall_seconds`: named ExoGibbs solve workflows, including the
+  caller's synchronization, fixed-point orchestration, and result conversion.
+  Ito's propagated-rainout phase also constructs its solver setup inside the
+  documented helper, so compare its finer PD-IPM/zero-barrier leaves when
+  separating solver-core work from orchestration.
+- `setup_phase_wall_seconds`: explicitly named catalog, data-loading, and
+  reduced-setup phases.
+- `unphased_workload_wall_seconds`: imports, validation, and other workload
+  work outside named setup and solver phases.
+- `pdipm.compilation_seconds`: sum of explicit JAX
+  `.lower(...).compile()` calls in the fixed-support solver.
+- `pdipm.execution_seconds`: compiled PD-IPM calls, synchronized before the
+  timer stops. Unsynchronized input preparation on which the executable
+  depends can be charged here, so this is a synchronized execution boundary,
+  not a pure kernel profile.
+- `pdipm.diagnostic_compilation_seconds` and
+  `pdipm.diagnostic_execution_seconds`: explicit terminal-diagnostic
+  compilation and synchronized execution. Their sum is retained as
+  `pdipm.diagnostic_seconds`.
+- `zero_barrier.host_wall_seconds`: host-observed wall time around the
+  SciPy/NumPy zero-barrier refinement. The optimization runs on the CPU even
+  when PD-IPM uses a GPU, but this boundary can also include input transfer
+  and device synchronization needed by the host call.
+- `solver_budget.pdipm_internal_orchestration_wall_seconds`: time inside the
+  fixed-support batch wrapper outside its explicit compile, execute, and
+  diagnostic timers, including batch preparation and result assembly.
+- `solver_budget.outside_pdipm_and_zero_barrier_wall_seconds`: time in solver
+  phases outside the fixed-support and zero-barrier wrappers. It includes
+  support selection and closure, gas solves, result construction, transfers,
+  and other orchestration.
+- `other_solver_and_orchestration_wall_seconds`: compatibility total equal to
+  the preceding two residuals.
+
+The solver budget is an additive partition:
+
+```text
+solver phase wall
+= PD-IPM compile
++ PD-IPM execute
++ diagnostic compile
++ diagnostic execute
++ PD-IPM internal orchestration
++ zero-barrier host work
++ work outside PD-IPM and zero-barrier
+```
+
+`pdipm_wall_seconds` is a parent subtotal, so do not add it again to its
+compile, execute, diagnostic, and internal-orchestration children. A PD-IPM
+call is one lifecycle invocation; a bucket is one same-support executable
+invocation within that call. Both counts are recorded.
+
+Every named setup or solver phase has the same partition in `phase_budgets`.
+This exposes, for example, the L-dwarf gas-only phase and the separate KCl,
+Na2S, silicate, local-equilibrium, and rainout solves without case-specific
+instrumentation. `phase_budgets.csv` puts those records in long form for
+cross-version comparisons.
+
+`timing_attribution_consistent` must be true for a valid result; it checks the
+solver and every phase partition and detects a future instrumentation change
+that double-counts named components. The residual categories deliberately do
+not add synchronization points. Because JAX dispatch is asynchronous, treat
+them as wall-time attribution rather than a device-kernel ownership profile.
+
+`output_layer_count` counts returned rows across the final documented
+profiles. Component call and bucket counts are cumulative, so they also expose
+repeated full-profile work such as the Ito pressure fixed-point iterations.
+`--smoke-layers N` limits each returned profile to at most N conditions; cases
+with paired profiles therefore return `2 * N` rows, while Ito returns `N`.
+
+The PD-IPM timing comes from the production timing boundary. The benchmark
+adds temporary wrappers around the production batch and zero-barrier entry
+points, and restores them after each workload. It does not change solver
+mathematics or public APIs.
+
+The measured scope excludes standalone FastChem execution, plotting, and file
+generation. Those tasks can obscure the solver regression this suite is
+intended to detect. The workload adapters import the example scripts' setup
+helpers, constants, conditions, and production API calls so they stay aligned
+with the documented calculations.
+
+## Reading results
+
+A performance number is valid only when `status` is `pass` and every expected
+output layer converged. Compare like for like:
+
+- same case and full/smoke scope;
+- same CPU or GPU backend and device;
+- same JAX, jaxlib, Python, revision, and diagnostic setting;
+- same compiler mode for regression baselines.
+
+To evaluate the compiler option itself, compare the paired `default` and
+`disable_most_optimizations` rows while holding every other item above fixed.
+Both rows must independently pass their convergence and physical audits.
+
+Do not add hard wall-time gates from a single run. Establish a versioned
+baseline with repeated runs first, then choose thresholds from the observed
+variance. Use `pdipm_repeated_shape_compilation_seconds` to identify accidental
+recompilation, and use the zero-barrier call and function-evaluation counts to
+distinguish host optimization regressions from JAX compile regressions.

--- a/benchmarks/documented_examples/__init__.py
+++ b/benchmarks/documented_examples/__init__.py
@@ -1,0 +1,1 @@
+"""Benchmarks for the solver workloads shown in the documentation."""

--- a/benchmarks/documented_examples/instrumentation.py
+++ b/benchmarks/documented_examples/instrumentation.py
@@ -1,0 +1,553 @@
+"""Non-invasive timing hooks for documented condensate workloads."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from contextlib import contextmanager
+import hashlib
+import math
+import time
+from typing import Any, Iterator, Mapping
+
+
+SOLVER_BUDGET_SCHEMA = "exogibbs_documented_example_solver_budget_v1"
+_ATTRIBUTION_ABSOLUTE_TOLERANCE_SECONDS = 1.0e-9
+
+
+def _shape(value: Any) -> tuple[int, ...] | None:
+    shape = getattr(value, "shape", None)
+    if shape is None:
+        return None
+    return tuple(int(item) for item in shape)
+
+
+def _float(mapping: Mapping[str, Any], name: str) -> float:
+    value = mapping.get(name, 0.0)
+    return float(value) if value is not None else 0.0
+
+
+def _diagnostic_timings(result: Mapping[str, Any]) -> tuple[float, float]:
+    """Return additive diagnostic compile and execution timings."""
+
+    total = _float(result, "diagnostic_seconds")
+    compilation = result.get("diagnostic_compilation_seconds")
+    execution = result.get("diagnostic_execution_seconds")
+    if compilation is None and execution is None:
+        return 0.0, total
+    if compilation is None:
+        execution_seconds = float(execution)
+        return total - execution_seconds, execution_seconds
+    if execution is None:
+        compilation_seconds = float(compilation)
+        return compilation_seconds, total - compilation_seconds
+    return float(compilation), float(execution)
+
+
+def _wall_budget(
+    *,
+    wall_seconds: float,
+    pdipm_calls: list[dict[str, Any]],
+    zero_barrier_calls: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Partition one wall interval without adding synchronization points."""
+
+    pdipm_wall = sum(float(call.get("wall_seconds", 0.0)) for call in pdipm_calls)
+    compilation = sum(
+        float(call.get("compilation_seconds", 0.0)) for call in pdipm_calls
+    )
+    execution = sum(
+        float(call.get("execution_seconds", 0.0)) for call in pdipm_calls
+    )
+    diagnostic = sum(
+        float(call.get("diagnostic_seconds", 0.0)) for call in pdipm_calls
+    )
+    diagnostic_compilation = sum(
+        float(call.get("diagnostic_compilation_seconds", 0.0))
+        for call in pdipm_calls
+    )
+    diagnostic_execution = sum(
+        float(call.get("diagnostic_execution_seconds", 0.0))
+        for call in pdipm_calls
+    )
+    pdipm_internal = pdipm_wall - compilation - execution - diagnostic
+    zero_barrier_wall = sum(
+        float(call.get("host_wall_seconds", 0.0))
+        for call in zero_barrier_calls
+    )
+    zero_barrier_function_evaluations = sum(
+        int(call["function_evaluations"])
+        for call in zero_barrier_calls
+        if call.get("function_evaluations") is not None
+    )
+    outside_instrumented_calls = wall_seconds - pdipm_wall - zero_barrier_wall
+    leaf_component_sum = (
+        compilation
+        + execution
+        + diagnostic_compilation
+        + diagnostic_execution
+        + pdipm_internal
+        + zero_barrier_wall
+        + outside_instrumented_calls
+    )
+    attribution_delta = wall_seconds - leaf_component_sum
+    scale = max(abs(wall_seconds), abs(leaf_component_sum), 1.0)
+    tolerance = _ATTRIBUTION_ABSOLUTE_TOLERANCE_SECONDS * scale
+    values = (
+        wall_seconds,
+        pdipm_wall,
+        compilation,
+        execution,
+        diagnostic,
+        diagnostic_compilation,
+        diagnostic_execution,
+        pdipm_internal,
+        zero_barrier_wall,
+        outside_instrumented_calls,
+        attribution_delta,
+    )
+    consistent = (
+        all(math.isfinite(value) for value in values)
+        and pdipm_internal >= -tolerance
+        and outside_instrumented_calls >= -tolerance
+        and abs(
+            diagnostic - diagnostic_compilation - diagnostic_execution
+        )
+        <= tolerance
+        and abs(attribution_delta) <= tolerance
+    )
+    return {
+        "schema": SOLVER_BUDGET_SCHEMA,
+        "wall_seconds": wall_seconds,
+        "pdipm_call_count": len(pdipm_calls),
+        "pdipm_bucket_count": sum(
+            len(call.get("buckets", ())) for call in pdipm_calls
+        ),
+        "pdipm_wall_seconds": pdipm_wall,
+        "pdipm_compilation_seconds": compilation,
+        "pdipm_execution_seconds": execution,
+        "pdipm_diagnostic_seconds": diagnostic,
+        "pdipm_diagnostic_compilation_seconds": diagnostic_compilation,
+        "pdipm_diagnostic_execution_seconds": diagnostic_execution,
+        "pdipm_internal_orchestration_wall_seconds": pdipm_internal,
+        "zero_barrier_call_count": len(zero_barrier_calls),
+        "zero_barrier_host_wall_seconds": zero_barrier_wall,
+        "zero_barrier_function_evaluations": (
+            zero_barrier_function_evaluations
+        ),
+        "outside_pdipm_and_zero_barrier_wall_seconds": (
+            outside_instrumented_calls
+        ),
+        "attribution_delta_seconds": attribution_delta,
+        "attribution_consistent": consistent,
+    }
+
+
+class TimingCollector:
+    """Collect solver-component timings without changing production code."""
+
+    def __init__(self) -> None:
+        self.phases: list[dict[str, Any]] = []
+        self.pdipm_calls: list[dict[str, Any]] = []
+        self.zero_barrier_calls: list[dict[str, Any]] = []
+        self._phase_stack: list[str] = []
+        self._phase_categories: list[str] = []
+        self._original_pdipm: Any = None
+        self._original_zero_barrier: Any = None
+        self._batch_module: Any = None
+        self._zero_barrier_module: Any = None
+
+    @property
+    def current_phase(self) -> str | None:
+        """Return the innermost active benchmark phase."""
+
+        return self._phase_stack[-1] if self._phase_stack else None
+
+    @property
+    def current_category(self) -> str | None:
+        """Return the category of the innermost active phase."""
+
+        return self._phase_categories[-1] if self._phase_categories else None
+
+    def __enter__(self) -> "TimingCollector":
+        from exogibbs.equilibrium.condensate.fixed_support import batch
+        from exogibbs.equilibrium.condensate.fixed_support import zero_barrier
+
+        self._batch_module = batch
+        self._zero_barrier_module = zero_barrier
+        self._original_pdipm = batch.run_fixed_support_profile
+        self._original_zero_barrier = (
+            zero_barrier.polish_zero_barrier_active_support
+        )
+        batch.run_fixed_support_profile = self._timed_pdipm
+        zero_barrier.polish_zero_barrier_active_support = (
+            self._timed_zero_barrier
+        )
+        return self
+
+    def __exit__(self, *_exc_info: Any) -> None:
+        if self._batch_module is not None:
+            self._batch_module.run_fixed_support_profile = self._original_pdipm
+        if self._zero_barrier_module is not None:
+            self._zero_barrier_module.polish_zero_barrier_active_support = (
+                self._original_zero_barrier
+            )
+
+    @contextmanager
+    def phase(self, name: str, *, category: str) -> Iterator[None]:
+        """Measure one named setup or solver phase."""
+
+        self._phase_stack.append(name)
+        self._phase_categories.append(category)
+        started = time.perf_counter()
+        status = "pass"
+        error_message = None
+        try:
+            yield
+        except Exception as error:
+            status = "error"
+            error_message = f"{type(error).__name__}: {error}"
+            raise
+        finally:
+            wall_seconds = time.perf_counter() - started
+            self._phase_stack.pop()
+            self._phase_categories.pop()
+            self.phases.append(
+                {
+                    "name": name,
+                    "category": category,
+                    "wall_seconds": wall_seconds,
+                    "status": status,
+                    "error": error_message,
+                }
+            )
+
+    def _timed_pdipm(self, *args: Any, **kwargs: Any) -> Any:
+        phase = self.current_phase
+        category = self.current_category
+        started = time.perf_counter()
+        try:
+            result = self._original_pdipm(*args, **kwargs)
+        except Exception as error:
+            self.pdipm_calls.append(
+                {
+                    "phase": phase,
+                    "phase_category": category,
+                    "wall_seconds": time.perf_counter() - started,
+                    "status": "error",
+                    "error": f"{type(error).__name__}: {error}",
+                    "buckets": (),
+                }
+            )
+            raise
+
+        wall_seconds = time.perf_counter() - started
+        formula_matrix = kwargs.get("formula_matrix")
+        if formula_matrix is None and len(args) >= 2:
+            formula_matrix = args[1]
+        formula_shape = _shape(formula_matrix)
+        include_diagnostics = bool(
+            kwargs.get("include_terminal_diagnostics", True)
+        )
+        diagnostic_compilation, diagnostic_execution = _diagnostic_timings(
+            result
+        )
+        config = kwargs.get("config")
+        config_fingerprint = hashlib.sha256(
+            repr(config).encode("utf-8")
+        ).hexdigest()[:12]
+        bucket_records = []
+        for bucket_index, report in enumerate(result.get("bucket_reports", ())):
+            support_indices = tuple(
+                int(item) for item in report.get("support_indices", ())
+            )
+            layer_indices = tuple(
+                int(item) for item in report.get("layer_indices", ())
+            )
+            element_count = formula_shape[0] if formula_shape else None
+            gas_count = formula_shape[1] if formula_shape else None
+            signature = (
+                f"backend={result.get('backend', 'unknown')},"
+                f"dtype={getattr(formula_matrix, 'dtype', None)},"
+                f"config={config_fingerprint},"
+                f"elements={element_count},gas={gas_count},"
+                f"support={len(support_indices)},batch={len(layer_indices)},"
+                f"diagnostics={int(include_diagnostics)}"
+            )
+            bucket_diagnostic_compilation, bucket_diagnostic_execution = (
+                _diagnostic_timings(report)
+            )
+            bucket_records.append(
+                {
+                    "bucket_index": bucket_index,
+                    "signature": signature,
+                    "support_count": len(support_indices),
+                    "batch_size": len(layer_indices),
+                    "support_indices": support_indices,
+                    "layer_indices": layer_indices,
+                    "compilation_seconds": _float(
+                        report, "compilation_seconds"
+                    ),
+                    "execution_seconds": _float(report, "execution_seconds"),
+                    "diagnostic_compilation_seconds": (
+                        bucket_diagnostic_compilation
+                    ),
+                    "diagnostic_execution_seconds": (
+                        bucket_diagnostic_execution
+                    ),
+                }
+            )
+        self.pdipm_calls.append(
+            {
+                "phase": phase,
+                "phase_category": category,
+                "wall_seconds": wall_seconds,
+                "status": "pass",
+                "error": None,
+                "compilation_seconds": _float(result, "compilation_seconds"),
+                "execution_seconds": _float(result, "execution_seconds"),
+                "diagnostic_seconds": _float(result, "diagnostic_seconds"),
+                "diagnostic_compilation_seconds": diagnostic_compilation,
+                "diagnostic_execution_seconds": diagnostic_execution,
+                "backend": str(result.get("backend", "unknown")),
+                "buckets": tuple(bucket_records),
+            }
+        )
+        return result
+
+    def _timed_zero_barrier(self, *args: Any, **kwargs: Any) -> Any:
+        phase = self.current_phase
+        category = self.current_category
+        started = time.perf_counter()
+        try:
+            result = self._original_zero_barrier(*args, **kwargs)
+        except Exception as error:
+            self.zero_barrier_calls.append(
+                {
+                    "phase": phase,
+                    "phase_category": category,
+                    "host_wall_seconds": (
+                        time.perf_counter() - started
+                    ),
+                    "status": "error",
+                    "error": f"{type(error).__name__}: {error}",
+                    "function_evaluations": None,
+                }
+            )
+            raise
+
+        report = result.report if isinstance(result.report, Mapping) else {}
+        closure = report.get("exact_active_set_closure", {})
+        if not isinstance(closure, Mapping):
+            closure = {}
+        function_evaluations = closure.get(
+            "cumulative_function_evaluations",
+            report.get("function_evaluations"),
+        )
+        self.zero_barrier_calls.append(
+            {
+                "phase": phase,
+                "phase_category": category,
+                "host_wall_seconds": (
+                    time.perf_counter() - started
+                ),
+                "execution_location": "host_cpu",
+                "status": "pass",
+                "error": None,
+                "accepted": bool(result.accepted),
+                "initial_support_count": len(kwargs.get("support_indices", ())),
+                "final_support_count": len(result.support_indices),
+                "function_evaluations": (
+                    None
+                    if function_evaluations is None
+                    else int(function_evaluations)
+                ),
+                "active_set_round_count": (
+                    None
+                    if closure.get("round_count") is None
+                    else int(closure["round_count"])
+                ),
+                "termination_reason": closure.get("termination_reason"),
+            }
+        )
+        return result
+
+    def summary(self, *, workload_wall_seconds: float) -> dict[str, Any]:
+        """Return the stable timing summary and detailed call records."""
+
+        solver_wall_seconds = sum(
+            float(phase["wall_seconds"])
+            for phase in self.phases
+            if phase["category"] == "solver"
+        )
+        setup_wall_seconds = sum(
+            float(phase["wall_seconds"])
+            for phase in self.phases
+            if phase["category"] == "setup"
+        )
+        pdipm_compilation = sum(
+            float(call.get("compilation_seconds", 0.0))
+            for call in self.pdipm_calls
+        )
+        pdipm_execution = sum(
+            float(call.get("execution_seconds", 0.0))
+            for call in self.pdipm_calls
+        )
+        pdipm_diagnostics = sum(
+            float(call.get("diagnostic_seconds", 0.0))
+            for call in self.pdipm_calls
+        )
+        pdipm_diagnostic_compilation = sum(
+            float(call.get("diagnostic_compilation_seconds", 0.0))
+            for call in self.pdipm_calls
+        )
+        pdipm_diagnostic_execution = sum(
+            float(call.get("diagnostic_execution_seconds", 0.0))
+            for call in self.pdipm_calls
+        )
+        pdipm_wall = sum(
+            float(call.get("wall_seconds", 0.0))
+            for call in self.pdipm_calls
+        )
+        zero_barrier_wall = sum(
+            float(call["host_wall_seconds"])
+            for call in self.zero_barrier_calls
+        )
+
+        shape_groups: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        for call in self.pdipm_calls:
+            for bucket in call.get("buckets", ()):
+                shape_groups[str(bucket["signature"])].append(bucket)
+        shape_compilation = []
+        first_shape_compilation = 0.0
+        repeated_shape_compilation = 0.0
+        for signature, buckets in shape_groups.items():
+            first = float(buckets[0]["compilation_seconds"])
+            repeated = sum(
+                float(bucket["compilation_seconds"])
+                for bucket in buckets[1:]
+            )
+            first_shape_compilation += first
+            repeated_shape_compilation += repeated
+            shape_compilation.append(
+                {
+                    "signature": signature,
+                    "invocation_count": len(buckets),
+                    "first_compilation_seconds": first,
+                    "repeated_compilation_seconds": repeated,
+                }
+            )
+
+        solver_pdipm_calls = [
+            call
+            for call in self.pdipm_calls
+            if call.get("phase_category") == "solver"
+        ]
+        solver_zero_barrier_calls = [
+            call
+            for call in self.zero_barrier_calls
+            if call.get("phase_category") == "solver"
+        ]
+        solver_budget = _wall_budget(
+            wall_seconds=solver_wall_seconds,
+            pdipm_calls=solver_pdipm_calls,
+            zero_barrier_calls=solver_zero_barrier_calls,
+        )
+        phase_groups: dict[tuple[str, str], list[dict[str, Any]]] = {}
+        for phase in self.phases:
+            key = (str(phase["name"]), str(phase["category"]))
+            phase_groups.setdefault(key, []).append(phase)
+        phase_budgets = []
+        for (name, category), phases in phase_groups.items():
+            phase_pdipm_calls = [
+                call
+                for call in self.pdipm_calls
+                if call.get("phase") == name
+                and call.get("phase_category") == category
+            ]
+            phase_zero_barrier_calls = [
+                call
+                for call in self.zero_barrier_calls
+                if call.get("phase") == name
+                and call.get("phase_category") == category
+            ]
+            budget = _wall_budget(
+                wall_seconds=sum(
+                    float(phase["wall_seconds"]) for phase in phases
+                ),
+                pdipm_calls=phase_pdipm_calls,
+                zero_barrier_calls=phase_zero_barrier_calls,
+            )
+            phase_budgets.append(
+                {
+                    "name": name,
+                    "category": category,
+                    "invocation_count": len(phases),
+                    **budget,
+                }
+            )
+        function_evaluations = [
+            int(call["function_evaluations"])
+            for call in self.zero_barrier_calls
+            if call.get("function_evaluations") is not None
+        ]
+        other_solver_wall = (
+            solver_budget["pdipm_internal_orchestration_wall_seconds"]
+            + solver_budget[
+                "outside_pdipm_and_zero_barrier_wall_seconds"
+            ]
+        )
+        unphased_wall = (
+            float(workload_wall_seconds)
+            - setup_wall_seconds
+            - solver_wall_seconds
+        )
+        timing_consistent = (
+            solver_budget["attribution_consistent"]
+            and all(
+                budget["attribution_consistent"] for budget in phase_budgets
+            )
+            and unphased_wall
+            >= -_ATTRIBUTION_ABSOLUTE_TOLERANCE_SECONDS
+        )
+        return {
+            "workload_wall_seconds": float(workload_wall_seconds),
+            "setup_phase_wall_seconds": setup_wall_seconds,
+            "solver_phase_wall_seconds": solver_wall_seconds,
+            "unphased_workload_wall_seconds": unphased_wall,
+            "pdipm": {
+                "call_count": len(self.pdipm_calls),
+                "bucket_count": sum(
+                    len(call.get("buckets", ())) for call in self.pdipm_calls
+                ),
+                "compilation_seconds": pdipm_compilation,
+                "execution_seconds": pdipm_execution,
+                "diagnostic_seconds": pdipm_diagnostics,
+                "diagnostic_compilation_seconds": (
+                    pdipm_diagnostic_compilation
+                ),
+                "diagnostic_execution_seconds": pdipm_diagnostic_execution,
+                "wall_seconds": pdipm_wall,
+                "first_shape_compilation_seconds": first_shape_compilation,
+                "repeated_shape_compilation_seconds": (
+                    repeated_shape_compilation
+                ),
+                "executable_shape_count": len(shape_groups),
+                "shape_compilation": tuple(shape_compilation),
+                "calls": tuple(self.pdipm_calls),
+            },
+            "zero_barrier": {
+                "execution_location": "host_cpu",
+                "call_count": len(self.zero_barrier_calls),
+                "host_wall_seconds": zero_barrier_wall,
+                "function_evaluations": sum(function_evaluations),
+                "calls": tuple(self.zero_barrier_calls),
+            },
+            "other_solver_and_orchestration_wall_seconds": other_solver_wall,
+            "solver_budget": solver_budget,
+            "phase_budgets": tuple(phase_budgets),
+            "timing_attribution_consistent": timing_consistent,
+            "phases": tuple(self.phases),
+        }
+
+
+__all__ = ("SOLVER_BUDGET_SCHEMA", "TimingCollector")

--- a/benchmarks/documented_examples/ldwarf_repeated.py
+++ b/benchmarks/documented_examples/ldwarf_repeated.py
@@ -1,0 +1,804 @@
+"""Measure repeated warm L-dwarf production-profile evaluations."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+from pathlib import Path
+import platform as system_platform
+import resource
+import time
+import traceback
+from typing import Any, Mapping, Sequence
+
+import numpy as np
+
+from benchmarks.documented_examples.worker import _checkout_package_path
+from benchmarks.documented_examples.worker import _jax_environment
+from benchmarks.documented_examples.worker import _revision
+from benchmarks.documented_examples.worker import _source_provenance
+from benchmarks.documented_examples.worker import _timestamp
+from benchmarks.documented_examples.worker import _tree_fingerprint
+from benchmarks.documented_examples.worker import _write_json
+from benchmarks.documented_examples.worker import configure_jax_environment
+from benchmarks.documented_examples.worker import OPTIMIZATION_MODES
+
+
+SCHEMA = "exogibbs_ldwarf_repeated_profile_benchmark_v1"
+DEFAULT_EVALUATION_COUNT = 10
+DEFAULT_SEED = 0
+PRESSURE_OFFSET_LIMIT_DEX = 0.005
+TEMPERATURE_OFFSET_LIMIT_K = 10.0
+TEMPERATURE_TILT_LIMIT_K = 5.0
+SOURCE_SCRIPTS = (
+    "examples/comparisons/comparison_with_fastchem4_condensates.py",
+)
+
+
+def generate_conditions(
+    base_temperatures: Sequence[float],
+    base_pressures: Sequence[float],
+    *,
+    evaluation_count: int = DEFAULT_EVALUATION_COUNT,
+    seed: int = DEFAULT_SEED,
+) -> dict[str, Any]:
+    """Generate deterministic, smooth, non-extreme T-P perturbations."""
+
+    temperatures = np.asarray(base_temperatures, dtype=np.float64)
+    pressures = np.asarray(base_pressures, dtype=np.float64)
+    if evaluation_count <= 0:
+        raise ValueError("evaluation_count must be positive.")
+    if (
+        temperatures.ndim != 1
+        or pressures.ndim != 1
+        or temperatures.shape != pressures.shape
+        or temperatures.size == 0
+    ):
+        raise ValueError("Base T and P must be non-empty equal-length vectors.")
+    if not np.all(np.isfinite(temperatures)) or not np.all(
+        np.isfinite(pressures) & (pressures > 0.0)
+    ):
+        raise ValueError("Base T and P must be finite and P must be positive.")
+
+    generator = np.random.default_rng(seed)
+    unit_offsets = generator.uniform(-1.0, 1.0, size=(evaluation_count, 3))
+    pressure_offsets = PRESSURE_OFFSET_LIMIT_DEX * unit_offsets[:, 0]
+    temperature_offsets = TEMPERATURE_OFFSET_LIMIT_K * unit_offsets[:, 1]
+    temperature_tilts = TEMPERATURE_TILT_LIMIT_K * unit_offsets[:, 2]
+    coordinate = np.linspace(-1.0, 1.0, temperatures.size)
+    generated_pressures = pressures[None, :] * np.power(
+        10.0, pressure_offsets[:, None]
+    )
+    generated_temperatures = (
+        temperatures[None, :]
+        + temperature_offsets[:, None]
+        + temperature_tilts[:, None] * coordinate[None, :]
+    )
+    if not np.all(
+        np.isfinite(generated_temperatures) & (generated_temperatures > 0.0)
+    ) or not np.all(
+        np.isfinite(generated_pressures) & (generated_pressures > 0.0)
+    ):
+        raise RuntimeError("Generated T-P profiles must be finite and positive.")
+    if not np.all(np.diff(generated_pressures, axis=1) > 0.0):
+        raise RuntimeError("Generated pressure profiles are not monotonic.")
+    if not np.all(np.diff(generated_temperatures, axis=1) > 0.0):
+        raise RuntimeError("Generated temperature profiles are not monotonic.")
+
+    fingerprint_payload = {
+        "seed": seed,
+        "pressure_offset_limit_dex": PRESSURE_OFFSET_LIMIT_DEX,
+        "temperature_offset_limit_k": TEMPERATURE_OFFSET_LIMIT_K,
+        "temperature_tilt_limit_k": TEMPERATURE_TILT_LIMIT_K,
+        "temperature_k": generated_temperatures.tolist(),
+        "pressure_bar": generated_pressures.tolist(),
+    }
+    fingerprint = hashlib.sha256(
+        json.dumps(fingerprint_payload, sort_keys=True).encode("utf-8")
+    ).hexdigest()
+    return {
+        **fingerprint_payload,
+        "sha256": fingerprint,
+        "pressure_offset_dex": pressure_offsets.tolist(),
+        "temperature_offset_k": temperature_offsets.tolist(),
+        "temperature_tilt_k": temperature_tilts.tolist(),
+        "temperature_k": generated_temperatures,
+        "pressure_bar": generated_pressures,
+    }
+
+
+def steady_statistics(
+    wall_seconds: Sequence[float],
+) -> dict[str, float | int]:
+    """Summarize directly measured post-cold evaluation latency."""
+
+    values = np.asarray(wall_seconds, dtype=np.float64)
+    if values.ndim != 1 or values.size == 0:
+        raise ValueError("wall_seconds must contain at least one value.")
+    if not np.all(np.isfinite(values) & (values >= 0.0)):
+        raise ValueError("wall_seconds must be finite and non-negative.")
+    total = float(np.sum(values))
+    return {
+        "evaluation_count": int(values.size),
+        "total_wall_seconds": total,
+        "mean_wall_seconds_per_evaluation": float(np.mean(values)),
+        "median_wall_seconds_per_evaluation": float(np.median(values)),
+        "p95_wall_seconds_per_evaluation": float(np.percentile(values, 95.0)),
+        "minimum_wall_seconds_per_evaluation": float(np.min(values)),
+        "maximum_wall_seconds_per_evaluation": float(np.max(values)),
+        "standard_deviation_seconds": float(np.std(values)),
+    }
+
+
+def _budget_per_evaluation(
+    budget: Mapping[str, Any], evaluation_count: int
+) -> dict[str, float]:
+    names = (
+        "wall_seconds",
+        "pdipm_call_count",
+        "pdipm_bucket_count",
+        "pdipm_wall_seconds",
+        "pdipm_compilation_seconds",
+        "pdipm_execution_seconds",
+        "pdipm_diagnostic_seconds",
+        "pdipm_diagnostic_compilation_seconds",
+        "pdipm_diagnostic_execution_seconds",
+        "pdipm_internal_orchestration_wall_seconds",
+        "zero_barrier_call_count",
+        "zero_barrier_host_wall_seconds",
+        "zero_barrier_function_evaluations",
+        "outside_pdipm_and_zero_barrier_wall_seconds",
+    )
+    return {
+        name: float(budget[name]) / evaluation_count
+        for name in names
+    }
+
+
+def _support_signature(profile: Any) -> tuple[tuple[str, ...], ...]:
+    return tuple(
+        tuple(str(name) for name in layer.condensate_support_names)
+        for layer in profile.layers
+    )
+
+
+def _support_sha256(signature: Sequence[Sequence[str]]) -> str:
+    return hashlib.sha256(
+        json.dumps(signature, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def _profile_validation(profile: Any) -> dict[str, Any]:
+    from benchmarks.documented_examples.workloads import _profile_physical_audit
+    from benchmarks.documented_examples.workloads import _profile_summary
+
+    summary = _profile_summary(profile)
+    audit = _profile_physical_audit(profile)
+    signature = _support_signature(profile)
+    accepted = bool(
+        summary["all_layers_converged"]
+        and audit["all_layers_finite_and_physically_accepted"]
+    )
+    return {
+        "accepted": accepted,
+        "summary": summary,
+        "physical_audit": audit,
+        "support_signature": signature,
+        "support_sha256": _support_sha256(signature),
+    }
+
+
+def _shape_signatures(timing: Mapping[str, Any]) -> tuple[str, ...]:
+    pdipm = timing.get("pdipm", {})
+    if not isinstance(pdipm, Mapping):
+        return ()
+    records = pdipm.get("shape_compilation", ())
+    return tuple(
+        sorted(
+            str(record["signature"])
+            for record in records
+            if isinstance(record, Mapping) and "signature" in record
+        )
+    )
+
+
+def _pdipm_support_signature(
+    calls: Sequence[Mapping[str, Any]],
+) -> tuple[tuple[tuple[tuple[int, ...], tuple[int, ...]], ...], ...]:
+    """Return the exact fixed-support buckets used by each PD-IPM call."""
+
+    return tuple(
+        tuple(
+            sorted(
+                (
+                    tuple(int(value) for value in bucket.get("layer_indices", ())),
+                    tuple(
+                        int(value)
+                        for value in bucket.get("support_indices", ())
+                    ),
+                )
+                for bucket in call.get("buckets", ())
+            )
+        )
+        for call in calls
+    )
+
+
+def _new_shape_signatures(
+    cold_timing: Mapping[str, Any], steady_timing: Mapping[str, Any]
+) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            set(_shape_signatures(steady_timing))
+            - set(_shape_signatures(cold_timing))
+        )
+    )
+
+
+def _result_status(
+    *, all_evaluations_accepted: bool, timing_attribution_consistent: bool
+) -> str:
+    if not all_evaluations_accepted:
+        return "fail_validation"
+    if not timing_attribution_consistent:
+        return "fail_timing"
+    return "pass"
+
+
+def _run_benchmark(
+    *, evaluation_count: int, seed: int, smoke_layers: int | None
+) -> dict[str, Any]:
+    import jax
+    import jax.numpy as jnp
+
+    from benchmarks.documented_examples.instrumentation import TimingCollector
+    from examples.comparisons import (
+        comparison_with_fastchem4_condensates as example,
+    )
+    from exogibbs.api.condensate import CondensateEquilibriumOptions
+
+    base_temperatures, base_pressures = example._profile_conditions("l-dwarf")
+    if smoke_layers is not None:
+        base_temperatures = base_temperatures[:smoke_layers]
+        base_pressures = base_pressures[:smoke_layers]
+    conditions = generate_conditions(
+        base_temperatures,
+        base_pressures,
+        evaluation_count=evaluation_count,
+        seed=seed,
+    )
+
+    setup_started = time.perf_counter()
+    setup = example.condensate_chemical_setup(
+        gas_path="FastChem4/logK/logK_wo_ions.dat",
+        condensate_path="FastChem4/logK/logK_condensates.dat",
+        species_default_elements=False,
+        element_file="FastChem4/element_abundances/asplund_2021.dat",
+        silent=True,
+    )
+    aligned_abundance = example.build_aligned_abundance_vector(
+        setup.elements,
+        source="fastchem_file",
+        normalize=True,
+        element_file=example.ELEMENT_FILE,
+    )
+    budget = jnp.asarray(aligned_abundance.vector, dtype=jnp.float64)
+    setup_seconds = time.perf_counter() - setup_started
+    options = CondensateEquilibriumOptions(return_diagnostics=False)
+
+    def solve(temperature: Any, pressure: Any) -> Any:
+        profile = example.solve_condensate_profile(
+            setup,
+            T=jnp.asarray(temperature, dtype=jnp.float64),
+            P=jnp.asarray(pressure, dtype=jnp.float64),
+            b=budget,
+            options=options,
+            return_diagnostics=False,
+        )
+        support_arrays = tuple(
+            layer.condensate_support_indices for layer in profile.layers
+        )
+        jax.block_until_ready((profile.batched_arrays, support_arrays))
+        return profile
+
+    cold_collector = TimingCollector()
+    cold_started = time.perf_counter()
+    with cold_collector:
+        with cold_collector.phase("cold_nominal", category="solver"):
+            cold_profile = solve(base_temperatures, base_pressures)
+    cold_validation = _profile_validation(cold_profile)
+    cold_workload_seconds = time.perf_counter() - cold_started
+    cold_timing = cold_collector.summary(
+        workload_wall_seconds=cold_workload_seconds
+    )
+    cold_shapes = set(_shape_signatures(cold_timing))
+    cold_pdipm_support = _pdipm_support_signature(
+        cold_timing["pdipm"]["calls"]
+    )
+
+    steady_collector = TimingCollector()
+    validations = []
+    steady_started = time.perf_counter()
+    with steady_collector:
+        for index in range(evaluation_count):
+            print(
+                f"STEADY {index + 1}/{evaluation_count}",
+                flush=True,
+            )
+            phase = f"evaluation_{index + 1:03d}"
+            with steady_collector.phase(phase, category="solver"):
+                profile = solve(
+                    conditions["temperature_k"][index],
+                    conditions["pressure_bar"][index],
+                )
+            validations.append(_profile_validation(profile))
+    steady_workload_seconds = time.perf_counter() - steady_started
+    steady_timing = steady_collector.summary(
+        workload_wall_seconds=steady_workload_seconds
+    )
+    phase_budgets = {
+        str(record["name"]): record
+        for record in steady_timing["phase_budgets"]
+    }
+    evaluation_records = []
+    evaluation_wall = []
+    cold_support = cold_validation["support_signature"]
+    seen_shapes = set(cold_shapes)
+    for index, validation in enumerate(validations):
+        phase = f"evaluation_{index + 1:03d}"
+        phase_budget = phase_budgets[phase]
+        phase_calls = tuple(
+            call
+            for call in steady_timing["pdipm"]["calls"]
+            if call.get("phase") == phase
+        )
+        phase_shapes = tuple(
+            sorted(
+                {
+                    str(bucket["signature"])
+                    for call in phase_calls
+                    for bucket in call.get("buckets", ())
+                }
+            )
+        )
+        phase_pdipm_support = _pdipm_support_signature(phase_calls)
+        new_phase_shapes = tuple(sorted(set(phase_shapes) - seen_shapes))
+        seen_shapes.update(phase_shapes)
+        changed_support_layers = tuple(
+            layer_index
+            for layer_index, (cold_layer, current_layer) in enumerate(
+                zip(cold_support, validation["support_signature"])
+            )
+            if cold_layer != current_layer
+        )
+        wall_seconds = float(phase_budget["wall_seconds"])
+        evaluation_wall.append(wall_seconds)
+        evaluation_records.append(
+            {
+                "evaluation": index + 1,
+                "temperature_offset_k": conditions["temperature_offset_k"][
+                    index
+                ],
+                "temperature_tilt_k": conditions["temperature_tilt_k"][index],
+                "pressure_offset_dex": conditions["pressure_offset_dex"][index],
+                "minimum_temperature_k": float(
+                    np.min(conditions["temperature_k"][index])
+                ),
+                "maximum_temperature_k": float(
+                    np.max(conditions["temperature_k"][index])
+                ),
+                "minimum_pressure_bar": float(
+                    np.min(conditions["pressure_bar"][index])
+                ),
+                "maximum_pressure_bar": float(
+                    np.max(conditions["pressure_bar"][index])
+                ),
+                "wall_seconds": wall_seconds,
+                "validation": validation,
+                "executable_shape_signatures": phase_shapes,
+                "pdipm_support_signature": phase_pdipm_support,
+                "pdipm_support_identity_preserved": (
+                    phase_pdipm_support == cold_pdipm_support
+                ),
+                "new_executable_shape_signatures_after_cold": (
+                    new_phase_shapes
+                ),
+                "changed_support_layer_indices": changed_support_layers,
+                "budget": phase_budget,
+            }
+        )
+
+    new_shapes = _new_shape_signatures(cold_timing, steady_timing)
+    final_support_preserved = all(
+        validation["support_signature"]
+        == cold_validation["support_signature"]
+        for validation in validations
+    )
+    pdipm_support_preserved = all(
+        record["pdipm_support_identity_preserved"]
+        for record in evaluation_records
+    )
+    all_accepted = cold_validation["accepted"] and all(
+        validation["accepted"] for validation in validations
+    )
+    statistics = steady_statistics(evaluation_wall)
+    cold_compilation_boundary = float(
+        cold_timing["solver_budget"]["pdipm_compilation_seconds"]
+        + cold_timing["solver_budget"][
+            "pdipm_diagnostic_compilation_seconds"
+        ]
+    )
+    steady_compilation_boundary = float(
+        steady_timing["solver_budget"]["pdipm_compilation_seconds"]
+        + steady_timing["solver_budget"][
+            "pdipm_diagnostic_compilation_seconds"
+        ]
+    )
+    timing_valid = bool(
+        cold_timing["timing_attribution_consistent"]
+        and steady_timing["timing_attribution_consistent"]
+    )
+    result_status = _result_status(
+        all_evaluations_accepted=all_accepted,
+        timing_attribution_consistent=timing_valid,
+    )
+    late_shape_evaluations = tuple(
+        record["evaluation"]
+        for record in evaluation_records
+        if record["new_executable_shape_signatures_after_cold"]
+    )
+    changed_support_evaluations = tuple(
+        record["evaluation"]
+        for record in evaluation_records
+        if record["changed_support_layer_indices"]
+    )
+    changed_pdipm_support_evaluations = tuple(
+        record["evaluation"]
+        for record in evaluation_records
+        if not record["pdipm_support_identity_preserved"]
+    )
+    steady_budget = steady_timing["solver_budget"]
+    return {
+        "status": result_status,
+        "scope": {
+            "kind": "smoke" if smoke_layers is not None else "full",
+            "scenario": "nuts_like_production_forward",
+            "nuts_representative": False,
+            "includes": (
+                "full-catalog production support lifecycle",
+                "fixed-support PD-IPM",
+                "host zero-barrier refinement",
+                "result construction and synchronization",
+            ),
+            "excludes": (
+                "independent gas-only comparison profile",
+                "reverse-mode gradient",
+                "spectral likelihood",
+                "NUTS transition logic",
+            ),
+        },
+        "configuration": {
+            "evaluation_count": evaluation_count,
+            "seed": seed,
+            "layer_count": len(base_temperatures),
+            "smoke_layers": smoke_layers,
+            "return_diagnostics": False,
+        },
+        "conditions": {
+            key: value.tolist() if isinstance(value, np.ndarray) else value
+            for key, value in conditions.items()
+        },
+        "setup": {"wall_seconds": setup_seconds},
+        "cold": {
+            "validation": cold_validation,
+            "timing": cold_timing,
+            "budget": cold_timing["solver_budget"],
+            "pdipm_compilation_boundary_seconds": (
+                cold_compilation_boundary
+            ),
+            "shape_signatures": tuple(sorted(cold_shapes)),
+            "pdipm_support_signature": cold_pdipm_support,
+        },
+        "steady": {
+            **statistics,
+            "workload_wall_seconds_including_validation": (
+                steady_workload_seconds
+            ),
+            "budget_total": steady_budget,
+            "budget_per_evaluation": _budget_per_evaluation(
+                steady_budget, evaluation_count
+            ),
+            "pdipm_compilation_boundary_seconds": (
+                steady_compilation_boundary
+            ),
+            "new_pdipm_executable_shape_count_after_cold": len(new_shapes),
+            "new_pdipm_executable_shape_signatures": new_shapes,
+            "late_shape_evaluations": late_shape_evaluations,
+            "no_new_pdipm_executable_shapes_after_cold": not new_shapes,
+            "final_support_identity_preserved": final_support_preserved,
+            "changed_final_support_evaluations": (
+                changed_support_evaluations
+            ),
+            "pdipm_support_identity_preserved": pdipm_support_preserved,
+            "changed_pdipm_support_evaluations": (
+                changed_pdipm_support_evaluations
+            ),
+            "nuts_fixed_support_assumption_met": (
+                final_support_preserved and pdipm_support_preserved
+            ),
+            "timing": steady_timing,
+            "evaluations": tuple(evaluation_records),
+        },
+        "validation": {
+            "all_evaluations_accepted": all_accepted,
+            "timing_attribution_consistent": timing_valid,
+            "final_support_identity_preserved": final_support_preserved,
+            "pdipm_support_identity_preserved": pdipm_support_preserved,
+            "failed_evaluations": tuple(
+                record["evaluation"]
+                for record in evaluation_records
+                if not record["validation"]["accepted"]
+            ),
+        },
+        "catalog": {
+            "element_count": len(setup.elements),
+            "gas_species_count": len(setup.gas_species),
+            "condensate_species_count": len(setup.condensate_species),
+        },
+    }
+
+
+def _evaluation_row(record: Mapping[str, Any]) -> dict[str, Any]:
+    budget = record["budget"]
+    return {
+        "evaluation": record["evaluation"],
+        "temperature_offset_k": record["temperature_offset_k"],
+        "temperature_tilt_k": record["temperature_tilt_k"],
+        "pressure_offset_dex": record["pressure_offset_dex"],
+        "minimum_temperature_k": record["minimum_temperature_k"],
+        "maximum_temperature_k": record["maximum_temperature_k"],
+        "minimum_pressure_bar": record["minimum_pressure_bar"],
+        "maximum_pressure_bar": record["maximum_pressure_bar"],
+        "wall_seconds": record["wall_seconds"],
+        "accepted": record["validation"]["accepted"],
+        "support_sha256": record["validation"]["support_sha256"],
+        "pdipm_support_identity_preserved": record[
+            "pdipm_support_identity_preserved"
+        ],
+        "executable_shape_signatures": ";".join(
+            record["executable_shape_signatures"]
+        ),
+        "new_executable_shape_signatures_after_cold": ";".join(
+            record["new_executable_shape_signatures_after_cold"]
+        ),
+        "changed_support_layer_indices": ";".join(
+            str(index) for index in record["changed_support_layer_indices"]
+        ),
+        "pdipm_call_count": budget["pdipm_call_count"],
+        "pdipm_bucket_count": budget["pdipm_bucket_count"],
+        "pdipm_wall_seconds": budget["pdipm_wall_seconds"],
+        "pdipm_compilation_seconds": budget["pdipm_compilation_seconds"],
+        "pdipm_execution_seconds": budget["pdipm_execution_seconds"],
+        "pdipm_diagnostic_seconds": budget["pdipm_diagnostic_seconds"],
+        "pdipm_diagnostic_compilation_seconds": budget[
+            "pdipm_diagnostic_compilation_seconds"
+        ],
+        "pdipm_diagnostic_execution_seconds": budget[
+            "pdipm_diagnostic_execution_seconds"
+        ],
+        "pdipm_internal_orchestration_wall_seconds": budget[
+            "pdipm_internal_orchestration_wall_seconds"
+        ],
+        "zero_barrier_call_count": budget["zero_barrier_call_count"],
+        "zero_barrier_host_wall_seconds": budget[
+            "zero_barrier_host_wall_seconds"
+        ],
+        "zero_barrier_function_evaluations": budget[
+            "zero_barrier_function_evaluations"
+        ],
+        "outside_pdipm_and_zero_barrier_wall_seconds": budget[
+            "outside_pdipm_and_zero_barrier_wall_seconds"
+        ],
+        "attribution_delta_seconds": budget["attribution_delta_seconds"],
+        "attribution_consistent": budget["attribution_consistent"],
+    }
+
+
+def _write_evaluations_csv(path: Path, records: Sequence[Mapping[str, Any]]) -> None:
+    rows = [_evaluation_row(record) for record in records]
+    with path.open("w", newline="") as output:
+        writer = csv.DictWriter(output, fieldnames=tuple(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _write_markdown(path: Path, payload: Mapping[str, Any]) -> None:
+    cold = payload["cold"]
+    steady = payload["steady"]
+    per_evaluation = steady["budget_per_evaluation"]
+    summary_rows = (
+        ("evaluation_count", steady["evaluation_count"]),
+        ("total_wall_seconds", steady["total_wall_seconds"]),
+        (
+            "mean_wall_seconds_per_evaluation",
+            steady["mean_wall_seconds_per_evaluation"],
+        ),
+        (
+            "median_wall_seconds_per_evaluation",
+            steady["median_wall_seconds_per_evaluation"],
+        ),
+        (
+            "p95_wall_seconds_per_evaluation",
+            steady["p95_wall_seconds_per_evaluation"],
+        ),
+        (
+            "new_pdipm_executable_shape_count_after_cold",
+            steady["new_pdipm_executable_shape_count_after_cold"],
+        ),
+        (
+            "pdipm_calls_per_evaluation",
+            per_evaluation["pdipm_call_count"],
+        ),
+        (
+            "pdipm_buckets_per_evaluation",
+            per_evaluation["pdipm_bucket_count"],
+        ),
+        (
+            "no_new_pdipm_executable_shapes_after_cold",
+            steady["no_new_pdipm_executable_shapes_after_cold"],
+        ),
+        (
+            "final_support_identity_preserved",
+            steady["final_support_identity_preserved"],
+        ),
+        (
+            "pdipm_support_identity_preserved",
+            steady["pdipm_support_identity_preserved"],
+        ),
+    )
+    budget_fields = (
+        "pdipm_compilation_seconds",
+        "pdipm_execution_seconds",
+        "pdipm_diagnostic_compilation_seconds",
+        "pdipm_diagnostic_execution_seconds",
+        "pdipm_internal_orchestration_wall_seconds",
+        "zero_barrier_host_wall_seconds",
+        "outside_pdipm_and_zero_barrier_wall_seconds",
+    )
+    lines = [
+        "# Repeated L-dwarf production-profile benchmark",
+        "",
+        f"Status: `{payload['status']}`",
+        "",
+        f"Cold solver wall: {cold['timing']['solver_phase_wall_seconds']} s",
+        "Cold explicit PD-IPM compile boundary: "
+        f"{cold['pdipm_compilation_boundary_seconds']} s",
+        f"Cold PD-IPM calls: {cold['budget']['pdipm_call_count']}",
+        f"Cold PD-IPM buckets: {cold['budget']['pdipm_bucket_count']}",
+        "",
+        "| Steady metric | Value |",
+        "| --- | ---: |",
+        *(f"| {name} | {value} |" for name, value in summary_rows),
+        "",
+        "| Additive wall budget per evaluation | Seconds |",
+        "| --- | ---: |",
+        *(f"| {name} | {per_evaluation[name]} |" for name in budget_fields),
+        "",
+        "This is a synchronized production forward benchmark, not a "
+        "value-and-gradient or NUTS transition benchmark.",
+    ]
+    path.write_text("\n".join(lines) + "\n")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--platform", choices=("cpu", "gpu"), required=True)
+    parser.add_argument(
+        "--optimization",
+        choices=OPTIMIZATION_MODES,
+        default="default",
+    )
+    parser.add_argument(
+        "--evaluations", type=int, default=DEFAULT_EVALUATION_COUNT
+    )
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
+    parser.add_argument("--smoke-layers", type=int, default=None)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    if args.evaluations <= 0:
+        raise SystemExit("--evaluations must be positive")
+    if args.smoke_layers is not None and args.smoke_layers <= 0:
+        raise SystemExit("--smoke-layers must be positive")
+
+    configure_jax_environment(args.platform, args.optimization)
+    repository_root = Path(__file__).resolve().parents[2]
+    payload: dict[str, Any] = {
+        "schema": SCHEMA,
+        "status": "running",
+        "started_at_utc": _timestamp(),
+        "execution": {
+            "requested_platform": args.platform,
+            "optimization_mode": args.optimization,
+        },
+        "revision": _revision(repository_root),
+        "solver_source_tree": _tree_fingerprint(
+            repository_root / "src" / "exogibbs"
+        ),
+        "source_provenance": _source_provenance(
+            repository_root, SOURCE_SCRIPTS
+        ),
+    }
+    try:
+        environment = _jax_environment(args.platform, args.optimization)
+        environment["exogibbs_package_root"] = _checkout_package_path(
+            repository_root
+        )
+        payload["environment"] = environment
+    except NotImplementedError as error:
+        payload.update(
+            {
+                "status": "unsupported",
+                "error": f"{type(error).__name__}: {error}",
+                "traceback": traceback.format_exc(),
+            }
+        )
+        return_code = 2
+    except Exception as error:
+        payload.update(
+            {
+                "status": "unavailable",
+                "error": f"{type(error).__name__}: {error}",
+                "traceback": traceback.format_exc(),
+            }
+        )
+        return_code = 2
+    else:
+        try:
+            result = _run_benchmark(
+                evaluation_count=args.evaluations,
+                seed=args.seed,
+                smoke_layers=args.smoke_layers,
+            )
+            payload.update(result)
+            return_code = 0 if payload["status"] == "pass" else 1
+        except Exception as error:
+            payload.update(
+                {
+                    "status": "error",
+                    "error": f"{type(error).__name__}: {error}",
+                    "traceback": traceback.format_exc(),
+                }
+            )
+            return_code = 1
+
+    usage = resource.getrusage(resource.RUSAGE_SELF)
+    maximum_resident_set_size_kb = float(usage.ru_maxrss)
+    if system_platform.system() == "Darwin":
+        maximum_resident_set_size_kb /= 1024.0
+    payload["resources"] = {
+        "maximum_resident_set_size_kb": maximum_resident_set_size_kb
+    }
+    payload["finished_at_utc"] = _timestamp()
+    if payload["status"] == "pass":
+        csv_path = args.output.with_name(f"{args.output.stem}.evaluations.csv")
+        markdown_path = args.output.with_name(f"{args.output.stem}.md")
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        _write_evaluations_csv(csv_path, payload["steady"]["evaluations"])
+        _write_markdown(markdown_path, payload)
+        payload["artifacts"] = {
+            "evaluations_csv": str(csv_path),
+            "summary_markdown": str(markdown_path),
+        }
+    _write_json(args.output, payload)
+    print(f"{payload['status'].upper()} {args.output}", flush=True)
+    return return_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/documented_examples/manifest.py
+++ b/benchmarks/documented_examples/manifest.py
@@ -1,0 +1,170 @@
+"""Manifest for the documented condensate example benchmark suite."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class DocumentedExampleCase:
+    """One documentation entry and its measured ExoGibbs workload."""
+
+    case_id: str
+    document: str
+    description: str
+    source_scripts: tuple[str, ...]
+    full_output_layer_count: int
+    output_rows_per_condition: int
+    expected_phases: tuple[tuple[str, str], ...]
+    workload: str
+    input_artifacts: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible manifest record."""
+
+        return asdict(self)
+
+    def expected_output_layer_count(self, smoke_layers: int | None) -> int:
+        """Return the output-row contract for a full or smoke workload."""
+
+        if smoke_layers is None:
+            return self.full_output_layer_count
+        condition_count = (
+            self.full_output_layer_count // self.output_rows_per_condition
+        )
+        return self.output_rows_per_condition * min(
+            smoke_layers, condition_count
+        )
+
+
+CASES = (
+    DocumentedExampleCase(
+        case_id="visscher_2006_na2s_morley_2012_kcl",
+        document="visscher_2006_na2s_morley_2012_kcl",
+        description="One-bar KCl and Na2S condensation scans",
+        source_scripts=(
+            "examples/comparisons/"
+            "comparison_with_visscher_2006_na2s_morley_2012_kcl.py",
+        ),
+        full_output_layer_count=174,
+        output_rows_per_condition=2,
+        expected_phases=(
+            ("build_reduced_setups", "setup"),
+            ("solve_kcl", "solver"),
+            ("solve_na2s", "solver"),
+        ),
+        workload="run_visscher_2006",
+    ),
+    DocumentedExampleCase(
+        case_id="visscher_2010_forsterite_enstatite_competition",
+        document="visscher_2010_forsterite_enstatite_competition",
+        description="Forsterite-enstatite-quartz competition scans",
+        source_scripts=(
+            "examples/comparisons/"
+            "comparison_with_visscher_2010_forsterite_enstatite.py",
+        ),
+        full_output_layer_count=254,
+        output_rows_per_condition=2,
+        expected_phases=(
+            ("build_reduced_setups", "setup"),
+            ("solve_with_enstatite", "solver"),
+            ("solve_without_enstatite", "solver"),
+        ),
+        workload="run_visscher_2010",
+    ),
+    DocumentedExampleCase(
+        case_id="ito_2025_rainout_comparison",
+        document="ito_2025_rainout_comparison",
+        description="Ito 2025 propagated H/O/Si rainout profile",
+        source_scripts=(
+            "examples/comparisons/comparison_with_ito_2025_rainout.py",
+            "examples/comparisons/comparison_with_ito_2025.py",
+        ),
+        full_output_layer_count=855,
+        output_rows_per_condition=1,
+        expected_phases=(
+            ("load_ito_profile", "setup"),
+            ("solve_propagated_rainout", "solver"),
+        ),
+        workload="run_ito_2025_rainout",
+        input_artifacts=("external_data/Ito_2025.xlsx",),
+    ),
+    DocumentedExampleCase(
+        case_id="fe_fes_rainout_demo",
+        document="fe_fes_rainout_demo",
+        description="Reduced Fe-FeS local-equilibrium and rainout profiles",
+        source_scripts=(
+            "examples/comparisons/demo_fe_fes_rainout.py",
+        ),
+        full_output_layer_count=34,
+        output_rows_per_condition=2,
+        expected_phases=(
+            ("build_reduced_setup", "setup"),
+            ("solve_local", "solver"),
+            ("solve_rainout", "solver"),
+        ),
+        workload="run_fe_fes_rainout",
+    ),
+    DocumentedExampleCase(
+        case_id="comparison_example_lineage",
+        document="comparison_example_lineage",
+        description="Full-catalog L-dwarf condensate and gas profiles",
+        source_scripts=(
+            "examples/comparisons/comparison_with_fastchem4_condensates.py",
+        ),
+        full_output_layer_count=26,
+        output_rows_per_condition=2,
+        expected_phases=(
+            ("build_full_catalog_setup", "setup"),
+            ("solve_condensate_profile", "solver"),
+            ("solve_gas_only_profile", "solver"),
+        ),
+        workload="run_fastchem4_l_dwarf",
+    ),
+)
+
+CASES_BY_ID = {case.case_id: case for case in CASES}
+
+
+def get_case(case_id: str) -> DocumentedExampleCase:
+    """Return one registered benchmark case."""
+
+    try:
+        return CASES_BY_ID[case_id]
+    except KeyError as error:
+        raise KeyError(f"Unknown documented example case: {case_id!r}") from error
+
+
+def example_documents_from_index(path: Path) -> tuple[str, ...]:
+    """Return entries from the EXAMPLES toctree in ``documents/index.rst``."""
+
+    lines = path.read_text().splitlines()
+    try:
+        caption_index = next(
+            index
+            for index, line in enumerate(lines)
+            if line.strip() == ":caption: EXAMPLES:"
+        )
+    except StopIteration as error:
+        raise ValueError("documents/index.rst has no EXAMPLES toctree.") from error
+
+    entries = []
+    for line in lines[caption_index + 1 :]:
+        stripped = line.strip()
+        if stripped.startswith(".. toctree::"):
+            break
+        if not stripped or stripped.startswith(":") or stripped.startswith(".."):
+            continue
+        entries.append(stripped.removesuffix(".rst"))
+    return tuple(entries)
+
+
+__all__ = (
+    "CASES",
+    "CASES_BY_ID",
+    "DocumentedExampleCase",
+    "example_documents_from_index",
+    "get_case",
+)

--- a/benchmarks/documented_examples/run.py
+++ b/benchmarks/documented_examples/run.py
@@ -1,0 +1,1000 @@
+"""Run the documented example benchmark matrix in isolated processes."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from datetime import datetime, timezone
+import json
+import math
+import os
+from pathlib import Path
+import subprocess
+import sys
+from typing import Any, Iterable, Mapping, Sequence
+
+from benchmarks.documented_examples.instrumentation import SOLVER_BUDGET_SCHEMA
+from benchmarks.documented_examples.manifest import CASES, CASES_BY_ID
+from benchmarks.documented_examples.worker import OPTIMIZATION_MODES
+from benchmarks.documented_examples.worker import SCHEMA as WORKER_SCHEMA
+
+
+SCHEMA = "exogibbs_documented_example_benchmark_suite_v2"
+PHASE_BUDGET_FIELDS = (
+    "case_id",
+    "platform",
+    "optimization",
+    "repetition",
+    "scope",
+    "status",
+    "phase_name",
+    "phase_category",
+    "phase_invocation_count",
+    "phase_wall_seconds",
+    "pdipm_call_count",
+    "pdipm_bucket_count",
+    "pdipm_wall_seconds",
+    "pdipm_compilation_seconds",
+    "pdipm_execution_seconds",
+    "pdipm_diagnostic_seconds",
+    "pdipm_diagnostic_compilation_seconds",
+    "pdipm_diagnostic_execution_seconds",
+    "pdipm_internal_orchestration_wall_seconds",
+    "zero_barrier_call_count",
+    "zero_barrier_host_wall_seconds",
+    "zero_barrier_function_evaluations",
+    "outside_pdipm_and_zero_barrier_wall_seconds",
+    "attribution_delta_seconds",
+    "attribution_consistent",
+)
+
+
+def _timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _slug_timestamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    temporary.replace(path)
+
+
+def _read_result(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as error:
+        return {
+            "status": "missing_result",
+            "error": f"{type(error).__name__}: {error}",
+        }
+    return payload if isinstance(payload, dict) else {"status": "invalid_result"}
+
+
+def _is_finite_number(value: Any) -> bool:
+    return (
+        not isinstance(value, bool)
+        and isinstance(value, (int, float))
+        and math.isfinite(float(value))
+    )
+
+
+def _budget_violations(
+    budget: Mapping[str, Any], *, label: str
+) -> list[str]:
+    violations = []
+    if budget.get("schema") != SOLVER_BUDGET_SCHEMA:
+        violations.append(f"pass result has invalid {label} schema")
+    wall_seconds = budget.get("wall_seconds")
+    tolerance = 1.0e-9 * max(
+        float(wall_seconds) if _is_finite_number(wall_seconds) else 0.0,
+        1.0,
+    )
+    for name in (
+        "wall_seconds",
+        "pdipm_wall_seconds",
+        "pdipm_compilation_seconds",
+        "pdipm_execution_seconds",
+        "pdipm_diagnostic_seconds",
+        "pdipm_diagnostic_compilation_seconds",
+        "pdipm_diagnostic_execution_seconds",
+        "pdipm_internal_orchestration_wall_seconds",
+        "zero_barrier_host_wall_seconds",
+        "outside_pdipm_and_zero_barrier_wall_seconds",
+        "attribution_delta_seconds",
+    ):
+        value = budget.get(name)
+        if not _is_finite_number(value) or (
+            name != "attribution_delta_seconds" and float(value) < -tolerance
+        ):
+            violations.append(f"pass result has invalid {label} metric {name}")
+    for name in (
+        "pdipm_call_count",
+        "pdipm_bucket_count",
+        "zero_barrier_call_count",
+        "zero_barrier_function_evaluations",
+    ):
+        value = budget.get(name)
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            violations.append(f"pass result has invalid {label} count {name}")
+    if budget.get("attribution_consistent") is not True:
+        violations.append(f"pass result has inconsistent {label} attribution")
+    values = {
+        name: float(budget[name])
+        for name in (
+            "wall_seconds",
+            "pdipm_wall_seconds",
+            "pdipm_compilation_seconds",
+            "pdipm_execution_seconds",
+            "pdipm_diagnostic_seconds",
+            "pdipm_diagnostic_compilation_seconds",
+            "pdipm_diagnostic_execution_seconds",
+            "pdipm_internal_orchestration_wall_seconds",
+            "zero_barrier_host_wall_seconds",
+            "outside_pdipm_and_zero_barrier_wall_seconds",
+            "attribution_delta_seconds",
+        )
+        if _is_finite_number(budget.get(name))
+    }
+    if len(values) == 11:
+        equations = (
+            (
+                values["pdipm_wall_seconds"],
+                values["pdipm_compilation_seconds"]
+                + values["pdipm_execution_seconds"]
+                + values["pdipm_diagnostic_seconds"]
+                + values["pdipm_internal_orchestration_wall_seconds"],
+                "PD-IPM partition",
+            ),
+            (
+                values["pdipm_diagnostic_seconds"],
+                values["pdipm_diagnostic_compilation_seconds"]
+                + values["pdipm_diagnostic_execution_seconds"],
+                "diagnostic partition",
+            ),
+            (
+                values["wall_seconds"],
+                values["pdipm_wall_seconds"]
+                + values["zero_barrier_host_wall_seconds"]
+                + values[
+                    "outside_pdipm_and_zero_barrier_wall_seconds"
+                ],
+                "wall partition",
+            ),
+        )
+        for actual, expected, equation in equations:
+            if not math.isclose(actual, expected, abs_tol=tolerance):
+                violations.append(
+                    f"pass result has inconsistent {label} {equation}"
+                )
+        if abs(values["attribution_delta_seconds"]) > tolerance:
+            violations.append(
+                f"pass result has nonzero {label} attribution delta"
+            )
+    return violations
+
+
+def _validate_worker_result(
+    payload: Mapping[str, Any],
+    *,
+    case_id: str,
+    platform: str,
+    optimization: str,
+    repetition: int,
+    smoke_layers: int | None,
+) -> tuple[str, ...]:
+    """Return contract violations for one isolated worker result."""
+
+    expected_scope = "full" if smoke_layers is None else "smoke"
+    checks = (
+        ("schema", payload.get("schema"), WORKER_SCHEMA),
+        ("case_id", _nested(payload, "case", "case_id"), case_id),
+        (
+            "platform",
+            _nested(payload, "execution", "requested_platform"),
+            platform,
+        ),
+        (
+            "optimization",
+            _nested(payload, "execution", "optimization_mode"),
+            optimization,
+        ),
+        (
+            "repetition",
+            _nested(payload, "execution", "repetition"),
+            repetition,
+        ),
+        ("scope", _nested(payload, "scope", "kind"), expected_scope),
+        (
+            "smoke_layers",
+            _nested(payload, "scope", "smoke_layers"),
+            smoke_layers,
+        ),
+    )
+    violations = [
+        f"{name}: {actual!r} != {expected!r}"
+        for name, actual, expected in checks
+        if actual != expected
+    ]
+    if payload.get("status") == "pass":
+        validation = payload.get("validation")
+        timing = payload.get("timing")
+        if not isinstance(validation, Mapping):
+            violations.append("pass result has no validation mapping")
+        else:
+            if validation.get("all_layers_converged") is not True:
+                violations.append("pass result did not accept every layer")
+            output_count = validation.get("output_layer_count")
+            if (
+                isinstance(output_count, bool)
+                or not isinstance(output_count, int)
+                or output_count <= 0
+            ):
+                violations.append("pass result has invalid output_layer_count")
+            elif smoke_layers is None:
+                expected_count = CASES_BY_ID[case_id].expected_output_layer_count(
+                    smoke_layers
+                )
+                if output_count != expected_count:
+                    violations.append(
+                        "full result output_layer_count: "
+                        f"{output_count!r} != {expected_count!r}"
+                    )
+            else:
+                expected_count = CASES_BY_ID[case_id].expected_output_layer_count(
+                    smoke_layers
+                )
+                if output_count != expected_count:
+                    violations.append(
+                        "smoke result output_layer_count: "
+                        f"{output_count!r} != {expected_count!r}"
+                    )
+        if not isinstance(timing, Mapping):
+            violations.append("pass result has no timing mapping")
+        else:
+            metric_paths = (
+                ("workload_wall_seconds",),
+                ("setup_phase_wall_seconds",),
+                ("solver_phase_wall_seconds",),
+                ("unphased_workload_wall_seconds",),
+                ("pdipm", "compilation_seconds"),
+                ("pdipm", "execution_seconds"),
+                ("pdipm", "diagnostic_seconds"),
+                ("pdipm", "diagnostic_compilation_seconds"),
+                ("pdipm", "diagnostic_execution_seconds"),
+                ("pdipm", "wall_seconds"),
+                ("zero_barrier", "host_wall_seconds"),
+            )
+            for path in metric_paths:
+                value = _nested(timing, *path)
+                if (
+                    not _is_finite_number(value)
+                    or float(value) < 0.0
+                ):
+                    violations.append(
+                        "pass result has invalid timing metric "
+                        + ".".join(path)
+                    )
+            for path in (
+                ("pdipm", "call_count"),
+                ("pdipm", "bucket_count"),
+                ("zero_barrier", "call_count"),
+            ):
+                value = _nested(timing, *path)
+                if (
+                    isinstance(value, bool)
+                    or not isinstance(value, int)
+                    or value < 0
+                ):
+                    violations.append(
+                        "pass result has invalid timing count "
+                        + ".".join(path)
+                    )
+            solver_budget = timing.get("solver_budget")
+            if not isinstance(solver_budget, Mapping):
+                violations.append("pass result has no solver_budget mapping")
+            else:
+                violations.extend(
+                    _budget_violations(solver_budget, label="solver_budget")
+                )
+            phase_budgets = timing.get("phase_budgets")
+            if not isinstance(phase_budgets, (list, tuple)) or not phase_budgets:
+                violations.append("pass result has no phase_budgets")
+            else:
+                for index, budget in enumerate(phase_budgets):
+                    if not isinstance(budget, Mapping):
+                        violations.append(
+                            f"pass result has invalid phase_budget[{index}]"
+                        )
+                        continue
+                    label = f"phase_budget[{index}]"
+                    violations.extend(_budget_violations(budget, label=label))
+                    if not isinstance(budget.get("name"), str):
+                        violations.append(f"pass result has invalid {label} name")
+                    if budget.get("category") not in ("setup", "solver"):
+                        violations.append(
+                            f"pass result has invalid {label} category"
+                        )
+                    invocation_count = budget.get("invocation_count")
+                    if (
+                        isinstance(invocation_count, bool)
+                        or not isinstance(invocation_count, int)
+                        or invocation_count <= 0
+                    ):
+                        violations.append(
+                            f"pass result has invalid {label} invocation_count"
+                        )
+                valid_phase_budgets = [
+                    budget
+                    for budget in phase_budgets
+                    if isinstance(budget, Mapping)
+                ]
+                actual_phases = {
+                    (budget.get("name"), budget.get("category"))
+                    for budget in valid_phase_budgets
+                }
+                expected_phases = set(CASES_BY_ID[case_id].expected_phases)
+                if actual_phases != expected_phases:
+                    violations.append(
+                        "pass result phase set differs from manifest"
+                    )
+                solver_phase_budgets = [
+                    budget
+                    for budget in valid_phase_budgets
+                    if budget.get("category") == "solver"
+                ]
+                if isinstance(solver_budget, Mapping):
+                    for name in (
+                        "pdipm_call_count",
+                        "pdipm_bucket_count",
+                        "pdipm_wall_seconds",
+                        "pdipm_compilation_seconds",
+                        "pdipm_execution_seconds",
+                        "pdipm_diagnostic_seconds",
+                        "pdipm_diagnostic_compilation_seconds",
+                        "pdipm_diagnostic_execution_seconds",
+                        "pdipm_internal_orchestration_wall_seconds",
+                        "zero_barrier_call_count",
+                        "zero_barrier_host_wall_seconds",
+                        "zero_barrier_function_evaluations",
+                        "outside_pdipm_and_zero_barrier_wall_seconds",
+                    ):
+                        phase_total = sum(
+                            float(budget.get(name, 0.0))
+                            for budget in solver_phase_budgets
+                            if _is_finite_number(budget.get(name))
+                        )
+                        expected_total = solver_budget.get(name)
+                        if _is_finite_number(expected_total) and not math.isclose(
+                            phase_total,
+                            float(expected_total),
+                            abs_tol=1.0e-9 * max(abs(phase_total), 1.0),
+                        ):
+                            violations.append(
+                                "pass result solver phase total differs from "
+                                f"solver_budget.{name}"
+                            )
+                for category, timing_name in (
+                    ("setup", "setup_phase_wall_seconds"),
+                    ("solver", "solver_phase_wall_seconds"),
+                ):
+                    phase_total = sum(
+                        float(budget["wall_seconds"])
+                        for budget in valid_phase_budgets
+                        if budget.get("category") == category
+                        and _is_finite_number(budget.get("wall_seconds"))
+                    )
+                    expected_total = timing.get(timing_name)
+                    if _is_finite_number(expected_total) and not math.isclose(
+                        phase_total,
+                        float(expected_total),
+                        abs_tol=1.0e-9 * max(abs(phase_total), 1.0),
+                    ):
+                        violations.append(
+                            f"pass result has inconsistent {category} phase total"
+                        )
+                global_component_paths = (
+                    ("pdipm_call_count", ("pdipm", "call_count")),
+                    ("pdipm_bucket_count", ("pdipm", "bucket_count")),
+                    ("pdipm_wall_seconds", ("pdipm", "wall_seconds")),
+                    (
+                        "pdipm_compilation_seconds",
+                        ("pdipm", "compilation_seconds"),
+                    ),
+                    (
+                        "pdipm_execution_seconds",
+                        ("pdipm", "execution_seconds"),
+                    ),
+                    (
+                        "pdipm_diagnostic_seconds",
+                        ("pdipm", "diagnostic_seconds"),
+                    ),
+                    (
+                        "pdipm_diagnostic_compilation_seconds",
+                        ("pdipm", "diagnostic_compilation_seconds"),
+                    ),
+                    (
+                        "pdipm_diagnostic_execution_seconds",
+                        ("pdipm", "diagnostic_execution_seconds"),
+                    ),
+                    (
+                        "zero_barrier_call_count",
+                        ("zero_barrier", "call_count"),
+                    ),
+                    (
+                        "zero_barrier_host_wall_seconds",
+                        ("zero_barrier", "host_wall_seconds"),
+                    ),
+                    (
+                        "zero_barrier_function_evaluations",
+                        ("zero_barrier", "function_evaluations"),
+                    ),
+                )
+                for budget_name, path in global_component_paths:
+                    phase_total = sum(
+                        float(budget.get(budget_name, 0.0))
+                        for budget in valid_phase_budgets
+                        if _is_finite_number(budget.get(budget_name))
+                    )
+                    global_total = _nested(timing, *path)
+                    if _is_finite_number(global_total) and not math.isclose(
+                        phase_total,
+                        float(global_total),
+                        abs_tol=1.0e-9 * max(abs(phase_total), 1.0),
+                    ):
+                        violations.append(
+                            "pass result phase total differs from "
+                            + ".".join(path)
+                        )
+            if isinstance(solver_budget, Mapping) and _is_finite_number(
+                solver_budget.get("wall_seconds")
+            ) and _is_finite_number(timing.get("solver_phase_wall_seconds")):
+                if not math.isclose(
+                    float(solver_budget["wall_seconds"]),
+                    float(timing["solver_phase_wall_seconds"]),
+                    abs_tol=1.0e-9
+                    * max(float(timing["solver_phase_wall_seconds"]), 1.0),
+                ):
+                    violations.append(
+                        "pass result solver_budget wall differs from solver phase"
+                    )
+            if isinstance(solver_budget, Mapping):
+                other_solver = timing.get(
+                    "other_solver_and_orchestration_wall_seconds"
+                )
+                internal = solver_budget.get(
+                    "pdipm_internal_orchestration_wall_seconds"
+                )
+                outside = solver_budget.get(
+                    "outside_pdipm_and_zero_barrier_wall_seconds"
+                )
+                if all(
+                    _is_finite_number(value)
+                    for value in (other_solver, internal, outside)
+                ) and not math.isclose(
+                    float(other_solver),
+                    float(internal) + float(outside),
+                    abs_tol=1.0e-9 * max(abs(float(other_solver)), 1.0),
+                ):
+                    violations.append(
+                        "pass result has inconsistent compatibility residual"
+                    )
+            workload_components = (
+                timing.get("setup_phase_wall_seconds"),
+                timing.get("solver_phase_wall_seconds"),
+                timing.get("unphased_workload_wall_seconds"),
+            )
+            workload_wall = timing.get("workload_wall_seconds")
+            if _is_finite_number(workload_wall) and all(
+                _is_finite_number(value) for value in workload_components
+            ):
+                component_sum = sum(float(value) for value in workload_components)
+                if not math.isclose(
+                    float(workload_wall),
+                    component_sum,
+                    abs_tol=1.0e-9 * max(float(workload_wall), 1.0),
+                ):
+                    violations.append(
+                        "pass result has inconsistent workload phase total"
+                    )
+            if timing.get("timing_attribution_consistent") is not True:
+                violations.append("pass result has inconsistent timing attribution")
+        if not isinstance(payload.get("environment"), Mapping):
+            violations.append("pass result has no environment mapping")
+    return tuple(violations)
+
+
+def _nested(mapping: Mapping[str, Any], *names: str) -> Any:
+    value: Any = mapping
+    for name in names:
+        if not isinstance(value, Mapping):
+            return None
+        value = value.get(name)
+    return value
+
+
+def summary_row(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return one compact tabular record from a worker result."""
+
+    timing = payload.get("timing", {})
+    if not isinstance(timing, Mapping):
+        timing = {}
+    return {
+        "case_id": _nested(payload, "case", "case_id"),
+        "platform": _nested(payload, "execution", "requested_platform"),
+        "optimization": _nested(
+            payload, "execution", "optimization_mode"
+        ),
+        "repetition": _nested(payload, "execution", "repetition"),
+        "scope": _nested(payload, "scope", "kind"),
+        "status": payload.get("status"),
+        "worker_return_code": payload.get("worker_return_code"),
+        "output_layer_count": _nested(
+            payload, "validation", "output_layer_count"
+        ),
+        "workload_wall_seconds": timing.get("workload_wall_seconds"),
+        "solver_phase_wall_seconds": timing.get("solver_phase_wall_seconds"),
+        "pdipm_compile_seconds": _nested(
+            timing, "solver_budget", "pdipm_compilation_seconds"
+        ),
+        "pdipm_execute_seconds": _nested(
+            timing, "solver_budget", "pdipm_execution_seconds"
+        ),
+        "pdipm_diagnostic_seconds": _nested(
+            timing, "solver_budget", "pdipm_diagnostic_seconds"
+        ),
+        "pdipm_first_shape_compilation_seconds": _nested(
+            timing, "pdipm", "first_shape_compilation_seconds"
+        ),
+        "pdipm_repeated_shape_compilation_seconds": _nested(
+            timing, "pdipm", "repeated_shape_compilation_seconds"
+        ),
+        "pdipm_executable_shape_count": _nested(
+            timing, "pdipm", "executable_shape_count"
+        ),
+        "zero_barrier_host_wall_seconds": _nested(
+            timing, "solver_budget", "zero_barrier_host_wall_seconds"
+        ),
+        "zero_barrier_call_count": _nested(
+            timing, "solver_budget", "zero_barrier_call_count"
+        ),
+        "zero_barrier_function_evaluations": _nested(
+            timing, "solver_budget", "zero_barrier_function_evaluations"
+        ),
+        "setup_phase_wall_seconds": timing.get("setup_phase_wall_seconds"),
+        "unphased_workload_wall_seconds": timing.get(
+            "unphased_workload_wall_seconds"
+        ),
+        "pdipm_call_count": _nested(
+            timing, "solver_budget", "pdipm_call_count"
+        ),
+        "pdipm_bucket_count": _nested(
+            timing, "solver_budget", "pdipm_bucket_count"
+        ),
+        "pdipm_wall_seconds": _nested(
+            timing, "solver_budget", "pdipm_wall_seconds"
+        ),
+        "pdipm_diagnostic_compilation_seconds": _nested(
+            timing,
+            "solver_budget",
+            "pdipm_diagnostic_compilation_seconds",
+        ),
+        "pdipm_diagnostic_execution_seconds": _nested(
+            timing,
+            "solver_budget",
+            "pdipm_diagnostic_execution_seconds",
+        ),
+        "pdipm_internal_orchestration_wall_seconds": _nested(
+            timing,
+            "solver_budget",
+            "pdipm_internal_orchestration_wall_seconds",
+        ),
+        "outside_pdipm_and_zero_barrier_wall_seconds": _nested(
+            timing,
+            "solver_budget",
+            "outside_pdipm_and_zero_barrier_wall_seconds",
+        ),
+        "other_solver_and_orchestration_wall_seconds": timing.get(
+            "other_solver_and_orchestration_wall_seconds"
+        ),
+        "timing_attribution_consistent": timing.get(
+            "timing_attribution_consistent"
+        ),
+        "timing_attribution_delta_seconds": _nested(
+            timing, "solver_budget", "attribution_delta_seconds"
+        ),
+        "maximum_resident_set_size_kb": _nested(
+            payload, "resources", "maximum_resident_set_size_kb"
+        ),
+        "result_file": payload.get("result_file"),
+        "log_file": payload.get("log_file"),
+    }
+
+
+def _write_csv(path: Path, rows: Sequence[Mapping[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = list(summary_row({}).keys())
+    with path.open("w", newline="") as output:
+        writer = csv.DictWriter(output, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def phase_budget_rows(
+    payloads: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    """Return long-form phase budgets for every worker result."""
+
+    rows = []
+    for payload in payloads:
+        timing = payload.get("timing", {})
+        if not isinstance(timing, Mapping):
+            continue
+        budgets = timing.get("phase_budgets", ())
+        if not isinstance(budgets, (list, tuple)):
+            continue
+        for budget in budgets:
+            if not isinstance(budget, Mapping):
+                continue
+            rows.append(
+                {
+                    "case_id": _nested(payload, "case", "case_id"),
+                    "platform": _nested(
+                        payload, "execution", "requested_platform"
+                    ),
+                    "optimization": _nested(
+                        payload, "execution", "optimization_mode"
+                    ),
+                    "repetition": _nested(
+                        payload, "execution", "repetition"
+                    ),
+                    "scope": _nested(payload, "scope", "kind"),
+                    "status": payload.get("status"),
+                    "phase_name": budget.get("name"),
+                    "phase_category": budget.get("category"),
+                    "phase_invocation_count": budget.get("invocation_count"),
+                    "phase_wall_seconds": budget.get("wall_seconds"),
+                    "pdipm_call_count": budget.get("pdipm_call_count"),
+                    "pdipm_bucket_count": budget.get("pdipm_bucket_count"),
+                    "pdipm_wall_seconds": budget.get("pdipm_wall_seconds"),
+                    "pdipm_compilation_seconds": budget.get(
+                        "pdipm_compilation_seconds"
+                    ),
+                    "pdipm_execution_seconds": budget.get(
+                        "pdipm_execution_seconds"
+                    ),
+                    "pdipm_diagnostic_seconds": budget.get(
+                        "pdipm_diagnostic_seconds"
+                    ),
+                    "pdipm_diagnostic_compilation_seconds": budget.get(
+                        "pdipm_diagnostic_compilation_seconds"
+                    ),
+                    "pdipm_diagnostic_execution_seconds": budget.get(
+                        "pdipm_diagnostic_execution_seconds"
+                    ),
+                    "pdipm_internal_orchestration_wall_seconds": budget.get(
+                        "pdipm_internal_orchestration_wall_seconds"
+                    ),
+                    "zero_barrier_call_count": budget.get(
+                        "zero_barrier_call_count"
+                    ),
+                    "zero_barrier_host_wall_seconds": budget.get(
+                        "zero_barrier_host_wall_seconds"
+                    ),
+                    "zero_barrier_function_evaluations": budget.get(
+                        "zero_barrier_function_evaluations"
+                    ),
+                    "outside_pdipm_and_zero_barrier_wall_seconds": budget.get(
+                        "outside_pdipm_and_zero_barrier_wall_seconds"
+                    ),
+                    "attribution_delta_seconds": budget.get(
+                        "attribution_delta_seconds"
+                    ),
+                    "attribution_consistent": budget.get(
+                        "attribution_consistent"
+                    ),
+                }
+            )
+    return rows
+
+
+def _write_phase_budget_csv(
+    path: Path, payloads: Sequence[Mapping[str, Any]]
+) -> None:
+    rows = phase_budget_rows(payloads)
+    with path.open("w", newline="") as output:
+        writer = csv.DictWriter(output, fieldnames=PHASE_BUDGET_FIELDS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _write_markdown(path: Path, rows: Sequence[Mapping[str, Any]]) -> None:
+    overview_fields = (
+        "case_id",
+        "platform",
+        "optimization",
+        "repetition",
+        "scope",
+        "status",
+        "output_layer_count",
+        "workload_wall_seconds",
+        "setup_phase_wall_seconds",
+        "solver_phase_wall_seconds",
+        "unphased_workload_wall_seconds",
+        "pdipm_call_count",
+        "pdipm_bucket_count",
+        "zero_barrier_call_count",
+        "zero_barrier_function_evaluations",
+    )
+    budget_fields = (
+        "case_id",
+        "platform",
+        "optimization",
+        "repetition",
+        "pdipm_compile_seconds",
+        "pdipm_execute_seconds",
+        "pdipm_diagnostic_compilation_seconds",
+        "pdipm_diagnostic_execution_seconds",
+        "pdipm_internal_orchestration_wall_seconds",
+        "zero_barrier_host_wall_seconds",
+        "outside_pdipm_and_zero_barrier_wall_seconds",
+        "timing_attribution_consistent",
+    )
+
+    def table(fields: Sequence[str]) -> list[str]:
+        table_lines = [
+            "| " + " | ".join(fields) + " |",
+            "| " + " | ".join("---" for _ in fields) + " |",
+        ]
+        for row in rows:
+            table_lines.append(
+                "| "
+                + " | ".join(
+                    "" if row.get(field) is None else str(row[field])
+                    for field in fields
+                )
+                + " |"
+            )
+        return table_lines
+
+    lines = [
+        "# Documented example benchmark summary",
+        "",
+        "## Workload overview",
+        "",
+        *table(overview_fields),
+        "",
+        "## Solver wall-time budget",
+        "",
+        *table(budget_fields),
+        "",
+        "Per-phase budgets are in `phase_budgets.csv` and each worker JSON.",
+    ]
+    path.write_text("\n".join(lines) + "\n")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--case",
+        action="append",
+        choices=tuple(CASES_BY_ID),
+        help="Case to run; repeat this option. The default is every case.",
+    )
+    parser.add_argument(
+        "--platform",
+        action="append",
+        choices=("cpu", "gpu"),
+        help="Platform to run; repeat this option. The default is CPU and GPU.",
+    )
+    parser.add_argument(
+        "--optimization",
+        action="append",
+        choices=OPTIMIZATION_MODES,
+        help="Optimization mode; repeat this option. The default is both.",
+    )
+    parser.add_argument("--repeat", type=int, default=1)
+    parser.add_argument("--smoke-layers", type=int, default=None)
+    parser.add_argument(
+        "--output-directory",
+        type=Path,
+        default=None,
+        help="Default: results/documented_example_benchmarks/TIMESTAMP",
+    )
+    parser.add_argument(
+        "--fail-fast",
+        action="store_true",
+        help="Stop after the first failed or unavailable worker.",
+    )
+    return parser
+
+
+def _ordered_unique(values: Iterable[str]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(values))
+
+
+def benchmark_jobs(
+    cases: Sequence[str],
+    platforms: Sequence[str],
+    optimizations: Sequence[str],
+    repeat: int,
+) -> tuple[tuple[str, str, str, int], ...]:
+    """Return the deterministic Cartesian benchmark matrix."""
+
+    return tuple(
+        (case_id, platform, optimization, repetition)
+        for case_id in cases
+        for platform in platforms
+        for optimization in optimizations
+        for repetition in range(1, repeat + 1)
+    )
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    if args.repeat <= 0:
+        raise SystemExit("--repeat must be positive")
+    if args.smoke_layers is not None and args.smoke_layers <= 0:
+        raise SystemExit("--smoke-layers must be positive")
+
+    cases = _ordered_unique(args.case or (case.case_id for case in CASES))
+    platforms = _ordered_unique(args.platform or ("cpu", "gpu"))
+    optimizations = _ordered_unique(
+        args.optimization or OPTIMIZATION_MODES
+    )
+    output_directory = args.output_directory or (
+        Path("results") / "documented_example_benchmarks" / _slug_timestamp()
+    )
+    output_directory.mkdir(parents=True, exist_ok=True)
+
+    suite: dict[str, Any] = {
+        "schema": SCHEMA,
+        "status": "running",
+        "started_at_utc": _timestamp(),
+        "selection": {
+            "cases": cases,
+            "platforms": platforms,
+            "optimizations": optimizations,
+            "repeat": args.repeat,
+            "smoke_layers": args.smoke_layers,
+        },
+        "results": [],
+    }
+    summary_path = output_directory / "summary.json"
+    _write_json(summary_path, suite)
+
+    repository_root = Path(__file__).resolve().parents[2]
+    child_environment = os.environ.copy()
+    import_paths = (
+        str(repository_root / "src"),
+        str(repository_root),
+    )
+    inherited_pythonpath = child_environment.get("PYTHONPATH")
+    if inherited_pythonpath:
+        import_paths += (inherited_pythonpath,)
+    child_environment["PYTHONPATH"] = os.pathsep.join(import_paths)
+    result_payloads = []
+    stop = False
+    jobs = benchmark_jobs(cases, platforms, optimizations, args.repeat)
+    for case_id, platform, optimization, repetition in jobs:
+        stem = (
+            f"{case_id}__{platform}__{optimization}"
+            f"__repeat{repetition}"
+        )
+        result_path = output_directory / f"{stem}.json"
+        log_path = output_directory / f"{stem}.log"
+        if result_path.exists():
+            result_path.unlink()
+        command = (
+            sys.executable,
+            "-m",
+            "benchmarks.documented_examples.worker",
+            "--case",
+            case_id,
+            "--platform",
+            platform,
+            "--optimization",
+            optimization,
+            "--output",
+            str(result_path.resolve()),
+            "--repetition",
+            str(repetition),
+        )
+        if args.smoke_layers is not None:
+            command += ("--smoke-layers", str(args.smoke_layers))
+        print(f"RUN {' '.join(command)}", flush=True)
+        with log_path.open("w") as log:
+            completed = subprocess.run(
+                command,
+                cwd=repository_root,
+                env=child_environment,
+                check=False,
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+        payload = _read_result(result_path)
+        if not isinstance(payload.get("case"), Mapping):
+            payload["case"] = {"case_id": case_id}
+        if not isinstance(payload.get("execution"), Mapping):
+            payload["execution"] = {
+                "requested_platform": platform,
+                "optimization_mode": optimization,
+                "repetition": repetition,
+            }
+        if not isinstance(payload.get("scope"), Mapping):
+            payload["scope"] = {
+                "kind": "full" if args.smoke_layers is None else "smoke",
+                "smoke_layers": args.smoke_layers,
+            }
+        violations = _validate_worker_result(
+            payload,
+            case_id=case_id,
+            platform=platform,
+            optimization=optimization,
+            repetition=repetition,
+            smoke_layers=args.smoke_layers,
+        )
+        if violations:
+            payload["reported_status"] = payload.get("status")
+            payload["status"] = "invalid_result"
+            payload["contract_violations"] = violations
+        if completed.returncode != 0 and payload.get("status") == "pass":
+            payload["reported_status"] = "pass"
+            payload["status"] = "worker_error"
+            payload["contract_violations"] = (
+                f"worker return code was {completed.returncode}",
+            )
+        payload["worker_return_code"] = completed.returncode
+        payload["result_file"] = str(result_path)
+        payload["log_file"] = str(log_path)
+        result_payloads.append(payload)
+        suite["results"] = result_payloads
+        _write_json(summary_path, suite)
+        print(
+            f"{payload.get('status', 'unknown').upper()} "
+            f"{case_id} {platform} {optimization}: {log_path}",
+            flush=True,
+        )
+        if (
+            completed.returncode != 0 or payload.get("status") != "pass"
+        ) and args.fail_fast:
+            stop = True
+        if stop:
+            break
+
+    rows = [summary_row(payload) for payload in result_payloads]
+    _write_csv(output_directory / "summary.csv", rows)
+    _write_phase_budget_csv(
+        output_directory / "phase_budgets.csv", result_payloads
+    )
+    _write_markdown(output_directory / "summary.md", rows)
+    passed_results = [
+        payload.get("status") == "pass"
+        and payload.get("worker_return_code") == 0
+        for payload in result_payloads
+    ]
+    suite.update(
+        {
+            "status": (
+                "pass"
+                if passed_results and all(passed_results)
+                else "incomplete"
+            ),
+            "finished_at_utc": _timestamp(),
+            "result_count": len(result_payloads),
+            "passed_result_count": sum(passed_results),
+            "results": result_payloads,
+        }
+    )
+    _write_json(summary_path, suite)
+    print(f"SUMMARY {summary_path}", flush=True)
+    return 0 if suite["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/documented_examples/run_all_gpu.csh
+++ b/benchmarks/documented_examples/run_all_gpu.csh
@@ -1,0 +1,143 @@
+#!/bin/csh -f
+
+set REPOSITORY_ROOT = ""
+if ( $?EXOGIBBS_REPOSITORY_ROOT ) then
+  set REPOSITORY_ROOT = "$EXOGIBBS_REPOSITORY_ROOT"
+else
+  set SCRIPT_DIR = `dirname "$0"`
+  set REPOSITORY_ROOT = "$SCRIPT_DIR/../.."
+endif
+cd "$REPOSITORY_ROOT"
+if ( $status != 0 ) then
+  echo "ERROR: could not enter the ExoGibbs repository root"
+  exit 1
+endif
+
+if ( $#argv > 1 ) then
+  echo "usage: $0 [OUTPUT_DIRECTORY]"
+  exit 2
+endif
+
+set PYTHON_COMMAND = "python"
+if ( $?EXOGIBBS_PYTHON ) then
+  set PYTHON_COMMAND = "$EXOGIBBS_PYTHON"
+endif
+"$PYTHON_COMMAND" --version
+if ( $status != 0 ) then
+  echo "ERROR: Python executable failed: $PYTHON_COMMAND"
+  exit 2
+endif
+
+if ( $?PYTHONPATH ) then
+  setenv PYTHONPATH "${cwd}/src:${cwd}:${PYTHONPATH}"
+else
+  setenv PYTHONPATH "${cwd}/src:${cwd}"
+endif
+setenv PYTHONHASHSEED 0
+setenv XLA_PYTHON_CLIENT_PREALLOCATE false
+setenv MPLBACKEND Agg
+
+set STAMP = `date '+%Y%m%dT%H%M%S'`
+set OUTPUT_ROOT = "$cwd/results/documented_example_benchmarks/gpu_all_${STAMP}.$$"
+if ( $#argv == 1 ) then
+  set OUTPUT_ROOT = "$1"
+endif
+set DOCUMENTED_OUTPUT = "$OUTPUT_ROOT/documented_examples"
+mkdir -p "$DOCUMENTED_OUTPUT"
+if ( $status != 0 ) then
+  echo "ERROR: could not create output directory: $OUTPUT_ROOT"
+  exit 1
+endif
+
+echo "== ExoGibbs documented GPU benchmarks =="
+echo "repository:   $cwd"
+echo "python:       $PYTHON_COMMAND"
+echo "output:       $OUTPUT_ROOT"
+echo "workloads:    five documented examples, then L-dwarf cold + warm 10"
+echo "optimizations: default, then disable_most_optimizations"
+date
+
+nvidia-smi
+if ( $status != 0 ) then
+  echo "ERROR: nvidia-smi failed"
+  exit 1
+endif
+
+env \
+  JAX_PLATFORMS=cuda \
+  JAX_PLATFORM_NAME=cuda \
+  JAX_ENABLE_X64=1 \
+  XLA_PYTHON_CLIENT_PREALLOCATE=false \
+  "$PYTHON_COMMAND" -c 'import jax; devices = jax.devices(); print("JAX backend:", jax.default_backend()); print("JAX devices:", devices); raise SystemExit(0 if jax.default_backend() == "gpu" and devices else 1)'
+if ( $status != 0 ) then
+  echo "ERROR: JAX did not initialize a CUDA GPU backend"
+  exit 1
+endif
+
+"$PYTHON_COMMAND" -m py_compile \
+  benchmarks/documented_examples/run.py \
+  benchmarks/documented_examples/worker.py \
+  benchmarks/documented_examples/ldwarf_repeated.py
+if ( $status != 0 ) then
+  echo "ERROR: benchmark syntax preflight failed"
+  exit 1
+endif
+
+@ FAILURE_COUNT = 0
+
+echo ""
+echo "== [1/3] five documented examples: GPU, both compiler modes =="
+date
+"$PYTHON_COMMAND" -m benchmarks.documented_examples.run \
+  --platform gpu \
+  --optimization default \
+  --optimization disable_most_optimizations \
+  --repeat 1 \
+  --output-directory "$DOCUMENTED_OUTPUT"
+set DOCUMENTED_RC = $status
+if ( $DOCUMENTED_RC != 0 ) then
+  echo "ERROR: one or more documented example jobs failed"
+  @ FAILURE_COUNT += 1
+endif
+
+echo ""
+echo "== [2/3] L-dwarf cold + warm 10: default compiler =="
+date
+"$PYTHON_COMMAND" -m benchmarks.documented_examples.ldwarf_repeated \
+  --platform gpu \
+  --optimization default \
+  --evaluations 10 \
+  --output "$OUTPUT_ROOT/ldwarf_repeated_gpu_default.json"
+set LDWARF_DEFAULT_RC = $status
+if ( $LDWARF_DEFAULT_RC != 0 ) then
+  echo "ERROR: default L-dwarf repeated benchmark failed"
+  @ FAILURE_COUNT += 1
+endif
+
+echo ""
+echo "== [3/3] L-dwarf cold + warm 10: compile-light =="
+date
+"$PYTHON_COMMAND" -m benchmarks.documented_examples.ldwarf_repeated \
+  --platform gpu \
+  --optimization disable_most_optimizations \
+  --evaluations 10 \
+  --output "$OUTPUT_ROOT/ldwarf_repeated_gpu_disable_optimizations.json"
+set LDWARF_LIGHT_RC = $status
+if ( $LDWARF_LIGHT_RC != 0 ) then
+  echo "ERROR: compile-light L-dwarf repeated benchmark failed"
+  @ FAILURE_COUNT += 1
+endif
+
+echo ""
+echo "== ExoGibbs GPU benchmark sequence complete =="
+echo "documented examples exit code: $DOCUMENTED_RC"
+echo "L-dwarf default exit code:     $LDWARF_DEFAULT_RC"
+echo "L-dwarf compile-light code:    $LDWARF_LIGHT_RC"
+echo "output:                         $OUTPUT_ROOT"
+date
+
+if ( $FAILURE_COUNT != 0 ) then
+  echo "ERROR: $FAILURE_COUNT benchmark stage(s) failed"
+  exit 1
+endif
+exit 0

--- a/benchmarks/documented_examples/worker.py
+++ b/benchmarks/documented_examples/worker.py
@@ -1,0 +1,379 @@
+"""Run one documented example benchmark in an isolated JAX process."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path
+import platform as system_platform
+import resource
+import subprocess
+import sys
+import time
+import traceback
+from typing import Any, Mapping
+
+from benchmarks.documented_examples.manifest import CASES_BY_ID, get_case
+
+
+SCHEMA = "exogibbs_documented_example_benchmark_v2"
+OPTIMIZATION_MODES = ("default", "disable_most_optimizations")
+
+
+def _timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    temporary.replace(path)
+
+
+def configure_jax_environment(platform: str, optimization_mode: str) -> None:
+    """Set JAX options before importing JAX or any example module."""
+
+    jax_platform = "cpu" if platform == "cpu" else "cuda"
+    os.environ["JAX_PLATFORMS"] = jax_platform
+    os.environ["JAX_PLATFORM_NAME"] = jax_platform
+    os.environ["JAX_ENABLE_X64"] = "1"
+    os.environ["JAX_ENABLE_COMPILATION_CACHE"] = "false"
+    os.environ["XLA_PYTHON_CLIENT_PREALLOCATE"] = "false"
+    os.environ["JAX_DISABLE_MOST_OPTIMIZATIONS"] = (
+        "true" if optimization_mode == "disable_most_optimizations" else "false"
+    )
+
+
+def _revision(repository_root: Path) -> dict[str, Any]:
+    def run(*arguments: str) -> str:
+        completed = subprocess.run(
+            arguments,
+            cwd=repository_root,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        return completed.stdout.strip()
+
+    status = run("git", "status", "--short")
+    diff = run("git", "diff", "--binary", "--", "src", "benchmarks", "examples")
+    return {
+        "commit": run("git", "rev-parse", "HEAD") or None,
+        "dirty": bool(status),
+        "status_line_count": len(status.splitlines()) if status else 0,
+        "status_sha256": hashlib.sha256(status.encode("utf-8")).hexdigest(),
+        "tracked_source_diff_sha256": hashlib.sha256(
+            diff.encode("utf-8")
+        ).hexdigest(),
+    }
+
+
+def _tree_fingerprint(root: Path) -> dict[str, Any]:
+    """Fingerprint every Python source used by the installed solver tree."""
+
+    digest = hashlib.sha256()
+    file_count = 0
+    total_bytes = 0
+    for path in sorted(root.rglob("*.py")):
+        payload = path.read_bytes()
+        relative = path.relative_to(root)
+        digest.update(str(relative).encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(payload)
+        digest.update(b"\0")
+        file_count += 1
+        total_bytes += len(payload)
+    return {
+        "root": str(root),
+        "python_file_count": file_count,
+        "total_bytes": total_bytes,
+        "sha256": digest.hexdigest(),
+    }
+
+
+def _source_provenance(
+    repository_root: Path,
+    source_scripts: tuple[str, ...],
+) -> tuple[dict[str, Any], ...]:
+    """Fingerprint example inputs and benchmark sources used by this worker."""
+
+    benchmark_directory = Path(__file__).resolve().parent
+    paths = [repository_root / source for source in source_scripts]
+    paths.extend(sorted(benchmark_directory.glob("*.py")))
+    paths.append(benchmark_directory / "README.md")
+    records = []
+    for path in dict.fromkeys(item.resolve() for item in paths):
+        payload = path.read_bytes()
+        try:
+            relative = path.relative_to(repository_root.resolve())
+        except ValueError:
+            relative = path
+        records.append(
+            {
+                "path": str(relative),
+                "size_bytes": len(payload),
+                "sha256": hashlib.sha256(payload).hexdigest(),
+            }
+        )
+    return tuple(records)
+
+
+def _checkout_package_path(repository_root: Path) -> str:
+    """Fail if this worker imported ExoGibbs from outside the checkout."""
+
+    import exogibbs
+
+    package_file = getattr(exogibbs, "__file__", None)
+    if package_file is None:
+        raise RuntimeError("The imported exogibbs package has no source path.")
+    package_root = Path(package_file).resolve().parent
+    expected_root = (repository_root / "src" / "exogibbs").resolve()
+    if package_root != expected_root:
+        raise RuntimeError(
+            "Benchmark imported exogibbs from outside this checkout: "
+            f"actual={package_root}, expected={expected_root}."
+        )
+    return str(package_root)
+
+
+def _jax_environment(
+    requested_platform: str,
+    optimization_mode: str,
+) -> dict[str, Any]:
+    import jax
+    import jaxlib
+
+    config_names = (
+        "jax_disable_most_optimizations",
+        "jax_optimization_level",
+        "jax_exec_time_optimization_effort",
+        "jax_memory_fitting_level",
+        "jax_memory_fitting_effort",
+        "jax_enable_compilation_cache",
+        "jax_enable_x64",
+    )
+    config_values = {
+        name: jax.config.values[name]
+        for name in config_names
+        if name in jax.config.values
+    }
+    option_supported = "jax_disable_most_optimizations" in config_values
+    requested_value = optimization_mode == "disable_most_optimizations"
+    effective_value = config_values.get("jax_disable_most_optimizations")
+    if requested_value and not option_supported:
+        raise NotImplementedError(
+            "This JAX version has no jax_disable_most_optimizations option."
+        )
+    if effective_value is not requested_value:
+        raise RuntimeError(
+            "jax_disable_most_optimizations did not take the requested value: "
+            f"requested={requested_value!r}, effective={effective_value!r}."
+        )
+    if config_values.get("jax_enable_x64") is not True:
+        raise RuntimeError("JAX x64 mode is not enabled.")
+    if config_values.get("jax_enable_compilation_cache") is not False:
+        raise RuntimeError("JAX persistent compilation cache is not disabled.")
+
+    devices = jax.devices()
+    backend = jax.default_backend()
+    expected_backend = "cpu" if requested_platform == "cpu" else "gpu"
+    if backend != expected_backend:
+        raise RuntimeError(
+            f"Requested {requested_platform!r}, but JAX selected {backend!r}."
+        )
+    return {
+        "python_version": system_platform.python_version(),
+        "python_executable": sys.executable,
+        "jax_version": jax.__version__,
+        "jaxlib_version": jaxlib.__version__,
+        "requested_platform": requested_platform,
+        "backend": backend,
+        "devices": tuple(
+            {
+                "id": int(device.id),
+                "platform": str(device.platform),
+                "device_kind": str(device.device_kind),
+            }
+            for device in devices
+        ),
+        "optimization": {
+            "mode": optimization_mode,
+            "option": "jax_disable_most_optimizations",
+            "supported": option_supported,
+            "requested_value": requested_value,
+            "effective_value": effective_value,
+        },
+        "jax_config": config_values,
+        "process_environment": {
+            name: os.environ.get(name)
+            for name in (
+                "JAX_PLATFORMS",
+                "JAX_PLATFORM_NAME",
+                "JAX_ENABLE_X64",
+                "JAX_ENABLE_COMPILATION_CACHE",
+                "JAX_DISABLE_MOST_OPTIMIZATIONS",
+                "XLA_PYTHON_CLIENT_PREALLOCATE",
+                "XLA_FLAGS",
+            )
+        },
+        "host": {
+            "hostname": system_platform.node(),
+            "system": system_platform.system(),
+            "machine": system_platform.machine(),
+            "processor": system_platform.processor(),
+            "logical_cpu_count": os.cpu_count(),
+        },
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--case", choices=tuple(CASES_BY_ID), required=True)
+    parser.add_argument("--platform", choices=("cpu", "gpu"), required=True)
+    parser.add_argument(
+        "--optimization",
+        choices=OPTIMIZATION_MODES,
+        required=True,
+    )
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--smoke-layers",
+        type=int,
+        default=None,
+        help="Run only the first N output conditions; never use for baselines.",
+    )
+    parser.add_argument("--repetition", type=int, default=1)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    if args.smoke_layers is not None and args.smoke_layers <= 0:
+        raise SystemExit("--smoke-layers must be positive")
+    if args.repetition <= 0:
+        raise SystemExit("--repetition must be positive")
+
+    configure_jax_environment(args.platform, args.optimization)
+    repository_root = Path(__file__).resolve().parents[2]
+    case = get_case(args.case)
+    payload: dict[str, Any] = {
+        "schema": SCHEMA,
+        "status": "running",
+        "started_at_utc": _timestamp(),
+        "case": case.to_dict(),
+        "scope": {
+            "kind": "full" if args.smoke_layers is None else "smoke",
+            "smoke_layers": args.smoke_layers,
+            "measured_work": (
+                "ExoGibbs solver calls at the documented conditions; "
+                "external solvers, plotting, and artifact writing are excluded"
+            ),
+        },
+        "execution": {
+            "requested_platform": args.platform,
+            "optimization_mode": args.optimization,
+            "repetition": args.repetition,
+            "pid": os.getpid(),
+        },
+        "revision": _revision(repository_root),
+        "solver_source_tree": _tree_fingerprint(
+            repository_root / "src" / "exogibbs"
+        ),
+        "source_provenance": _source_provenance(
+            repository_root,
+            case.source_scripts + case.input_artifacts,
+        ),
+    }
+
+    try:
+        environment = _jax_environment(args.platform, args.optimization)
+        environment["exogibbs_package_root"] = _checkout_package_path(
+            repository_root
+        )
+        payload["environment"] = environment
+    except NotImplementedError as error:
+        payload.update(
+            {
+                "status": "unsupported",
+                "finished_at_utc": _timestamp(),
+                "error": f"{type(error).__name__}: {error}",
+                "traceback": traceback.format_exc(),
+            }
+        )
+        _write_json(args.output, payload)
+        print(f"UNSUPPORTED {case.case_id}: {error}", flush=True)
+        return 2
+    except Exception as error:
+        payload.update(
+            {
+                "status": "unavailable",
+                "finished_at_utc": _timestamp(),
+                "error": f"{type(error).__name__}: {error}",
+                "traceback": traceback.format_exc(),
+            }
+        )
+        _write_json(args.output, payload)
+        print(f"UNAVAILABLE {case.case_id}: {error}", flush=True)
+        return 2
+
+    from benchmarks.documented_examples.instrumentation import TimingCollector
+    from benchmarks.documented_examples.workloads import run_case
+
+    print(
+        f"RUN {case.case_id} platform={args.platform} "
+        f"optimization={args.optimization} repetition={args.repetition}",
+        flush=True,
+    )
+    collector = TimingCollector()
+    workload_started = time.perf_counter()
+    try:
+        with collector:
+            validation = run_case(case, collector, args.smoke_layers)
+        workload_wall_seconds = time.perf_counter() - workload_started
+        payload.update(
+            {
+                "status": "pass",
+                "finished_at_utc": _timestamp(),
+                "validation": validation,
+                "timing": collector.summary(
+                    workload_wall_seconds=workload_wall_seconds
+                ),
+            }
+        )
+        return_code = 0
+    except Exception as error:
+        workload_wall_seconds = time.perf_counter() - workload_started
+        payload.update(
+            {
+                "status": "error",
+                "finished_at_utc": _timestamp(),
+                "error": f"{type(error).__name__}: {error}",
+                "traceback": traceback.format_exc(),
+                "timing": collector.summary(
+                    workload_wall_seconds=workload_wall_seconds
+                ),
+            }
+        )
+        return_code = 1
+
+    usage = resource.getrusage(resource.RUSAGE_SELF)
+    maximum_resident_set_size_kb = float(usage.ru_maxrss)
+    if system_platform.system() == "Darwin":
+        maximum_resident_set_size_kb /= 1024.0
+    payload["resources"] = {
+        "maximum_resident_set_size_kb": maximum_resident_set_size_kb
+    }
+    _write_json(args.output, payload)
+    print(
+        f"{payload['status'].upper()} {case.case_id}: {args.output}",
+        flush=True,
+    )
+    return return_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/documented_examples/workloads.py
+++ b/benchmarks/documented_examples/workloads.py
@@ -1,0 +1,475 @@
+"""ExoGibbs portions of the examples listed in the documentation."""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any, Callable, Sequence
+
+import numpy as np
+
+from benchmarks.documented_examples.instrumentation import TimingCollector
+from benchmarks.documented_examples.manifest import DocumentedExampleCase
+
+
+ACCEPTED_STATUSES = frozenset({"converged", "converged_with_caveat"})
+
+
+def _limited(values: Sequence[float], smoke_layers: int | None) -> np.ndarray:
+    array = np.asarray(values, dtype=np.float64)
+    if smoke_layers is None:
+        return array.copy()
+    if isinstance(smoke_layers, bool) or smoke_layers <= 0:
+        raise ValueError("smoke_layers must be a positive integer.")
+    return array[: min(int(smoke_layers), array.size)].copy()
+
+
+def _status_summary(statuses: Sequence[str]) -> dict[str, int]:
+    return dict(sorted(Counter(str(status) for status in statuses).items()))
+
+
+def _solution_summary(solution: Any) -> dict[str, Any]:
+    converged = np.asarray(solution.converged, dtype=bool)
+    return {
+        "layer_count": int(converged.size),
+        "converged_layer_count": int(np.count_nonzero(converged)),
+        "all_layers_converged": bool(np.all(converged)),
+        "statuses": _status_summary(solution.status),
+    }
+
+
+def _profile_summary(profile: Any) -> dict[str, Any]:
+    """Summarize convergence from a public profile result."""
+
+    converged = np.asarray(
+        [layer.converged for layer in profile.layers],
+        dtype=bool,
+    )
+    statuses = tuple(layer.status for layer in profile.layers)
+    return {
+        "layer_count": int(converged.size),
+        "converged_layer_count": int(np.count_nonzero(converged)),
+        "all_layers_converged": bool(np.all(converged)),
+        "statuses": _status_summary(statuses),
+    }
+
+
+def _profile_physical_audit(profile: Any) -> dict[str, Any]:
+    """Summarize the production zero-barrier acceptance gate per layer."""
+
+    positive_condensate_layers = 0
+    audited_positive_layers = 0
+    failed_layer_indices = []
+    acceptance_tiers = Counter()
+    for index, layer in enumerate(profile.layers):
+        acceptance_tiers[str(layer.acceptance_tier)] += 1
+        amounts = np.asarray(layer.condensate_amounts, dtype=np.float64)
+        physically_valid = bool(
+            np.all(np.isfinite(np.asarray(layer.gas_n, dtype=np.float64)))
+            and np.all(np.isfinite(amounts))
+            and np.all(np.asarray(layer.gas_n, dtype=np.float64) >= 0.0)
+            and np.all(amounts >= 0.0)
+        )
+        lifecycle = (
+            (layer.diagnostics or {}).get("fixed_support_v2", {})
+            if layer.diagnostics is not None
+            else {}
+        )
+        positive_condensate = bool(np.any(amounts > 0.0))
+        zero_barrier_passed = True
+        if positive_condensate:
+            positive_condensate_layers += 1
+            caller_audit = lifecycle.get("caller_gauge_zero_barrier_kkt", {})
+            zero_barrier_passed = caller_audit.get("accepted") is True
+            if zero_barrier_passed:
+                audited_positive_layers += 1
+        if (
+            not bool(layer.converged)
+            or str(layer.status) not in ACCEPTED_STATUSES
+            or not physically_valid
+            or not zero_barrier_passed
+        ):
+            failed_layer_indices.append(index)
+    return {
+        "layer_count": len(profile.layers),
+        "positive_condensate_layer_count": positive_condensate_layers,
+        "audited_positive_condensate_layer_count": audited_positive_layers,
+        "all_layers_finite_and_physically_accepted": not failed_layer_indices,
+        "failed_layer_indices": tuple(failed_layer_indices),
+        "acceptance_tiers": dict(sorted(acceptance_tiers.items())),
+    }
+
+
+def _gas_profile_physical_audit(
+    gas_x: Any,
+    converged: Any,
+    species_count: int,
+) -> dict[str, Any]:
+    """Check the gas-only profile contract used by the source example."""
+
+    fractions = np.asarray(gas_x, dtype=np.float64)
+    converged_array = np.asarray(converged, dtype=bool)
+    expected_shape = (converged_array.size, species_count)
+    shape_valid = fractions.shape == expected_shape
+    if shape_valid:
+        invalid_layers = np.flatnonzero(
+            np.any(~np.isfinite(fractions) | (fractions < 0.0), axis=1)
+            | (np.sum(fractions, axis=1) <= 0.0)
+        )
+    else:
+        invalid_layers = np.arange(converged_array.size)
+    return {
+        "layer_count": int(converged_array.size),
+        "expected_shape": expected_shape,
+        "actual_shape": fractions.shape,
+        "invalid_layer_indices": tuple(int(item) for item in invalid_layers),
+        "all_layers_finite_nonnegative_and_nonempty": bool(
+            shape_valid and invalid_layers.size == 0
+        ),
+    }
+
+
+def run_visscher_2006(
+    collector: TimingCollector,
+    smoke_layers: int | None,
+) -> dict[str, Any]:
+    """Run the documented reduced KCl and Na2S ExoGibbs scans."""
+
+    from examples.comparisons import (
+        comparison_with_visscher_2006_na2s_morley_2012_kcl as example,
+    )
+
+    temperatures = _limited(example.DEFAULT_TEMPERATURES_K, smoke_layers)
+    with collector.phase("build_reduced_setups", category="setup"):
+        setups = {
+            case.label: example.build_reduced_setup(case)
+            for case in example.BENCHMARK_CASES
+        }
+
+    summaries = {}
+    audits = {}
+    for case in example.BENCHMARK_CASES:
+        phase = f"solve_{case.label.lower()}"
+        with collector.phase(phase, category="solver"):
+            profile = example.solve_condensate_profile(
+                setups[case.label],
+                T=example.jnp.asarray(temperatures, dtype=example.jnp.float64),
+                P=example.jnp.full(
+                    temperatures.shape,
+                    example.PRESSURE_BAR,
+                    dtype=example.jnp.float64,
+                ),
+                b=example.solar_element_budget(setups[case.label]),
+                options=example.CondensateEquilibriumOptions(),
+            )
+            example.jax.block_until_ready(profile.batched_arrays)
+        summaries[case.label] = _profile_summary(profile)
+        audits[case.label] = _profile_physical_audit(profile)
+    return {
+        "output_layer_count": sum(
+            summary["layer_count"] for summary in summaries.values()
+        ),
+        "profiles": summaries,
+        "physical_audits": audits,
+        "all_layers_converged": all(
+            summary["all_layers_converged"] for summary in summaries.values()
+        ) and all(
+            audit["all_layers_finite_and_physically_accepted"]
+            for audit in audits.values()
+        ),
+    }
+
+
+def run_visscher_2010(
+    collector: TimingCollector,
+    smoke_layers: int | None,
+) -> dict[str, Any]:
+    """Run the documented silicate competition ExoGibbs scans."""
+
+    from examples.comparisons import (
+        comparison_with_visscher_2010_forsterite_enstatite as example,
+    )
+
+    temperatures = _limited(example.DEFAULT_TEMPERATURES_K, smoke_layers)
+    with collector.phase("build_reduced_setups", category="setup"):
+        setups = {
+            run.key: example.build_reduced_setup(run)
+            for run in example.COMPETITION_RUNS
+        }
+
+    summaries = {}
+    audits = {}
+    for run in example.COMPETITION_RUNS:
+        phase = f"solve_{run.key}"
+        with collector.phase(phase, category="solver"):
+            profile = example.solve_condensate_profile(
+                setups[run.key],
+                T=example.jnp.asarray(temperatures, dtype=example.jnp.float64),
+                P=example.jnp.full(
+                    temperatures.shape,
+                    example.PRESSURE_BAR,
+                    dtype=example.jnp.float64,
+                ),
+                b=example.solar_element_budget(setups[run.key]),
+                options=example.CondensateEquilibriumOptions(),
+            )
+            example.jax.block_until_ready(profile.batched_arrays)
+        summaries[run.key] = _profile_summary(profile)
+        audits[run.key] = _profile_physical_audit(profile)
+    return {
+        "output_layer_count": sum(
+            summary["layer_count"] for summary in summaries.values()
+        ),
+        "profiles": summaries,
+        "physical_audits": audits,
+        "all_layers_converged": all(
+            summary["all_layers_converged"] for summary in summaries.values()
+        ) and all(
+            audit["all_layers_finite_and_physically_accepted"]
+            for audit in audits.values()
+        ),
+    }
+
+
+def run_ito_2025_rainout(
+    collector: TimingCollector,
+    smoke_layers: int | None,
+) -> dict[str, Any]:
+    """Run the ExoGibbs half of the propagated Ito rainout example."""
+
+    from examples.comparisons import comparison_with_ito_2025 as ito_base
+    from examples.comparisons import comparison_with_ito_2025_rainout as example
+
+    with collector.phase("load_ito_profile", category="setup"):
+        profile = ito_base.load_ito_profile(example.DEFAULT_INPUT)
+        target = example._target_profile(profile, smoke_layers)
+        layer1_abundance = ito_base.reactive_element_abundances(
+            profile.gas_fractions[0]
+        )
+    with collector.phase("solve_propagated_rainout", category="solver"):
+        solution = example.solve_exogibbs_rainout(
+            target,
+            layer1_abundance=layer1_abundance,
+        )
+    summary = _solution_summary(solution)
+    physically_valid = bool(
+        np.all(np.isfinite(solution.gas_fractions))
+        and np.all(np.isfinite(solution.condensate_amounts))
+        and np.all(np.asarray(solution.gas_fractions) >= 0.0)
+        and np.all(np.asarray(solution.condensate_amounts) >= 0.0)
+        and np.all(np.asarray(solution.converged, dtype=bool))
+        and all(str(status) in ACCEPTED_STATUSES for status in solution.status)
+    )
+    return {
+        "output_layer_count": summary["layer_count"],
+        "profiles": {"propagated_rainout": summary},
+        "fixed_point_iterations": int(solution.fixed_point_iterations),
+        "all_layers_finite_and_accepted": physically_valid,
+        "all_layers_converged": (
+            summary["all_layers_converged"] and physically_valid
+        ),
+    }
+
+
+def run_fe_fes_rainout(
+    collector: TimingCollector,
+    smoke_layers: int | None,
+) -> dict[str, Any]:
+    """Run the documented Fe-FeS local and rainout profiles."""
+
+    from examples.comparisons import demo_fe_fes_rainout as example
+
+    temperatures = _limited(example.DEFAULT_TEMPERATURES_K, smoke_layers)
+    with collector.phase("build_reduced_setup", category="setup"):
+        setup = example.build_reduced_setup()
+    summaries = {}
+    audits = {}
+    for name, rainout in (("local", False), ("rainout", True)):
+        with collector.phase(f"solve_{name}", category="solver"):
+            options = example.CondensateEquilibriumOptions(
+                rainout=rainout,
+                profile_method="scan_hot_from_bottom" if rainout else None,
+            )
+            profile = example.solve_condensate_profile(
+                setup,
+                T=example.jnp.asarray(temperatures, dtype=example.jnp.float64),
+                P=example.jnp.full(
+                    temperatures.shape,
+                    example.PRESSURE_BAR,
+                    dtype=example.jnp.float64,
+                ),
+                b=example.solar_element_budget(setup),
+                options=options,
+            )
+            example.jax.block_until_ready(profile.batched_arrays)
+        summaries[name] = _profile_summary(profile)
+        audits[name] = _profile_physical_audit(profile)
+    return {
+        "output_layer_count": sum(
+            summary["layer_count"] for summary in summaries.values()
+        ),
+        "profiles": summaries,
+        "physical_audits": audits,
+        "all_layers_converged": all(
+            summary["all_layers_converged"] for summary in summaries.values()
+        ) and all(
+            audit["all_layers_finite_and_physically_accepted"]
+            for audit in audits.values()
+        ),
+    }
+
+
+def run_fastchem4_l_dwarf(
+    collector: TimingCollector,
+    smoke_layers: int | None,
+) -> dict[str, Any]:
+    """Run the ExoGibbs profiles used by the documented L-dwarf figure."""
+
+    from examples.comparisons import (
+        comparison_with_fastchem4_condensates as example,
+    )
+    from exogibbs.api.condensate import CondensateEquilibriumOptions
+    from exogibbs.api.gas import EquilibriumOptions as GasEquilibriumOptions
+
+    temperatures, pressures = example._profile_conditions("l-dwarf")
+    temperatures = _limited(temperatures, smoke_layers)
+    pressures = _limited(pressures, smoke_layers)
+    with collector.phase("build_full_catalog_setup", category="setup"):
+        setup = example.condensate_chemical_setup(
+            gas_path="FastChem4/logK/logK_wo_ions.dat",
+            condensate_path="FastChem4/logK/logK_condensates.dat",
+            species_default_elements=False,
+            element_file="FastChem4/element_abundances/asplund_2021.dat",
+            silent=True,
+        )
+        aligned_abundance = example.build_aligned_abundance_vector(
+            setup.elements,
+            source="fastchem_file",
+            normalize=True,
+            element_file=example.ELEMENT_FILE,
+        )
+        budget = example.jnp.asarray(
+            aligned_abundance.vector,
+            dtype=example.jnp.float64,
+        )
+
+    with collector.phase("solve_condensate_profile", category="solver"):
+        condensate_profile = example.solve_condensate_profile(
+            setup,
+            T=example.jnp.asarray(temperatures, dtype=example.jnp.float64),
+            P=example.jnp.asarray(pressures, dtype=example.jnp.float64),
+            b=budget,
+            options=CondensateEquilibriumOptions(return_diagnostics=True),
+            return_diagnostics=True,
+        )
+        example.jax.block_until_ready(condensate_profile.batched_arrays)
+    condensate_converged = np.asarray(
+        [layer.converged for layer in condensate_profile.layers],
+        dtype=bool,
+    )
+    condensate_statuses = tuple(
+        layer.status for layer in condensate_profile.layers
+    )
+
+    with collector.phase("solve_gas_only_profile", category="solver"):
+        gas_profile, gas_diagnostics = example.solve_gas_profile(
+            setup.gas_setup,
+            T=example.jnp.asarray(temperatures, dtype=example.jnp.float64),
+            P=example.jnp.asarray(pressures, dtype=example.jnp.float64),
+            b=budget,
+            options=GasEquilibriumOptions(),
+            return_diagnostics=True,
+        )
+        example.jax.block_until_ready(
+            (gas_profile.x, gas_diagnostics["converged"])
+        )
+    gas_converged = np.asarray(gas_diagnostics["converged"], dtype=bool)
+    gas_x = np.asarray(gas_profile.x, dtype=np.float64)
+    gas_audit = _gas_profile_physical_audit(
+        gas_x,
+        gas_converged,
+        len(setup.gas_species),
+    )
+    gas_physically_valid = gas_audit[
+        "all_layers_finite_nonnegative_and_nonempty"
+    ]
+
+    profiles = {
+        "condensate": {
+            "layer_count": int(condensate_converged.size),
+            "converged_layer_count": int(
+                np.count_nonzero(condensate_converged)
+            ),
+            "all_layers_converged": bool(np.all(condensate_converged)),
+            "statuses": _status_summary(condensate_statuses),
+        },
+        "gas_only": {
+            "layer_count": int(gas_converged.size),
+            "converged_layer_count": int(np.count_nonzero(gas_converged)),
+            "all_layers_converged": bool(np.all(gas_converged)),
+        },
+    }
+    condensate_audit = _profile_physical_audit(condensate_profile)
+    return {
+        "output_layer_count": sum(
+            profile["layer_count"] for profile in profiles.values()
+        ),
+        "profiles": profiles,
+        "physical_audits": {
+            "condensate": condensate_audit,
+            "gas_only": gas_audit,
+        },
+        "all_layers_converged": all(
+            profile["all_layers_converged"] for profile in profiles.values()
+        )
+        and condensate_audit["all_layers_finite_and_physically_accepted"]
+        and gas_physically_valid,
+        "catalog": {
+            "element_count": len(setup.elements),
+            "gas_species_count": len(setup.gas_species),
+            "condensate_species_count": len(setup.condensate_species),
+        },
+    }
+
+
+WORKLOADS: dict[
+    str,
+    Callable[[TimingCollector, int | None], dict[str, Any]],
+] = {
+    "run_visscher_2006": run_visscher_2006,
+    "run_visscher_2010": run_visscher_2010,
+    "run_ito_2025_rainout": run_ito_2025_rainout,
+    "run_fe_fes_rainout": run_fe_fes_rainout,
+    "run_fastchem4_l_dwarf": run_fastchem4_l_dwarf,
+}
+
+
+def run_case(
+    case: DocumentedExampleCase,
+    collector: TimingCollector,
+    smoke_layers: int | None,
+) -> dict[str, Any]:
+    """Execute one manifest workload and enforce its convergence contract."""
+
+    try:
+        workload = WORKLOADS[case.workload]
+    except KeyError as error:
+        raise ValueError(
+            f"No workload is registered for {case.workload!r}."
+        ) from error
+    result = workload(collector, smoke_layers)
+    if not result.get("all_layers_converged", False):
+        raise RuntimeError(f"Not every output layer converged: {result!r}")
+    actual = int(result.get("output_layer_count", 0))
+    if actual <= 0:
+        raise RuntimeError("The workload returned no output layers.")
+    expected = case.expected_output_layer_count(smoke_layers)
+    if actual != expected:
+        scope = "Full" if smoke_layers is None else "Smoke"
+        raise RuntimeError(
+            f"{scope} workload returned {actual} output layers; expected "
+            f"{expected}."
+        )
+    return result
+
+
+__all__ = ("WORKLOADS", "run_case")

--- a/src/exogibbs/equilibrium/condensate/fixed_support/batch.py
+++ b/src/exogibbs/equilibrium/condensate/fixed_support/batch.py
@@ -596,13 +596,6 @@ def _compiled_terminal_restoration_diagnostics_factory(config):
     return jax.jit(jax.vmap(diagnose))
 
 
-def _terminal_restoration_diagnostics(problems, continuation, config):
-    """Replay one terminal restoration step for compact failure diagnosis."""
-
-    compiled = _compiled_terminal_restoration_diagnostics_factory(config)
-    return compiled(problems, continuation.controller)
-
-
 @lru_cache(maxsize=32)
 def _compiled_terminal_normal_diagnostics_factory(config):
     """Reuse the compact terminal-normal diagnostic JIT."""
@@ -658,13 +651,6 @@ def _compiled_terminal_normal_diagnostics_factory(config):
     return jax.jit(jax.vmap(diagnose))
 
 
-def _terminal_normal_diagnostics(problems, continuation, config):
-    """Replay one terminal normal step for compact failure diagnosis."""
-
-    compiled = _compiled_terminal_normal_diagnostics_factory(config)
-    return compiled(problems, continuation.controller)
-
-
 def run_fixed_support_profile(
     *,
     buckets: Sequence[Any],
@@ -706,6 +692,8 @@ def run_fixed_support_profile(
     compilation_seconds = 0.0
     execution_seconds = 0.0
     diagnostic_seconds = 0.0
+    diagnostic_compilation_seconds = 0.0
+    diagnostic_execution_seconds = 0.0
     backend = jax.default_backend()
 
     for bucket in buckets:
@@ -724,17 +712,45 @@ def run_fixed_support_profile(
         )
         restoration_diagnostics = None
         normal_diagnostics = None
+        bucket_diagnostic_compilation_seconds = 0.0
+        bucket_diagnostic_execution_seconds = 0.0
         if include_terminal_diagnostics:
             continuation = result.continuation
-            diagnostic_start = time.perf_counter()
-            restoration_diagnostics = _terminal_restoration_diagnostics(
-                problems, continuation, config
+            restoration = _compiled_terminal_restoration_diagnostics_factory(
+                config
             )
-            normal_diagnostics = _terminal_normal_diagnostics(
-                problems, continuation, config
+            normal = _compiled_terminal_normal_diagnostics_factory(config)
+            diagnostic_compile_start = time.perf_counter()
+            compiled_restoration = restoration.lower(
+                problems, continuation.controller
+            ).compile()
+            compiled_normal = normal.lower(
+                problems, continuation.controller
+            ).compile()
+            bucket_diagnostic_compilation_seconds = (
+                time.perf_counter() - diagnostic_compile_start
+            )
+            diagnostic_execution_start = time.perf_counter()
+            restoration_diagnostics = compiled_restoration(
+                problems, continuation.controller
+            )
+            normal_diagnostics = compiled_normal(
+                problems, continuation.controller
             )
             _block_until_ready((restoration_diagnostics, normal_diagnostics))
-            diagnostic_seconds += time.perf_counter() - diagnostic_start
+            bucket_diagnostic_execution_seconds = (
+                time.perf_counter() - diagnostic_execution_start
+            )
+            diagnostic_compilation_seconds += (
+                bucket_diagnostic_compilation_seconds
+            )
+            diagnostic_execution_seconds += (
+                bucket_diagnostic_execution_seconds
+            )
+            diagnostic_seconds += (
+                bucket_diagnostic_compilation_seconds
+                + bucket_diagnostic_execution_seconds
+            )
             terminal = continuation.terminal_status
             completed_stages = continuation.completed_stage_count
             stage_statuses = continuation.stage_statuses
@@ -809,6 +825,12 @@ def run_fixed_support_profile(
                 "layer_indices": tuple(int(value) for value in bucket.layer_indices),
                 "compilation_seconds": execution.compilation_seconds,
                 "execution_seconds": execution.execution_seconds,
+                "diagnostic_compilation_seconds": (
+                    bucket_diagnostic_compilation_seconds
+                ),
+                "diagnostic_execution_seconds": (
+                    bucket_diagnostic_execution_seconds
+                ),
                 "terminal_status": terminal,
                 "completed_stage_count": completed_stages,
                 "stage_statuses": stage_statuses,
@@ -836,6 +858,8 @@ def run_fixed_support_profile(
         "compilation_seconds": compilation_seconds,
         "execution_seconds": execution_seconds,
         "diagnostic_seconds": diagnostic_seconds,
+        "diagnostic_compilation_seconds": diagnostic_compilation_seconds,
+        "diagnostic_execution_seconds": diagnostic_execution_seconds,
         "gas_log_amounts": gas_log_amounts,
         "condensate_amounts": condensate_amounts,
         "total_gas_log_amount": total_gas_log_amount,

--- a/src/exogibbs/equilibrium/condensate/lifecycle.py
+++ b/src/exogibbs/equilibrium/condensate/lifecycle.py
@@ -1180,6 +1180,8 @@ def _run_head_v2_profile(
     compilation_seconds = 0.0
     execution_seconds = 0.0
     diagnostic_seconds = 0.0
+    diagnostic_compilation_seconds = 0.0
+    diagnostic_execution_seconds = 0.0
     backend = jax.default_backend()
     for round_index in range(policy.lifecycle_max_rounds):
         if not pending:
@@ -1246,7 +1248,34 @@ def _run_head_v2_profile(
         )
         compilation_seconds += float(raw["compilation_seconds"])
         execution_seconds += float(raw["execution_seconds"])
-        diagnostic_seconds += float(raw["diagnostic_seconds"])
+        round_diagnostic_seconds = float(raw["diagnostic_seconds"])
+        diagnostic_seconds += round_diagnostic_seconds
+        round_diagnostic_compilation = raw.get(
+            "diagnostic_compilation_seconds"
+        )
+        round_diagnostic_execution = raw.get("diagnostic_execution_seconds")
+        if (
+            round_diagnostic_compilation is None
+            and round_diagnostic_execution is None
+        ):
+            diagnostic_execution_seconds += round_diagnostic_seconds
+        else:
+            if round_diagnostic_compilation is None:
+                round_diagnostic_compilation = (
+                    round_diagnostic_seconds
+                    - float(round_diagnostic_execution)
+                )
+            if round_diagnostic_execution is None:
+                round_diagnostic_execution = (
+                    round_diagnostic_seconds
+                    - float(round_diagnostic_compilation)
+                )
+            diagnostic_compilation_seconds += float(
+                round_diagnostic_compilation
+            )
+            diagnostic_execution_seconds += float(
+                round_diagnostic_execution
+            )
         backend = str(raw["backend"])
         converged = np.asarray(
             jax.device_get(raw["fixed_support_converged"]), dtype=bool
@@ -1539,6 +1568,10 @@ def _run_head_v2_profile(
             "compilation_seconds_total": compilation_seconds,
             "execution_seconds_total": execution_seconds,
             "diagnostic_seconds_total": diagnostic_seconds,
+            "diagnostic_compilation_seconds_total": (
+                diagnostic_compilation_seconds
+            ),
+            "diagnostic_execution_seconds_total": diagnostic_execution_seconds,
             "backend": backend,
             "production_preset_promoted": True,
             "amount_gauge": amount_gauge,
@@ -1811,6 +1844,8 @@ def _run_head_v2_profile(
             "compilation_seconds": compilation_seconds,
             "execution_seconds": execution_seconds,
             "diagnostic_seconds": diagnostic_seconds,
+            "diagnostic_compilation_seconds": diagnostic_compilation_seconds,
+            "diagnostic_execution_seconds": diagnostic_execution_seconds,
             "backend": backend,
             "layers": tuple(records),
             "amount_gauge": amount_gauge,

--- a/tests/unittests/benchmarks/documented_examples_benchmark_test.py
+++ b/tests/unittests/benchmarks/documented_examples_benchmark_test.py
@@ -1,0 +1,982 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+import subprocess
+import sys
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from benchmarks.documented_examples import instrumentation
+from benchmarks.documented_examples import workloads
+from benchmarks.documented_examples.instrumentation import SOLVER_BUDGET_SCHEMA
+from benchmarks.documented_examples.instrumentation import TimingCollector
+from benchmarks.documented_examples.manifest import CASES
+from benchmarks.documented_examples.manifest import example_documents_from_index
+from benchmarks.documented_examples.run import benchmark_jobs
+from benchmarks.documented_examples.run import _validate_worker_result
+from benchmarks.documented_examples.run import summary_row
+from benchmarks.documented_examples import run as suite_runner
+from benchmarks.documented_examples.worker import _jax_environment
+from benchmarks.documented_examples.worker import configure_jax_environment
+
+
+def test_manifest_covers_every_documented_example() -> None:
+    documents = example_documents_from_index(
+        REPOSITORY_ROOT / "documents" / "index.rst"
+    )
+
+    assert documents == tuple(case.document for case in CASES)
+    assert len({case.case_id for case in CASES}) == len(CASES)
+    assert len({case.workload for case in CASES}) == len(CASES)
+    assert set(case.workload for case in CASES) == set(workloads.WORKLOADS)
+    for case in CASES:
+        assert case.full_output_layer_count > 0
+        assert case.output_rows_per_condition > 0
+        assert (
+            case.full_output_layer_count % case.output_rows_per_condition == 0
+        )
+        assert case.expected_output_layer_count(1) == (
+            case.output_rows_per_condition
+        )
+        assert len(set(case.expected_phases)) == len(case.expected_phases)
+        assert all(
+            category in ("setup", "solver")
+            for _, category in case.expected_phases
+        )
+        assert case.source_scripts
+        document = REPOSITORY_ROOT / "documents" / f"{case.document}.rst"
+        assert document.is_file()
+        document_source = document.read_text()
+        assert all(
+            (REPOSITORY_ROOT / source).is_file()
+            for source in case.source_scripts
+        )
+        assert all(
+            Path(source).name in document_source
+            for source in case.source_scripts
+        )
+        assert all(
+            (REPOSITORY_ROOT / artifact).is_file()
+            for artifact in case.input_artifacts
+        )
+        assert all(
+            Path(artifact).name in document_source
+            for artifact in case.input_artifacts
+        )
+
+    assert sum(len(case.expected_phases) for case in CASES) == 14
+
+
+@pytest.mark.parametrize(
+    ("platform", "optimization", "jax_platform", "disabled"),
+    [
+        ("cpu", "default", "cpu", "false"),
+        ("gpu", "default", "cuda", "false"),
+        (
+            "cpu",
+            "disable_most_optimizations",
+            "cpu",
+            "true",
+        ),
+    ],
+)
+def test_jax_environment_is_explicit_before_worker_imports(
+    monkeypatch: pytest.MonkeyPatch,
+    platform: str,
+    optimization: str,
+    jax_platform: str,
+    disabled: str,
+) -> None:
+    monkeypatch.setenv("JAX_DISABLE_MOST_OPTIMIZATIONS", "inherited")
+
+    configure_jax_environment(platform, optimization)
+
+    assert __import__("os").environ["JAX_PLATFORMS"] == jax_platform
+    assert __import__("os").environ["JAX_PLATFORM_NAME"] == jax_platform
+    assert __import__("os").environ["JAX_ENABLE_X64"] == "1"
+    assert __import__("os").environ["JAX_ENABLE_COMPILATION_CACHE"] == "false"
+    assert __import__("os").environ["XLA_PYTHON_CLIENT_PREALLOCATE"] == "false"
+    assert (
+        __import__("os").environ["JAX_DISABLE_MOST_OPTIMIZATIONS"]
+        == disabled
+    )
+
+
+def test_worker_module_does_not_import_jax() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys; "
+                "import benchmarks.documented_examples.worker; "
+                "raise SystemExit('jax' in sys.modules)"
+            ),
+        ],
+        cwd=REPOSITORY_ROOT,
+        check=False,
+    )
+
+    assert completed.returncode == 0
+
+
+@pytest.mark.parametrize(
+    ("values", "exception"),
+    [
+        (
+            {
+                "jax_enable_x64": True,
+                "jax_enable_compilation_cache": False,
+            },
+            NotImplementedError,
+        ),
+        (
+            {
+                "jax_disable_most_optimizations": False,
+                "jax_enable_x64": True,
+                "jax_enable_compilation_cache": False,
+            },
+            RuntimeError,
+        ),
+        (
+            {
+                "jax_disable_most_optimizations": True,
+                "jax_enable_x64": False,
+                "jax_enable_compilation_cache": False,
+            },
+            RuntimeError,
+        ),
+        (
+            {
+                "jax_disable_most_optimizations": True,
+                "jax_enable_x64": True,
+                "jax_enable_compilation_cache": True,
+            },
+            RuntimeError,
+        ),
+    ],
+)
+def test_jax_environment_rejects_unsupported_or_ineffective_config(
+    monkeypatch: pytest.MonkeyPatch,
+    values: dict[str, object],
+    exception: type[Exception],
+) -> None:
+    fake_jax = SimpleNamespace(
+        __version__="test",
+        config=SimpleNamespace(values=values),
+        devices=lambda: (
+            SimpleNamespace(id=0, platform="cpu", device_kind="cpu"),
+        ),
+        default_backend=lambda: "cpu",
+    )
+    monkeypatch.setitem(sys.modules, "jax", fake_jax)
+    monkeypatch.setitem(
+        sys.modules,
+        "jaxlib",
+        SimpleNamespace(__version__="test"),
+    )
+
+    with pytest.raises(exception):
+        _jax_environment("cpu", "disable_most_optimizations")
+
+
+def test_default_benchmark_matrix_covers_every_case_and_mode() -> None:
+    case_ids = tuple(case.case_id for case in CASES)
+    jobs = benchmark_jobs(
+        case_ids,
+        ("cpu", "gpu"),
+        ("default", "disable_most_optimizations"),
+        repeat=2,
+    )
+
+    assert len(jobs) == len(CASES) * 2 * 2 * 2
+    assert set(jobs) == {
+        (case_id, platform, optimization, repetition)
+        for case_id in case_ids
+        for platform in ("cpu", "gpu")
+        for optimization in ("default", "disable_most_optimizations")
+        for repetition in (1, 2)
+    }
+
+
+def test_timing_collector_aggregates_and_restores_hooks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exogibbs.equilibrium.condensate.fixed_support import batch
+    from exogibbs.equilibrium.condensate.fixed_support import zero_barrier
+
+    pdipm_result = {
+        "backend": "cpu",
+        "compilation_seconds": 0.2,
+        "execution_seconds": 0.3,
+        "diagnostic_seconds": 0.1,
+        "diagnostic_compilation_seconds": 0.06,
+        "diagnostic_execution_seconds": 0.04,
+        "bucket_reports": (
+            {
+                "support_indices": (2,),
+                "layer_indices": (0, 1),
+                "compilation_seconds": 0.2,
+                "execution_seconds": 0.3,
+                "diagnostic_compilation_seconds": 0.06,
+                "diagnostic_execution_seconds": 0.04,
+            },
+        ),
+    }
+    zero_result = SimpleNamespace(
+        accepted=True,
+        support_indices=(2,),
+        report={
+            "exact_active_set_closure": {
+                "cumulative_function_evaluations": 7,
+                "round_count": 2,
+                "termination_reason": "accepted",
+            }
+        },
+    )
+
+    repeated_pdipm_result = {
+        **pdipm_result,
+        "compilation_seconds": 0.03,
+        "bucket_reports": (
+            {
+                **pdipm_result["bucket_reports"][0],
+                "compilation_seconds": 0.03,
+            },
+        ),
+    }
+    pdipm_results = iter((pdipm_result, repeated_pdipm_result))
+
+    def fake_pdipm(*_args: object, **_kwargs: object) -> dict:
+        return next(pdipm_results)
+
+    def fake_zero_barrier(*_args: object, **_kwargs: object) -> object:
+        return zero_result
+
+    monkeypatch.setattr(batch, "run_fixed_support_profile", fake_pdipm)
+    monkeypatch.setattr(
+        zero_barrier,
+        "polish_zero_barrier_active_support",
+        fake_zero_barrier,
+    )
+    ticks = iter(float(index) for index in range(20))
+    monkeypatch.setattr(instrumentation.time, "perf_counter", lambda: next(ticks))
+
+    formula = np.zeros((3, 5), dtype=np.float64)
+    with TimingCollector() as collector:
+        with collector.phase("setup", category="setup"):
+            pass
+        with collector.phase("solve", category="solver"):
+            assert collector._batch_module.run_fixed_support_profile(
+                buckets=(), formula_matrix=formula
+            ) is pdipm_result
+            assert collector._batch_module.run_fixed_support_profile(
+                buckets=(), formula_matrix=formula
+            ) is repeated_pdipm_result
+            assert collector._zero_barrier_module.polish_zero_barrier_active_support(
+                support_indices=(2,)
+            ) is zero_result
+
+    assert batch.run_fixed_support_profile is fake_pdipm
+    assert (
+        zero_barrier.polish_zero_barrier_active_support
+        is fake_zero_barrier
+    )
+    summary = collector.summary(workload_wall_seconds=10.0)
+    assert summary["setup_phase_wall_seconds"] == 1.0
+    assert summary["solver_phase_wall_seconds"] == 7.0
+    assert summary["pdipm"]["compilation_seconds"] == pytest.approx(0.23)
+    assert summary["pdipm"]["execution_seconds"] == pytest.approx(0.6)
+    assert summary["pdipm"]["diagnostic_seconds"] == pytest.approx(0.2)
+    assert summary["pdipm"]["diagnostic_compilation_seconds"] == pytest.approx(
+        0.12
+    )
+    assert summary["pdipm"]["diagnostic_execution_seconds"] == pytest.approx(
+        0.08
+    )
+    assert summary["pdipm"]["wall_seconds"] == 2.0
+    assert summary["pdipm"]["executable_shape_count"] == 1
+    assert summary["pdipm"]["first_shape_compilation_seconds"] == 0.2
+    assert summary["pdipm"]["repeated_shape_compilation_seconds"] == 0.03
+    assert summary["pdipm"]["shape_compilation"][0]["invocation_count"] == 2
+    assert summary["pdipm"]["shape_compilation"][0]["signature"] == (
+        "backend=cpu,dtype=float64,config=dc937b598926,elements=3,gas=5,"
+        "support=1,batch=2,diagnostics=1"
+    )
+    assert summary["zero_barrier"]["host_wall_seconds"] == 1.0
+    assert summary["zero_barrier"]["function_evaluations"] == 7
+    assert summary["zero_barrier"]["calls"][0]["active_set_round_count"] == 2
+    solver_budget = summary["solver_budget"]
+    assert solver_budget["schema"] == SOLVER_BUDGET_SCHEMA
+    assert solver_budget["wall_seconds"] == 7.0
+    assert solver_budget["pdipm_call_count"] == 2
+    assert solver_budget["pdipm_bucket_count"] == 2
+    assert solver_budget["pdipm_wall_seconds"] == 2.0
+    assert solver_budget["pdipm_internal_orchestration_wall_seconds"] == (
+        pytest.approx(0.97)
+    )
+    assert solver_budget["zero_barrier_host_wall_seconds"] == 1.0
+    assert solver_budget[
+        "outside_pdipm_and_zero_barrier_wall_seconds"
+    ] == pytest.approx(4.0)
+    assert solver_budget["attribution_consistent"] is True
+    assert summary["other_solver_and_orchestration_wall_seconds"] == (
+        pytest.approx(4.97)
+    )
+    phase_budgets = {
+        budget["name"]: budget for budget in summary["phase_budgets"]
+    }
+    assert phase_budgets["setup"][
+        "outside_pdipm_and_zero_barrier_wall_seconds"
+    ] == 1.0
+    assert phase_budgets["solve"]["pdipm_call_count"] == 2
+    assert phase_budgets["solve"]["zero_barrier_call_count"] == 1
+    assert summary["timing_attribution_consistent"] is True
+
+
+def test_phase_budget_attributes_gas_only_work_to_the_phase_residual() -> None:
+    collector = TimingCollector()
+    collector.phases = [
+        {
+            "name": "solve_condensate_profile",
+            "category": "solver",
+            "wall_seconds": 3.0,
+            "status": "pass",
+            "error": None,
+        },
+        {
+            "name": "solve_gas_only_profile",
+            "category": "solver",
+            "wall_seconds": 2.0,
+            "status": "pass",
+            "error": None,
+        },
+    ]
+    collector.pdipm_calls = [
+        {
+            "phase": "solve_condensate_profile",
+            "phase_category": "solver",
+            "wall_seconds": 1.5,
+            "compilation_seconds": 0.5,
+            "execution_seconds": 0.5,
+            "diagnostic_seconds": 0.0,
+            "diagnostic_compilation_seconds": 0.0,
+            "diagnostic_execution_seconds": 0.0,
+            "buckets": ({"signature": "one", "compilation_seconds": 0.5},),
+        }
+    ]
+
+    summary = collector.summary(workload_wall_seconds=5.0)
+    budgets = {budget["name"]: budget for budget in summary["phase_budgets"]}
+
+    gas_budget = budgets["solve_gas_only_profile"]
+    assert gas_budget["pdipm_call_count"] == 0
+    assert gas_budget["zero_barrier_call_count"] == 0
+    assert gas_budget[
+        "outside_pdipm_and_zero_barrier_wall_seconds"
+    ] == 2.0
+    assert gas_budget["attribution_consistent"] is True
+
+
+def test_run_case_fails_closed_but_allows_smoke_layer_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    case = CASES[0]
+    result = {
+        "all_layers_converged": True,
+        "output_layer_count": 2,
+    }
+    monkeypatch.setitem(
+        workloads.WORKLOADS,
+        case.workload,
+        lambda _collector, _smoke_layers: result,
+    )
+
+    with pytest.raises(RuntimeError, match="expected"):
+        workloads.run_case(case, TimingCollector(), smoke_layers=None)
+    assert workloads.run_case(
+        case,
+        TimingCollector(),
+        smoke_layers=1,
+    ) is result
+
+    result["output_layer_count"] = 1
+    with pytest.raises(RuntimeError, match="expected"):
+        workloads.run_case(case, TimingCollector(), smoke_layers=1)
+
+    result["output_layer_count"] = 2
+    result["all_layers_converged"] = False
+    with pytest.raises(RuntimeError, match="converged"):
+        workloads.run_case(case, TimingCollector(), smoke_layers=1)
+
+    result.update(all_layers_converged=True, output_layer_count=0)
+    with pytest.raises(RuntimeError, match="no output"):
+        workloads.run_case(case, TimingCollector(), smoke_layers=1)
+
+
+@pytest.mark.parametrize(
+    (
+        "condensate_amount",
+        "gas_amount",
+        "caller_audit",
+        "status",
+        "finite",
+        "accepted",
+    ),
+    [
+        (0.0, 1.0, None, "converged", True, True),
+        (0.5, 1.0, True, "converged", True, True),
+        (0.5, 1.0, None, "converged", True, False),
+        (0.5, 1.0, False, "converged", True, False),
+        (-0.5, 1.0, None, "converged", True, False),
+        (0.0, -1.0, None, "converged", True, False),
+        (0.0, 1.0, None, "not_converged", True, False),
+        (0.0, 1.0, None, "converged", False, False),
+    ],
+)
+def test_profile_physical_audit_fails_closed(
+    condensate_amount: float,
+    gas_amount: float,
+    caller_audit: bool | None,
+    status: str,
+    finite: bool,
+    accepted: bool,
+) -> None:
+    lifecycle = {}
+    if caller_audit is not None:
+        lifecycle["caller_gauge_zero_barrier_kkt"] = {
+            "accepted": caller_audit
+        }
+    gas_n = [gas_amount] if finite else [np.nan]
+    layer = SimpleNamespace(
+        acceptance_tier="fixed_support_v2_accepted",
+        condensate_amounts=np.asarray([condensate_amount]),
+        gas_n=np.asarray(gas_n),
+        converged=status == "converged",
+        status=status,
+        diagnostics={"fixed_support_v2": lifecycle},
+    )
+
+    report = workloads._profile_physical_audit(
+        SimpleNamespace(layers=(layer,))
+    )
+
+    assert report["all_layers_finite_and_physically_accepted"] is accepted
+    assert report["failed_layer_indices"] == (() if accepted else (0,))
+
+
+@pytest.mark.parametrize(
+    ("gas_x", "accepted"),
+    [
+        ([[0.25, 0.75]], True),
+        ([[0.25, -0.75]], False),
+        ([[0.0, 0.0]], False),
+        ([[np.nan, 1.0]], False),
+        ([0.25, 0.75], False),
+    ],
+)
+def test_gas_profile_physical_audit_fails_closed(
+    gas_x: list,
+    accepted: bool,
+) -> None:
+    report = workloads._gas_profile_physical_audit(
+        gas_x,
+        converged=[True],
+        species_count=2,
+    )
+
+    assert report["all_layers_finite_nonnegative_and_nonempty"] is accepted
+
+
+def test_summary_row_flattens_stable_metrics() -> None:
+    payload = {
+        "case": {"case_id": "case"},
+        "scope": {"kind": "full"},
+        "execution": {
+            "requested_platform": "cpu",
+            "optimization_mode": "default",
+            "repetition": 1,
+        },
+        "status": "pass",
+        "validation": {"output_layer_count": 4},
+        "timing": {
+            "workload_wall_seconds": 5.0,
+            "setup_phase_wall_seconds": 0.5,
+            "solver_phase_wall_seconds": 4.0,
+            "unphased_workload_wall_seconds": 0.5,
+            "pdipm": {
+                "compilation_seconds": 2.0,
+                "execution_seconds": 1.0,
+                "diagnostic_seconds": 0.5,
+                "diagnostic_compilation_seconds": 0.3,
+                "diagnostic_execution_seconds": 0.2,
+                "wall_seconds": 3.75,
+                "first_shape_compilation_seconds": 1.5,
+                "repeated_shape_compilation_seconds": 0.5,
+                "executable_shape_count": 2,
+            },
+            "zero_barrier": {
+                "host_wall_seconds": 0.25,
+                "call_count": 2,
+                "function_evaluations": 0,
+            },
+            "solver_budget": {
+                "pdipm_call_count": 3,
+                "pdipm_bucket_count": 4,
+                "pdipm_wall_seconds": 3.75,
+                "pdipm_compilation_seconds": 2.0,
+                "pdipm_execution_seconds": 1.0,
+                "pdipm_diagnostic_seconds": 0.5,
+                "pdipm_diagnostic_compilation_seconds": 0.3,
+                "pdipm_diagnostic_execution_seconds": 0.2,
+                "pdipm_internal_orchestration_wall_seconds": 0.25,
+                "zero_barrier_call_count": 2,
+                "zero_barrier_function_evaluations": 0,
+                "zero_barrier_host_wall_seconds": 0.25,
+                "outside_pdipm_and_zero_barrier_wall_seconds": 0.0,
+            },
+            "other_solver_and_orchestration_wall_seconds": 0.25,
+            "timing_attribution_consistent": True,
+        },
+    }
+
+    row = summary_row(payload)
+
+    assert row["case_id"] == "case"
+    assert row["pdipm_compile_seconds"] == 2.0
+    assert row["pdipm_execute_seconds"] == 1.0
+    assert row["pdipm_repeated_shape_compilation_seconds"] == 0.5
+    assert row["pdipm_executable_shape_count"] == 2
+    assert row["zero_barrier_host_wall_seconds"] == 0.25
+    assert row["pdipm_call_count"] == 3
+    assert row["pdipm_bucket_count"] == 4
+    assert row["pdipm_diagnostic_compilation_seconds"] == 0.3
+    assert row["pdipm_internal_orchestration_wall_seconds"] == 0.25
+
+
+def test_worker_contract_recomputes_budget_identities() -> None:
+    case_id = "fe_fes_rainout_demo"
+    timing = {
+        "workload_wall_seconds": 5.0,
+        "setup_phase_wall_seconds": 0.5,
+        "solver_phase_wall_seconds": 4.0,
+        "unphased_workload_wall_seconds": 0.5,
+        "pdipm": {
+            "call_count": 1,
+            "bucket_count": 1,
+            "compilation_seconds": 2.0,
+            "execution_seconds": 1.0,
+            "diagnostic_seconds": 0.5,
+            "diagnostic_compilation_seconds": 0.3,
+            "diagnostic_execution_seconds": 0.2,
+            "wall_seconds": 3.75,
+        },
+        "zero_barrier": {
+            "call_count": 0,
+            "host_wall_seconds": 0.0,
+            "function_evaluations": 0,
+        },
+        "solver_budget": {
+            "schema": SOLVER_BUDGET_SCHEMA,
+            "wall_seconds": 4.0,
+            "pdipm_call_count": 1,
+            "pdipm_bucket_count": 1,
+            "pdipm_wall_seconds": 3.75,
+            "pdipm_compilation_seconds": 2.0,
+            "pdipm_execution_seconds": 1.0,
+            "pdipm_diagnostic_seconds": 0.5,
+            "pdipm_diagnostic_compilation_seconds": 0.3,
+            "pdipm_diagnostic_execution_seconds": 0.2,
+            "pdipm_internal_orchestration_wall_seconds": 0.25,
+            "zero_barrier_call_count": 0,
+            "zero_barrier_function_evaluations": 0,
+            "zero_barrier_host_wall_seconds": 0.0,
+            "outside_pdipm_and_zero_barrier_wall_seconds": 0.25,
+            "attribution_delta_seconds": 0.0,
+            "attribution_consistent": True,
+        },
+        "phase_budgets": [
+            {
+                "name": "solve_local",
+                "category": "solver",
+                "invocation_count": 1,
+                "schema": SOLVER_BUDGET_SCHEMA,
+                "wall_seconds": 4.0,
+                "pdipm_call_count": 1,
+                "pdipm_bucket_count": 1,
+                "pdipm_wall_seconds": 3.75,
+                "pdipm_compilation_seconds": 2.0,
+                "pdipm_execution_seconds": 1.0,
+                "pdipm_diagnostic_seconds": 0.5,
+                "pdipm_diagnostic_compilation_seconds": 0.3,
+                "pdipm_diagnostic_execution_seconds": 0.2,
+                "pdipm_internal_orchestration_wall_seconds": 0.25,
+                "zero_barrier_call_count": 0,
+                "zero_barrier_function_evaluations": 0,
+                "zero_barrier_host_wall_seconds": 0.0,
+                "outside_pdipm_and_zero_barrier_wall_seconds": 0.25,
+                "attribution_delta_seconds": 0.0,
+                "attribution_consistent": True,
+            },
+            {
+                "name": "solve_rainout",
+                "category": "solver",
+                "invocation_count": 1,
+                "schema": SOLVER_BUDGET_SCHEMA,
+                "wall_seconds": 0.0,
+                "pdipm_call_count": 0,
+                "pdipm_bucket_count": 0,
+                "pdipm_wall_seconds": 0.0,
+                "pdipm_compilation_seconds": 0.0,
+                "pdipm_execution_seconds": 0.0,
+                "pdipm_diagnostic_seconds": 0.0,
+                "pdipm_diagnostic_compilation_seconds": 0.0,
+                "pdipm_diagnostic_execution_seconds": 0.0,
+                "pdipm_internal_orchestration_wall_seconds": 0.0,
+                "zero_barrier_call_count": 0,
+                "zero_barrier_function_evaluations": 0,
+                "zero_barrier_host_wall_seconds": 0.0,
+                "outside_pdipm_and_zero_barrier_wall_seconds": 0.0,
+                "attribution_delta_seconds": 0.0,
+                "attribution_consistent": True,
+            },
+            {
+                "name": "build_reduced_setup",
+                "category": "setup",
+                "invocation_count": 1,
+                "schema": SOLVER_BUDGET_SCHEMA,
+                "wall_seconds": 0.5,
+                "pdipm_call_count": 0,
+                "pdipm_bucket_count": 0,
+                "pdipm_wall_seconds": 0.0,
+                "pdipm_compilation_seconds": 0.0,
+                "pdipm_execution_seconds": 0.0,
+                "pdipm_diagnostic_seconds": 0.0,
+                "pdipm_diagnostic_compilation_seconds": 0.0,
+                "pdipm_diagnostic_execution_seconds": 0.0,
+                "pdipm_internal_orchestration_wall_seconds": 0.0,
+                "zero_barrier_call_count": 0,
+                "zero_barrier_function_evaluations": 0,
+                "zero_barrier_host_wall_seconds": 0.0,
+                "outside_pdipm_and_zero_barrier_wall_seconds": 0.5,
+                "attribution_delta_seconds": 0.0,
+                "attribution_consistent": True,
+            },
+        ],
+        "timing_attribution_consistent": True,
+    }
+    payload = {
+        "schema": "exogibbs_documented_example_benchmark_v2",
+        "status": "pass",
+        "case": {"case_id": case_id},
+        "execution": {
+            "requested_platform": "cpu",
+            "optimization_mode": "default",
+            "repetition": 1,
+        },
+        "scope": {"kind": "smoke", "smoke_layers": 1},
+        "validation": {
+            "all_layers_converged": True,
+            "output_layer_count": 2,
+        },
+        "timing": timing,
+        "environment": {},
+    }
+
+    assert not _validate_worker_result(
+        payload,
+        case_id=case_id,
+        platform="cpu",
+        optimization="default",
+        repetition=1,
+        smoke_layers=1,
+    )
+    timing["solver_budget"][
+        "outside_pdipm_and_zero_barrier_wall_seconds"
+    ] = 9.0
+
+    violations = _validate_worker_result(
+        payload,
+        case_id=case_id,
+        platform="cpu",
+        optimization="default",
+        repetition=1,
+        smoke_layers=1,
+    )
+
+    assert any("wall partition" in violation for violation in violations)
+
+
+@pytest.mark.parametrize(
+    (
+        "worker_status",
+        "worker_return_code",
+        "reported_case_id",
+        "result_status",
+        "suite_status",
+        "main_code",
+    ),
+    [
+        ("pass", 0, "fe_fes_rainout_demo", "pass", "pass", 0),
+        ("pass", 1, "fe_fes_rainout_demo", "worker_error", "incomplete", 1),
+        (
+            "unavailable",
+            2,
+            "fe_fes_rainout_demo",
+            "unavailable",
+            "incomplete",
+            1,
+        ),
+        ("pass", 0, "wrong_case", "invalid_result", "incomplete", 1),
+    ],
+)
+def test_suite_writes_summary_and_fails_closed_on_worker_status(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    worker_status: str,
+    worker_return_code: int,
+    reported_case_id: str,
+    result_status: str,
+    suite_status: str,
+    main_code: int,
+) -> None:
+    output_directory = tmp_path / "results"
+
+    def fake_run(command: tuple[str, ...], **_kwargs: object) -> object:
+        child_environment = _kwargs["env"]
+        python_paths = child_environment["PYTHONPATH"].split(
+            __import__("os").pathsep
+        )
+        assert python_paths[:2] == [
+            str(REPOSITORY_ROOT / "src"),
+            str(REPOSITORY_ROOT),
+        ]
+        output_index = command.index("--output") + 1
+        output = Path(command[output_index])
+        payload = {
+            "schema": "exogibbs_documented_example_benchmark_v2",
+            "status": worker_status,
+            "case": {"case_id": reported_case_id},
+            "scope": {"kind": "smoke"},
+            "execution": {
+                "requested_platform": "cpu",
+                "optimization_mode": "default",
+                "repetition": 1,
+            },
+            "validation": {"output_layer_count": 2},
+            "timing": {
+                "workload_wall_seconds": 5.0,
+                "setup_phase_wall_seconds": 0.5,
+                "solver_phase_wall_seconds": 4.0,
+                "unphased_workload_wall_seconds": 0.5,
+                "pdipm": {
+                    "call_count": 3,
+                    "bucket_count": 4,
+                    "compilation_seconds": 2.0,
+                    "execution_seconds": 1.0,
+                    "diagnostic_seconds": 0.5,
+                    "diagnostic_compilation_seconds": 0.3,
+                    "diagnostic_execution_seconds": 0.2,
+                    "wall_seconds": 3.75,
+                    "first_shape_compilation_seconds": 1.5,
+                    "repeated_shape_compilation_seconds": 0.5,
+                    "executable_shape_count": 2,
+                },
+                "zero_barrier": {
+                    "host_wall_seconds": 0.25,
+                    "call_count": 2,
+                    "function_evaluations": 0,
+                },
+                "other_solver_and_orchestration_wall_seconds": 0.25,
+                "solver_budget": {
+                    "schema": SOLVER_BUDGET_SCHEMA,
+                    "wall_seconds": 4.0,
+                    "pdipm_call_count": 3,
+                    "pdipm_bucket_count": 4,
+                    "pdipm_wall_seconds": 3.75,
+                    "pdipm_compilation_seconds": 2.0,
+                    "pdipm_execution_seconds": 1.0,
+                    "pdipm_diagnostic_seconds": 0.5,
+                    "pdipm_diagnostic_compilation_seconds": 0.3,
+                    "pdipm_diagnostic_execution_seconds": 0.2,
+                    "pdipm_internal_orchestration_wall_seconds": 0.25,
+                    "zero_barrier_call_count": 2,
+                    "zero_barrier_function_evaluations": 0,
+                    "zero_barrier_host_wall_seconds": 0.25,
+                    "outside_pdipm_and_zero_barrier_wall_seconds": 0.0,
+                    "attribution_delta_seconds": 0.0,
+                    "attribution_consistent": True,
+                },
+                "phase_budgets": [
+                    {
+                        "name": "solve_local",
+                        "category": "solver",
+                        "invocation_count": 1,
+                        "schema": SOLVER_BUDGET_SCHEMA,
+                        "wall_seconds": 4.0,
+                        "pdipm_call_count": 3,
+                        "pdipm_bucket_count": 4,
+                        "pdipm_wall_seconds": 3.75,
+                        "pdipm_compilation_seconds": 2.0,
+                        "pdipm_execution_seconds": 1.0,
+                        "pdipm_diagnostic_seconds": 0.5,
+                        "pdipm_diagnostic_compilation_seconds": 0.3,
+                        "pdipm_diagnostic_execution_seconds": 0.2,
+                        "pdipm_internal_orchestration_wall_seconds": 0.25,
+                        "zero_barrier_call_count": 2,
+                        "zero_barrier_function_evaluations": 0,
+                        "zero_barrier_host_wall_seconds": 0.25,
+                        "outside_pdipm_and_zero_barrier_wall_seconds": 0.0,
+                        "attribution_delta_seconds": 0.0,
+                        "attribution_consistent": True,
+                    },
+                    {
+                        "name": "solve_rainout",
+                        "category": "solver",
+                        "invocation_count": 1,
+                        "schema": SOLVER_BUDGET_SCHEMA,
+                        "wall_seconds": 0.0,
+                        "pdipm_call_count": 0,
+                        "pdipm_bucket_count": 0,
+                        "pdipm_wall_seconds": 0.0,
+                        "pdipm_compilation_seconds": 0.0,
+                        "pdipm_execution_seconds": 0.0,
+                        "pdipm_diagnostic_seconds": 0.0,
+                        "pdipm_diagnostic_compilation_seconds": 0.0,
+                        "pdipm_diagnostic_execution_seconds": 0.0,
+                        "pdipm_internal_orchestration_wall_seconds": 0.0,
+                        "zero_barrier_call_count": 0,
+                        "zero_barrier_function_evaluations": 0,
+                        "zero_barrier_host_wall_seconds": 0.0,
+                        "outside_pdipm_and_zero_barrier_wall_seconds": 0.0,
+                        "attribution_delta_seconds": 0.0,
+                        "attribution_consistent": True,
+                    },
+                    {
+                        "name": "build_reduced_setup",
+                        "category": "setup",
+                        "invocation_count": 1,
+                        "schema": SOLVER_BUDGET_SCHEMA,
+                        "wall_seconds": 0.5,
+                        "pdipm_call_count": 0,
+                        "pdipm_bucket_count": 0,
+                        "pdipm_wall_seconds": 0.0,
+                        "pdipm_compilation_seconds": 0.0,
+                        "pdipm_execution_seconds": 0.0,
+                        "pdipm_diagnostic_seconds": 0.0,
+                        "pdipm_diagnostic_compilation_seconds": 0.0,
+                        "pdipm_diagnostic_execution_seconds": 0.0,
+                        "pdipm_internal_orchestration_wall_seconds": 0.0,
+                        "zero_barrier_call_count": 0,
+                        "zero_barrier_function_evaluations": 0,
+                        "zero_barrier_host_wall_seconds": 0.0,
+                        "outside_pdipm_and_zero_barrier_wall_seconds": 0.5,
+                        "attribution_delta_seconds": 0.0,
+                        "attribution_consistent": True,
+                    },
+                ],
+                "timing_attribution_consistent": True,
+            },
+            "resources": {"maximum_resident_set_size_kb": 100},
+            "environment": {"backend": "cpu"},
+        }
+        payload["scope"]["smoke_layers"] = 1
+        payload["validation"]["all_layers_converged"] = True
+        output.write_text(json.dumps(payload))
+        return subprocess.CompletedProcess(command, worker_return_code)
+
+    monkeypatch.setattr(suite_runner.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run",
+            "--case",
+            "fe_fes_rainout_demo",
+            "--platform",
+            "cpu",
+            "--optimization",
+            "default",
+            "--smoke-layers",
+            "1",
+            "--output-directory",
+            str(output_directory),
+        ],
+    )
+
+    assert suite_runner.main() == main_code
+    summary = json.loads((output_directory / "summary.json").read_text())
+    assert summary["schema"] == (
+        "exogibbs_documented_example_benchmark_suite_v2"
+    )
+    assert summary["status"] == suite_status
+    assert summary["result_count"] == 1
+    assert summary["passed_result_count"] == int(
+        result_status == "pass" and worker_return_code == 0
+    )
+    assert summary["results"][0]["worker_return_code"] == worker_return_code
+    assert summary["results"][0]["status"] == result_status
+    if result_status == "invalid_result":
+        assert summary["results"][0]["reported_status"] == worker_status
+        assert summary["results"][0]["contract_violations"]
+
+    with (output_directory / "summary.csv").open(newline="") as input_file:
+        rows = list(csv.DictReader(input_file))
+    required_fields = {
+        "case_id",
+        "platform",
+        "optimization",
+        "status",
+        "worker_return_code",
+        "workload_wall_seconds",
+        "setup_phase_wall_seconds",
+        "solver_phase_wall_seconds",
+        "unphased_workload_wall_seconds",
+        "pdipm_compile_seconds",
+        "pdipm_execute_seconds",
+        "pdipm_diagnostic_seconds",
+        "pdipm_diagnostic_compilation_seconds",
+        "pdipm_diagnostic_execution_seconds",
+        "pdipm_repeated_shape_compilation_seconds",
+        "pdipm_executable_shape_count",
+        "pdipm_call_count",
+        "pdipm_bucket_count",
+        "pdipm_wall_seconds",
+        "pdipm_internal_orchestration_wall_seconds",
+        "outside_pdipm_and_zero_barrier_wall_seconds",
+        "zero_barrier_host_wall_seconds",
+        "zero_barrier_call_count",
+        "zero_barrier_function_evaluations",
+        "timing_attribution_consistent",
+        "result_file",
+        "log_file",
+    }
+    assert required_fields <= set(rows[0])
+    assert rows[0]["pdipm_compile_seconds"] == "2.0"
+    assert rows[0]["pdipm_call_count"] == "3"
+
+    with (output_directory / "phase_budgets.csv").open(
+        newline=""
+    ) as input_file:
+        phase_rows = list(csv.DictReader(input_file))
+    assert phase_rows[0]["phase_name"] == "solve_local"
+    assert phase_rows[0]["pdipm_call_count"] == "3"
+    assert phase_rows[0]["pdipm_diagnostic_seconds"] == "0.5"
+    assert phase_rows[0]["attribution_delta_seconds"] == "0.0"
+    assert phase_rows[0][
+        "outside_pdipm_and_zero_barrier_wall_seconds"
+    ] == "0.0"
+    markdown = (output_directory / "summary.md").read_text()
+    assert "## Workload overview" in markdown
+    assert "## Solver wall-time budget" in markdown
+    assert "pdipm_call_count" in markdown
+    assert "pdipm_internal_orchestration_wall_seconds" in markdown
+    assert "Per-phase budgets are in `phase_budgets.csv`" in markdown

--- a/tests/unittests/benchmarks/ldwarf_repeated_benchmark_test.py
+++ b/tests/unittests/benchmarks/ldwarf_repeated_benchmark_test.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from benchmarks.documented_examples.ldwarf_repeated import (  # noqa: E402
+    DEFAULT_EVALUATION_COUNT,
+    PRESSURE_OFFSET_LIMIT_DEX,
+    TEMPERATURE_OFFSET_LIMIT_K,
+    TEMPERATURE_TILT_LIMIT_K,
+    _new_shape_signatures,
+    _pdipm_support_signature,
+    _result_status,
+    _write_markdown,
+    generate_conditions,
+    steady_statistics,
+)
+
+
+def test_repeated_conditions_are_deterministic_smooth_and_bounded() -> None:
+    base_temperature = np.linspace(1100.0, 2600.0, 13)
+    base_pressure = np.logspace(-4.0, 2.0, 13)
+
+    first = generate_conditions(base_temperature, base_pressure)
+    second = generate_conditions(base_temperature, base_pressure)
+
+    assert DEFAULT_EVALUATION_COUNT == 10
+    assert first["sha256"] == second["sha256"]
+    assert first["temperature_k"] == pytest.approx(second["temperature_k"])
+    assert first["pressure_bar"] == pytest.approx(second["pressure_bar"])
+    assert first["temperature_k"].shape == (10, 13)
+    assert first["pressure_bar"].shape == (10, 13)
+    assert first["temperature_k"].dtype == np.float64
+    assert first["pressure_bar"].dtype == np.float64
+    assert np.all(np.diff(first["temperature_k"], axis=1) > 0.0)
+    assert np.all(np.diff(first["pressure_bar"], axis=1) > 0.0)
+    assert max(abs(value) for value in first["pressure_offset_dex"]) <= (
+        PRESSURE_OFFSET_LIMIT_DEX
+    )
+    assert max(abs(value) for value in first["temperature_offset_k"]) <= (
+        TEMPERATURE_OFFSET_LIMIT_K
+    )
+    assert max(abs(value) for value in first["temperature_tilt_k"]) <= (
+        TEMPERATURE_TILT_LIMIT_K
+    )
+
+
+def test_steady_statistics_exclude_cold_call() -> None:
+    statistics = steady_statistics(
+        tuple(float(value) for value in range(1, 11))
+    )
+
+    assert statistics["evaluation_count"] == 10
+    assert statistics["total_wall_seconds"] == 55.0
+    assert statistics["mean_wall_seconds_per_evaluation"] == 5.5
+    assert statistics["median_wall_seconds_per_evaluation"] == 5.5
+    assert statistics["p95_wall_seconds_per_evaluation"] == pytest.approx(9.55)
+    assert statistics["minimum_wall_seconds_per_evaluation"] == 1.0
+    assert statistics["maximum_wall_seconds_per_evaluation"] == 10.0
+
+
+def test_pdipm_support_signature_detects_identity_not_only_shape() -> None:
+    first = (
+        {
+            "buckets": (
+                {"layer_indices": (0, 2), "support_indices": (1, 4)},
+                {"layer_indices": (1,), "support_indices": (3,)},
+            )
+        },
+    )
+    reordered = (
+        {
+            "buckets": (
+                {"layer_indices": (1,), "support_indices": (3,)},
+                {"layer_indices": (0, 2), "support_indices": (1, 4)},
+            )
+        },
+    )
+    same_shape_different_support = (
+        {
+            "buckets": (
+                {"layer_indices": (0, 2), "support_indices": (1, 5)},
+                {"layer_indices": (1,), "support_indices": (3,)},
+            )
+        },
+    )
+
+    signature = _pdipm_support_signature(first)
+
+    assert signature == _pdipm_support_signature(reordered)
+    assert signature != _pdipm_support_signature(same_shape_different_support)
+
+
+def test_new_shape_and_validation_fail_closed() -> None:
+    cold = {
+        "pdipm": {"shape_compilation": ({"signature": "shape-a"},)}
+    }
+    cached = {
+        "pdipm": {"shape_compilation": ({"signature": "shape-a"},)}
+    }
+    changed = {
+        "pdipm": {
+            "shape_compilation": (
+                {"signature": "shape-a"},
+                {"signature": "shape-b"},
+            )
+        }
+    }
+
+    assert _new_shape_signatures(cold, cached) == ()
+    assert _new_shape_signatures(cold, changed) == ("shape-b",)
+    assert (
+        _result_status(
+            all_evaluations_accepted=False,
+            timing_attribution_consistent=True,
+        )
+        == "fail_validation"
+    )
+    assert (
+        _result_status(
+            all_evaluations_accepted=True,
+            timing_attribution_consistent=False,
+        )
+        == "fail_timing"
+    )
+
+
+def test_markdown_reports_cold_and_steady_pdipm_calls(tmp_path: Path) -> None:
+    output = tmp_path / "summary.md"
+    per_evaluation = {
+        "pdipm_call_count": 1.0,
+        "pdipm_bucket_count": 3.0,
+        "pdipm_compilation_seconds": 0.01,
+        "pdipm_execution_seconds": 1.0,
+        "pdipm_diagnostic_compilation_seconds": 0.0,
+        "pdipm_diagnostic_execution_seconds": 0.0,
+        "pdipm_internal_orchestration_wall_seconds": 0.1,
+        "zero_barrier_host_wall_seconds": 0.2,
+        "outside_pdipm_and_zero_barrier_wall_seconds": 0.3,
+    }
+    payload = {
+        "status": "pass",
+        "cold": {
+            "timing": {"solver_phase_wall_seconds": 10.0},
+            "pdipm_compilation_boundary_seconds": 8.0,
+            "budget": {"pdipm_call_count": 1, "pdipm_bucket_count": 3},
+        },
+        "steady": {
+            "evaluation_count": 10,
+            "total_wall_seconds": 16.0,
+            "mean_wall_seconds_per_evaluation": 1.6,
+            "median_wall_seconds_per_evaluation": 1.5,
+            "p95_wall_seconds_per_evaluation": 2.0,
+            "new_pdipm_executable_shape_count_after_cold": 0,
+            "no_new_pdipm_executable_shapes_after_cold": True,
+            "final_support_identity_preserved": True,
+            "pdipm_support_identity_preserved": True,
+            "budget_per_evaluation": per_evaluation,
+        },
+    }
+
+    _write_markdown(output, payload)
+    text = output.read_text()
+
+    assert "Cold PD-IPM calls: 1" in text
+    assert "| pdipm_calls_per_evaluation | 1.0 |" in text
+    assert "| pdipm_buckets_per_evaluation | 3.0 |" in text
+
+
+def test_repeated_module_does_not_import_jax_before_configuration() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys; "
+                "import benchmarks.documented_examples.ldwarf_repeated; "
+                "raise SystemExit('jax' in sys.modules)"
+            ),
+        ],
+        cwd=REPOSITORY_ROOT,
+        check=False,
+    )
+
+    assert completed.returncode == 0
+
+
+def test_gpu_sequence_runs_only_exogibbs_benchmarks() -> None:
+    script = (
+        REPOSITORY_ROOT
+        / "benchmarks"
+        / "documented_examples"
+        / "run_all_gpu.csh"
+    )
+    text = script.read_text()
+
+    assert script.stat().st_mode & 0o111
+    assert "benchmarks.documented_examples.run" in text
+    assert "benchmarks.documented_examples.ldwarf_repeated" in text
+    assert text.count("--evaluations 10") == 2
+    assert "--optimization default" in text
+    assert "--optimization disable_most_optimizations" in text
+    assert "exojax" not in text.lower()

--- a/tests/unittests/equilibrium/condensate/fixed_support/profile_test.py
+++ b/tests/unittests/equilibrium/condensate/fixed_support/profile_test.py
@@ -119,6 +119,12 @@ def test_prepared_profile_runs_one_masked_bucket_and_reports_closed_support():
     assert result["compilation_seconds"] >= 0.0
     assert result["execution_seconds"] >= 0.0
     assert result["diagnostic_seconds"] >= 0.0
+    assert result["diagnostic_compilation_seconds"] >= 0.0
+    assert result["diagnostic_execution_seconds"] >= 0.0
+    assert result["diagnostic_seconds"] == pytest.approx(
+        result["diagnostic_compilation_seconds"]
+        + result["diagnostic_execution_seconds"]
+    )
     assert result["terminal_status"] == pytest.approx(
         jnp.full((2,), int(TerminalStatus.CONVERGED))
     )
@@ -138,6 +144,8 @@ def test_prepared_profile_runs_one_masked_bucket_and_reports_closed_support():
     )
     assert len(result["bucket_reports"]) == 1
     report = result["bucket_reports"][0]
+    assert report["diagnostic_compilation_seconds"] >= 0.0
+    assert report["diagnostic_execution_seconds"] >= 0.0
     restoration = report["terminal_restoration_diagnostics"]
     assert restoration["available"].shape == (2,)
     assert not jnp.any(restoration["available"])
@@ -212,6 +220,10 @@ def test_prepared_profile_can_skip_terminal_diagnostic_compilation():
     )
 
     assert result["diagnostic_seconds"] == 0.0
+    assert result["diagnostic_compilation_seconds"] == 0.0
+    assert result["diagnostic_execution_seconds"] == 0.0
+    assert result["bucket_reports"][0]["diagnostic_compilation_seconds"] == 0.0
+    assert result["bucket_reports"][0]["diagnostic_execution_seconds"] == 0.0
     assert result["bucket_reports"][0]["terminal_restoration_diagnostics"] is None
     assert result["bucket_reports"][0]["terminal_normal_diagnostics"] is None
     assert result["bucket_reports"][0]["stage_statuses"] is None


### PR DESCRIPTION
## What

- Add a manifest-driven benchmark suite for all five workflows in the documentation `EXAMPLES` toctree, covering CPU/GPU and the default/compile-light JAX modes in isolated workers.
- Record provenance, convergence and physical audits, additive phase budgets, and JSON/CSV/Markdown summaries suitable for regression analysis.
- Add a full-catalog L-dwarf cold-plus-ten-warm benchmark and a sequential GPU runner for the complete matrix.
- Split terminal diagnostic timing into explicit compilation and execution components while retaining the existing diagnostic total, and test the timing contracts and documentation coverage.

## Why

This provides a repeatable performance-regression surface aligned with the documented production workloads. The finer timing attribution distinguishes JAX compilation and execution from host-side zero-barrier work and solver orchestration, and makes the compile-light trade-off auditable.

## Impact

Solver mathematics and public APIs are unchanged. Benchmark results now expose validated timing budgets and source provenance, while fixed-support diagnostic reports add compilation/execution breakdowns alongside the backward-compatible total.

## Checks

- `pytest tests/unittests`: 549 passed
- Targeted benchmark and fixed-support timing tests: 52 passed
- Python benchmark module compilation: passed
- csh GPU runner syntax check: passed
- Full GPU sequence on NVIDIA A100: all five documented workloads in both compiler modes, plus both cold/warm L-dwarf runs, passed