### PR TITLE
condensate: stabilize fixed-support profile shapes

### DIFF
--- a/benchmarks/documented_examples/README.md
+++ b/benchmarks/documented_examples/README.md
@@ -166,8 +166,10 @@ solver phase wall
 
 `pdipm_wall_seconds` is a parent subtotal, so do not add it again to its
 compile, execute, diagnostic, and internal-orchestration children. A PD-IPM
-call is one lifecycle invocation; a bucket is one same-support executable
-invocation within that call. Both counts are recorded.
+call is one lifecycle invocation; a bucket is one fixed-shape executable
+invocation within that call. Physical supports may differ between rows and
+are recorded separately from the executable capacities. Both counts are
+recorded.
 
 Every named setup or solver phase has the same partition in `phase_budgets`.
 This exposes, for example, the L-dwarf gas-only phase and the separate KCl,

--- a/benchmarks/documented_examples/instrumentation.py
+++ b/benchmarks/documented_examples/instrumentation.py
@@ -260,8 +260,25 @@ class TimingCollector:
             support_indices = tuple(
                 int(item) for item in report.get("support_indices", ())
             )
+            support_indices_by_layer = tuple(
+                tuple(int(item) for item in support)
+                for support in report.get("support_indices_by_layer", ())
+            )
             layer_indices = tuple(
                 int(item) for item in report.get("layer_indices", ())
+            )
+            source_layer_indices = tuple(
+                int(item)
+                for item in report.get(
+                    "source_layer_indices",
+                    layer_indices,
+                )
+            )
+            support_capacity = int(
+                report.get("support_capacity", len(support_indices))
+            )
+            batch_capacity = int(
+                report.get("batch_capacity", len(layer_indices))
             )
             element_count = formula_shape[0] if formula_shape else None
             gas_count = formula_shape[1] if formula_shape else None
@@ -270,7 +287,7 @@ class TimingCollector:
                 f"dtype={getattr(formula_matrix, 'dtype', None)},"
                 f"config={config_fingerprint},"
                 f"elements={element_count},gas={gas_count},"
-                f"support={len(support_indices)},batch={len(layer_indices)},"
+                f"support={support_capacity},batch={batch_capacity},"
                 f"diagnostics={int(include_diagnostics)}"
             )
             bucket_diagnostic_compilation, bucket_diagnostic_execution = (
@@ -280,10 +297,15 @@ class TimingCollector:
                 {
                     "bucket_index": bucket_index,
                     "signature": signature,
-                    "support_count": len(support_indices),
-                    "batch_size": len(layer_indices),
+                    "support_count": support_capacity,
+                    "batch_size": batch_capacity,
+                    "valid_batch_size": int(
+                        report.get("valid_batch_size", len(layer_indices))
+                    ),
                     "support_indices": support_indices,
+                    "support_indices_by_layer": support_indices_by_layer,
                     "layer_indices": layer_indices,
+                    "source_layer_indices": source_layer_indices,
                     "compilation_seconds": _float(
                         report, "compilation_seconds"
                     ),

--- a/benchmarks/documented_examples/ldwarf_repeated.py
+++ b/benchmarks/documented_examples/ldwarf_repeated.py
@@ -207,19 +207,49 @@ def _shape_signatures(timing: Mapping[str, Any]) -> tuple[str, ...]:
 def _pdipm_support_signature(
     calls: Sequence[Mapping[str, Any]],
 ) -> tuple[tuple[tuple[tuple[int, ...], tuple[int, ...]], ...], ...]:
-    """Return the exact fixed-support buckets used by each PD-IPM call."""
+    """Return the real per-layer supports used by each PD-IPM call."""
+
+    def bucket_entries(
+        bucket: Mapping[str, Any],
+    ) -> tuple[tuple[tuple[int, ...], tuple[int, ...]], ...]:
+        layer_indices = tuple(
+            int(value)
+            for value in bucket.get(
+                "source_layer_indices",
+                bucket.get("layer_indices", ()),
+            )
+        )
+        supports_by_layer = tuple(
+            tuple(int(value) for value in support)
+            for support in bucket.get("support_indices_by_layer", ())
+        )
+        if supports_by_layer:
+            if len(supports_by_layer) != len(layer_indices):
+                raise ValueError(
+                    "PD-IPM support metadata must have one row per layer."
+                )
+            return tuple(
+                ((layer_index,), support)
+                for layer_index, support in zip(
+                    layer_indices, supports_by_layer
+                )
+            )
+        return (
+            (
+                layer_indices,
+                tuple(
+                    int(value)
+                    for value in bucket.get("support_indices", ())
+                ),
+            ),
+        )
 
     return tuple(
         tuple(
             sorted(
-                (
-                    tuple(int(value) for value in bucket.get("layer_indices", ())),
-                    tuple(
-                        int(value)
-                        for value in bucket.get("support_indices", ())
-                    ),
-                )
+                entry
                 for bucket in call.get("buckets", ())
+                for entry in bucket_entries(bucket)
             )
         )
         for call in calls
@@ -238,12 +268,17 @@ def _new_shape_signatures(
 
 
 def _result_status(
-    *, all_evaluations_accepted: bool, timing_attribution_consistent: bool
+    *,
+    all_evaluations_accepted: bool,
+    timing_attribution_consistent: bool,
+    no_new_pdipm_executable_shapes_after_cold: bool,
 ) -> str:
     if not all_evaluations_accepted:
         return "fail_validation"
     if not timing_attribution_consistent:
         return "fail_timing"
+    if not no_new_pdipm_executable_shapes_after_cold:
+        return "fail_recompilation"
     return "pass"
 
 
@@ -443,6 +478,7 @@ def _run_benchmark(
     result_status = _result_status(
         all_evaluations_accepted=all_accepted,
         timing_attribution_consistent=timing_valid,
+        no_new_pdipm_executable_shapes_after_cold=not new_shapes,
     )
     late_shape_evaluations = tuple(
         record["evaluation"]
@@ -534,6 +570,7 @@ def _run_benchmark(
         "validation": {
             "all_evaluations_accepted": all_accepted,
             "timing_attribution_consistent": timing_valid,
+            "no_new_pdipm_executable_shapes_after_cold": not new_shapes,
             "final_support_identity_preserved": final_support_preserved,
             "pdipm_support_identity_preserved": pdipm_support_preserved,
             "failed_evaluations": tuple(

--- a/documents/fixed_support_solver_v2_design.md
+++ b/documents/fixed_support_solver_v2_design.md
@@ -204,6 +204,7 @@ gas standard-state source and pressure convention
 condensate standard-state source
 support indices
 row and variable scaling
+condensate slot mask
 ```
 
 The canonical gas source is
@@ -270,6 +271,7 @@ RestorationState:
     row_scales
     iteration
     accepted_iteration_count
+    proximity_mask
 ```
 
 Elastic slacks, duals, scales, and the restoration barrier persist across
@@ -549,8 +551,19 @@ defined SOC attempt.  No additional long-lived mode is introduced.
 
 ## 14. GPU execution model
 
-Compilation buckets already group layers with a common support shape.  v2
-keeps this model.
+The production adapter pads every profile call to support capacity
+``K = max(1, min(support_limit, catalog_size))`` and batch capacity equal to
+the original profile layer count.  Physical support indices and a dynamic
+slot mask are passed as array values, so changing phase identities or support
+counts does not change the executable shape.  Padding slots use ``Ac = 0``
+and ``hcond = 1``; at barrier ``epsilon`` they are anchored at
+``r = epsilon, rho = 0`` and are excluded from catalog scatter and closure.
+Batch padding repeats the last physical row and discards repeated outputs.
+An all-gas profile executes one all-dummy bucket to warm the same executable
+before returning the unchanged gas-only result.  Capacity overflow is an
+error rather than an adaptive resize.
+
+Exact-support grouping remains available to compatibility adapters.
 
 One compiled controller uses a fixed-shape batched `lax.while_loop`.  Each
 super-iteration forms `normal_mask` and `restoration_mask`.

--- a/src/exogibbs/equilibrium/condensate/fixed_support/batch.py
+++ b/src/exogibbs/equilibrium/condensate/fixed_support/batch.py
@@ -40,7 +40,7 @@ from exogibbs.equilibrium.condensate.fixed_support.types import (
 
 
 class FixedSupportV2BucketResult(NamedTuple):
-    """Batched numerical result for one common-support bucket."""
+    """Batched numerical result for one fixed-shape bucket."""
 
     continuation: ContinuationState
     final_kkt_norms: KKTComponentNorms
@@ -67,9 +67,16 @@ class FixedSupportV2BucketExecution:
 
 @dataclass(frozen=True)
 class PreparedFixedSupportV2Bucket:
-    """Backend-neutral prepared inputs for one common-support v2 bucket."""
+    """Backend-neutral prepared inputs for one v2 bucket.
 
-    support_indices: tuple[int, ...]
+    Exact-support buckets retain the historical one-dimensional
+    ``support_indices`` and two-dimensional condensate formula matrix.  A
+    fixed-shape bucket instead stores per-row indices and formula matrices,
+    together with a boolean mask that distinguishes physical slots from
+    synthetic padding slots.
+    """
+
+    support_indices: Any
     layer_indices: tuple[int, ...]
     formula_matrix_cond_active: Any
     ln_nk_init: Any
@@ -82,6 +89,25 @@ class PreparedFixedSupportV2Bucket:
     hvector: Any
     hvector_cond_active: Any
     ln_normalized_pressure: Any
+    condensate_slot_mask: Any | None = None
+    valid_batch_size: int | None = None
+    source_layer_indices: tuple[int, ...] | None = None
+
+
+@dataclass(frozen=True)
+class FixedSupportV2BatchShape:
+    """Fixed condensate and batch capacities for one padded executable."""
+
+    support_capacity: int
+    batch_capacity: int
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("support_capacity", self.support_capacity),
+            ("batch_capacity", self.batch_capacity),
+        ):
+            if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+                raise ValueError(f"{name} must be a positive integer.")
 
 
 @dataclass(frozen=True)
@@ -96,6 +122,189 @@ class PreparedFixedSupportV2LayerState:
     barrier_epsilon: Any | None = None
 
 
+def _pad_leading_axis(values, capacity: int):
+    """Pad one nonempty row array by repeating its final valid row."""
+
+    values = jnp.asarray(values)
+    padding = capacity - values.shape[0]
+    if padding <= 0:
+        return values
+    repeated = jnp.broadcast_to(values[-1], (padding,) + values.shape[1:])
+    return jnp.concatenate([values, repeated], axis=0)
+
+
+def _support_ordered_values(
+    values,
+    support_array,
+    *,
+    catalog_count: int,
+    name: str,
+):
+    values = jnp.asarray(values, dtype=jnp.float64)
+    if values.ndim != 1:
+        raise ValueError(f"{name} must be one-dimensional.")
+    if values.shape[0] == catalog_count:
+        return values[support_array]
+    if values.shape[0] != support_array.shape[0]:
+        raise ValueError(
+            f"{name} must have full condensate length or support length."
+        )
+    return values
+
+
+def _prepare_fixed_shape_bucket(
+    *,
+    init_states,
+    supports,
+    formula_matrix_cond,
+    targets,
+    hvectors,
+    hcond,
+    ln_pressures,
+    source_layers,
+    fixed_shape: FixedSupportV2BatchShape,
+) -> tuple[PreparedFixedSupportV2Bucket, ...]:
+    """Prepare one heterogeneous bucket with fixed ``(B, K)`` capacities."""
+
+    layer_count = len(init_states)
+    if layer_count == 0:
+        raise ValueError("A fixed-shape batch requires at least one layer.")
+    if layer_count > fixed_shape.batch_capacity:
+        raise ValueError(
+            "fixed-support v2 layer count exceeds fixed batch capacity."
+        )
+    if any(len(support) > fixed_shape.support_capacity for support in supports):
+        raise ValueError(
+            "fixed-support v2 support exceeds fixed support capacity."
+        )
+
+    element_count, catalog_count = formula_matrix_cond.shape
+    support_rows = []
+    slot_masks = []
+    formula_rows = []
+    ln_nk_rows = []
+    ln_mk_rows = []
+    ln_ntot_rows = []
+    hcond_rows = []
+    element_potential_rows = []
+    rho_rows = []
+    epsilon_rows = []
+    have_element_potential = True
+    have_rho = True
+    have_epsilon = True
+
+    for layer_index, (state, support) in enumerate(zip(init_states, supports)):
+        support_array = jnp.asarray(support, dtype=jnp.int32)
+        support_count = len(support)
+        slot_mask = jnp.arange(fixed_shape.support_capacity) < support_count
+        safe_support = jnp.zeros(
+            (fixed_shape.support_capacity,), dtype=jnp.int32
+        ).at[:support_count].set(support_array)
+        formula_row = jnp.zeros(
+            (element_count, fixed_shape.support_capacity), dtype=jnp.float64
+        ).at[:, :support_count].set(formula_matrix_cond[:, support_array])
+        hcond_row = jnp.ones(
+            (fixed_shape.support_capacity,), dtype=jnp.float64
+        ).at[:support_count].set(hcond[layer_index, support_array])
+
+        ln_nk = jnp.asarray(state.ln_nk, dtype=jnp.float64)
+        ln_ntot = jnp.asarray(state.ln_ntot, dtype=jnp.float64)
+        if ln_nk.ndim != 1:
+            raise ValueError("ln_nk must be one-dimensional.")
+        if ln_ntot.ndim != 0:
+            raise ValueError("ln_ntot must be scalar.")
+        real_ln_mk = _support_ordered_values(
+            state.ln_mk,
+            support_array,
+            catalog_count=catalog_count,
+            name="ln_mk",
+        )
+        ln_mk = jnp.zeros(
+            (fixed_shape.support_capacity,), dtype=jnp.float64
+        ).at[:support_count].set(real_ln_mk)
+
+        support_rows.append(safe_support)
+        slot_masks.append(slot_mask)
+        formula_rows.append(formula_row)
+        ln_nk_rows.append(ln_nk)
+        ln_mk_rows.append(ln_mk)
+        ln_ntot_rows.append(ln_ntot)
+        hcond_rows.append(hcond_row)
+
+        if state.element_potential is None:
+            have_element_potential = False
+        else:
+            element_potential = jnp.asarray(
+                state.element_potential, dtype=jnp.float64
+            )
+            if element_potential.shape != (element_count,):
+                raise ValueError(
+                    "element_potential must have one value per element."
+                )
+            element_potential_rows.append(element_potential)
+
+        if state.rho is None:
+            have_rho = False
+        else:
+            real_rho = _support_ordered_values(
+                state.rho,
+                support_array,
+                catalog_count=catalog_count,
+                name="rho",
+            )
+            rho_rows.append(
+                jnp.zeros(
+                    (fixed_shape.support_capacity,), dtype=jnp.float64
+                ).at[:support_count].set(real_rho)
+            )
+
+        if state.barrier_epsilon is None:
+            have_epsilon = False
+        else:
+            epsilon = jnp.asarray(
+                state.barrier_epsilon, dtype=jnp.float64
+            )
+            if epsilon.ndim != 0:
+                raise ValueError("barrier_epsilon must be scalar.")
+            epsilon_rows.append(epsilon)
+
+    def stacked_and_padded(rows):
+        return _pad_leading_axis(jnp.stack(rows), fixed_shape.batch_capacity)
+
+    return (
+        PreparedFixedSupportV2Bucket(
+            support_indices=stacked_and_padded(support_rows),
+            layer_indices=tuple(range(layer_count)),
+            formula_matrix_cond_active=stacked_and_padded(formula_rows),
+            ln_nk_init=stacked_and_padded(ln_nk_rows),
+            ln_mk_init=stacked_and_padded(ln_mk_rows),
+            ln_ntot_init=stacked_and_padded(ln_ntot_rows),
+            element_potential_init=(
+                stacked_and_padded(element_potential_rows)
+                if have_element_potential
+                else None
+            ),
+            rho_init=(
+                stacked_and_padded(rho_rows) if have_rho else None
+            ),
+            barrier_epsilon_init=(
+                stacked_and_padded(epsilon_rows) if have_epsilon else None
+            ),
+            element_inventory_target=_pad_leading_axis(
+                targets, fixed_shape.batch_capacity
+            ),
+            hvector=_pad_leading_axis(hvectors, fixed_shape.batch_capacity),
+            hvector_cond_active=stacked_and_padded(hcond_rows),
+            ln_normalized_pressure=_pad_leading_axis(
+                ln_pressures, fixed_shape.batch_capacity
+            ),
+            condensate_slot_mask=stacked_and_padded(slot_masks),
+            valid_batch_size=layer_count,
+            source_layer_indices=source_layers,
+        ),
+    )
+
+
 def prepare_fixed_support_v2_buckets(
     *,
     init_states: Sequence[PreparedFixedSupportV2LayerState],
@@ -105,14 +314,24 @@ def prepare_fixed_support_v2_buckets(
     hvector_by_layer: Any,
     hvector_cond_by_layer: Any,
     ln_normalized_pressure_by_layer: Any,
+    fixed_shape: FixedSupportV2BatchShape | None = None,
+    source_layer_indices: Sequence[int] | None = None,
 ) -> tuple[PreparedFixedSupportV2Bucket, ...]:
-    """Group validated layer states into exact-support v2 buckets."""
+    """Prepare exact-support buckets or one optional fixed-shape bucket."""
 
     n_layers = len(init_states)
     if len(support_indices_by_layer) != n_layers:
         raise ValueError(
             "init_states and support_indices_by_layer must have matching lengths."
         )
+    if source_layer_indices is None:
+        source_layers = tuple(range(n_layers))
+    else:
+        source_layers = tuple(int(index) for index in source_layer_indices)
+        if len(source_layers) != n_layers:
+            raise ValueError(
+                "source_layer_indices must have one value per layer."
+            )
 
     formula_matrix_cond = jnp.asarray(
         formula_matrix_cond,
@@ -160,10 +379,10 @@ def prepare_fixed_support_v2_buckets(
             "hvector_cond_by_layer must have one value per condensate."
         )
 
-    groups: dict[tuple[int, ...], list[int]] = {}
-    for layer_index, indices in enumerate(support_indices_by_layer):
+    supports = []
+    for indices in support_indices_by_layer:
         support = tuple(int(index) for index in indices)
-        if not support:
+        if not support and fixed_shape is None:
             raise ValueError("fixed-support v2 buckets require non-empty support.")
         if len(set(support)) != len(support):
             raise ValueError("fixed-support v2 support indices must be unique.")
@@ -174,6 +393,25 @@ def prepare_fixed_support_v2_buckets(
             raise ValueError(
                 "fixed-support v2 support contains an out-of-range index."
             )
+        supports.append(support)
+
+    if fixed_shape is not None:
+        if not isinstance(fixed_shape, FixedSupportV2BatchShape):
+            raise TypeError("fixed_shape must be a FixedSupportV2BatchShape.")
+        return _prepare_fixed_shape_bucket(
+            init_states=init_states,
+            supports=tuple(supports),
+            formula_matrix_cond=formula_matrix_cond,
+            targets=targets,
+            hvectors=hvectors,
+            hcond=hcond,
+            ln_pressures=ln_pressures,
+            source_layers=source_layers,
+            fixed_shape=fixed_shape,
+        )
+
+    groups: dict[tuple[int, ...], list[int]] = {}
+    for layer_index, support in enumerate(supports):
         groups.setdefault(support, []).append(layer_index)
 
     buckets = []
@@ -275,6 +513,9 @@ def prepare_fixed_support_v2_buckets(
                 hvector=hvectors[layer_array],
                 hvector_cond_active=hcond[layer_array][:, support_array],
                 ln_normalized_pressure=ln_pressures[layer_array],
+                source_layer_indices=tuple(
+                    source_layers[index] for index in layer_indices
+                ),
             )
         )
     return tuple(buckets)
@@ -310,6 +551,80 @@ def _block_until_ready(tree) -> None:
         leaf.block_until_ready()
 
 
+def _bucket_slot_arrays(bucket):
+    """Return canonical ``[B, K]`` indices/mask and valid batch metadata."""
+
+    q = jnp.asarray(bucket.ln_nk_init)
+    if q.ndim != 2:
+        raise ValueError("Prepared ln_nk_init must be two-dimensional.")
+    batch_capacity = q.shape[0]
+    support = jnp.asarray(bucket.support_indices, dtype=jnp.int32)
+    if support.ndim == 1:
+        support = jnp.broadcast_to(
+            support, (batch_capacity, support.shape[0])
+        )
+    elif support.ndim != 2 or support.shape[0] != batch_capacity:
+        raise ValueError(
+            "Prepared support indices must have shape [K] or [B, K]."
+        )
+    raw_mask = getattr(bucket, "condensate_slot_mask", None)
+    if raw_mask is None:
+        slot_mask = jnp.ones_like(support, dtype=bool)
+    else:
+        slot_mask = jnp.asarray(raw_mask, dtype=bool)
+        if slot_mask.ndim == 1:
+            slot_mask = jnp.broadcast_to(slot_mask, support.shape)
+        if slot_mask.shape != support.shape:
+            raise ValueError(
+                "Prepared condensate_slot_mask must match support indices."
+            )
+    if bool(jnp.any(support == -1)):
+        raise ValueError("Prepared support indices must not use -1 sentinels.")
+    if bool(jnp.any(support < 0)):
+        raise ValueError("Prepared support indices must be non-negative.")
+    if bool(jnp.any((~slot_mask) & (support != 0))):
+        raise ValueError("Prepared padding support indices must use safe index 0.")
+    raw_valid_count = getattr(bucket, "valid_batch_size", None)
+    valid_count = (
+        len(tuple(bucket.layer_indices))
+        if raw_valid_count is None
+        else int(raw_valid_count)
+    )
+    if valid_count != len(tuple(bucket.layer_indices)):
+        raise ValueError(
+            "valid_batch_size must equal the number of physical layer indices."
+        )
+    if valid_count < 1 or valid_count > batch_capacity:
+        raise ValueError(
+            "valid_batch_size must be within the prepared batch capacity."
+        )
+    return support, slot_mask, valid_count, batch_capacity
+
+
+def _slice_valid_batch(tree, valid_count: int, batch_capacity: int):
+    def take_prefix(value):
+        shape = getattr(value, "shape", None)
+        if shape is not None and len(shape) > 0 and shape[0] == batch_capacity:
+            return value[:valid_count]
+        return value
+
+    return jax.tree_util.tree_map(take_prefix, tree)
+
+
+def _real_supports_by_layer(bucket) -> tuple[tuple[int, ...], ...]:
+    support, slot_mask, valid_count, _batch_capacity = _bucket_slot_arrays(bucket)
+    support_host = jax.device_get(support[:valid_count])
+    mask_host = jax.device_get(slot_mask[:valid_count])
+    return tuple(
+        tuple(
+            int(index)
+            for index, active in zip(indices, mask)
+            if bool(active)
+        )
+        for indices, mask in zip(support_host, mask_host)
+    )
+
+
 def _validate_profile_structure(
     buckets: Sequence[Any],
     *,
@@ -321,15 +636,36 @@ def _validate_profile_structure(
     layer_indices = []
     for bucket in buckets:
         layers = tuple(int(value) for value in bucket.layer_indices)
-        support = tuple(int(value) for value in bucket.support_indices)
+        has_explicit_slot_mask = (
+            getattr(bucket, "condensate_slot_mask", None) is not None
+        )
+        support, slot_mask, valid_count, _batch_capacity = (
+            _bucket_slot_arrays(bucket)
+        )
+        support_host = jax.device_get(support)
+        mask_host = jax.device_get(slot_mask)
         if len(set(layers)) != len(layers):
             raise ValueError("A prepared bucket contains duplicate layer indices.")
         if any(index < 0 or index >= layer_count for index in layers):
             raise ValueError("A prepared bucket contains an invalid layer index.")
-        if len(set(support)) != len(support):
-            raise ValueError("A prepared bucket contains duplicate support indices.")
-        if any(index < 0 or index >= condensate_count for index in support):
+        if bool(jnp.any((support < 0) | (support >= condensate_count))):
             raise ValueError("A prepared bucket contains an invalid support index.")
+        for row_index in range(valid_count):
+            real_support = tuple(
+                int(index)
+                for index, active in zip(
+                    support_host[row_index], mask_host[row_index]
+                )
+                if bool(active)
+            )
+            if not real_support and not has_explicit_slot_mask:
+                raise ValueError(
+                    "fixed-support v2 buckets require non-empty support."
+                )
+            if len(set(real_support)) != len(real_support):
+                raise ValueError(
+                    "A prepared bucket contains duplicate support indices."
+                )
         layer_indices.extend(layers)
     if sorted(layer_indices) != list(range(layer_count)):
         raise ValueError(
@@ -348,6 +684,13 @@ def _prepared_problem_batch(
     batch_size = q.shape[0]
     ag = jnp.asarray(formula_matrix, dtype=dtype)
     ac = jnp.asarray(bucket.formula_matrix_cond_active, dtype=dtype)
+    if ac.ndim == 2:
+        ac = jnp.broadcast_to(ac, (batch_size,) + ac.shape)
+    elif ac.ndim != 3 or ac.shape[0] != batch_size:
+        raise ValueError(
+            "Prepared condensate formula matrix must have shape [E, K] "
+            "or [B, E, K]."
+        )
     target = jnp.asarray(bucket.element_inventory_target, dtype=dtype)
     qtot = jnp.asarray(bucket.ln_ntot_init, dtype=dtype)
     gamma_from_thermo = jnp.asarray(bucket.hvector, dtype=dtype) + jnp.asarray(
@@ -357,22 +700,35 @@ def _prepared_problem_batch(
     floor = jnp.asarray(budget_relative_floor, dtype=dtype)
     budget_scale = 1.0 / jnp.maximum(jnp.abs(target), floor)
     total_scale = 1.0 / jnp.maximum(jnp.exp(qtot), floor)
-    support = jnp.asarray(bucket.support_indices, dtype=jnp.int32)
+    support, slot_mask, _valid_count, prepared_batch_size = (
+        _bucket_slot_arrays(bucket)
+    )
+    if prepared_batch_size != batch_size:
+        raise ValueError("Prepared bucket arrays must share one batch capacity.")
+    hcond = jnp.asarray(bucket.hvector_cond_active, dtype=dtype)
+    if hcond.shape != support.shape:
+        raise ValueError(
+            "Prepared condensate sources must match the [B, K] slot shape."
+        )
+    if ac.shape != (batch_size, ag.shape[0], support.shape[1]):
+        raise ValueError(
+            "Prepared condensate formula matrices must match the [B, E, K] "
+            "slot shape."
+        )
+    if bool(jnp.any(jnp.where(slot_mask[:, None, :], 0.0, ac) != 0.0)):
+        raise ValueError("Prepared padding formula columns must be zero.")
+    if bool(jnp.any(jnp.where(slot_mask, 1.0, hcond) != 1.0)):
+        raise ValueError("Prepared padding condensate sources must equal one.")
     return FixedSupportProblem(
         gas_formula_matrix=jnp.broadcast_to(
             ag, (batch_size,) + ag.shape
         ),
-        condensate_formula_matrix=jnp.broadcast_to(
-            ac, (batch_size,) + ac.shape
-        ),
+        condensate_formula_matrix=ac,
         target_inventory=target,
         gamma=gamma,
-        condensate_standard_source=jnp.asarray(
-            bucket.hvector_cond_active, dtype=dtype
-        ),
-        support_indices=jnp.broadcast_to(
-            support, (batch_size,) + support.shape
-        ),
+        condensate_standard_source=hcond,
+        support_indices=support,
+        condensate_slot_mask=slot_mask,
         budget_row_scale=budget_scale,
         total_density_row_scale=total_scale,
     )
@@ -419,6 +775,11 @@ def _prepared_original_state_batch(bucket, problems, config):
     else:
         rho = first_epsilon - r
         epsilon = jnp.full((batch_size,), first_epsilon, dtype=dtype)
+    slot_mask = jnp.asarray(problems.condensate_slot_mask, dtype=bool)
+    if r.shape != slot_mask.shape:
+        raise ValueError("Prepared ln_mk_init must match the [B, K] slot shape.")
+    r = jnp.where(slot_mask, r, epsilon[:, None])
+    rho = jnp.where(slot_mask, rho, jnp.zeros_like(rho))
     return OriginalState(
         q=q,
         r=r,
@@ -438,7 +799,7 @@ def solve_prepared_bucket_v2(
     budget_relative_floor: float = 1.0e-6,
     include_solver_diagnostics: bool = True,
 ) -> FixedSupportV2BucketExecution:
-    """Compile and run one same-support prepared bucket with v2."""
+    """Compile and run one prepared fixed-shape bucket with v2."""
 
     problems = _prepared_problem_batch(
         bucket,
@@ -697,6 +1058,10 @@ def run_fixed_support_profile(
     backend = jax.default_backend()
 
     for bucket in buckets:
+        slot_indices, slot_mask, valid_count, batch_capacity = (
+            _bucket_slot_arrays(bucket)
+        )
+        real_supports = _real_supports_by_layer(bucket)
         execution = solve_prepared_bucket_v2(
             bucket,
             ag,
@@ -715,27 +1080,27 @@ def run_fixed_support_profile(
         bucket_diagnostic_compilation_seconds = 0.0
         bucket_diagnostic_execution_seconds = 0.0
         if include_terminal_diagnostics:
-            continuation = result.continuation
+            full_continuation = result.continuation
             restoration = _compiled_terminal_restoration_diagnostics_factory(
                 config
             )
             normal = _compiled_terminal_normal_diagnostics_factory(config)
             diagnostic_compile_start = time.perf_counter()
             compiled_restoration = restoration.lower(
-                problems, continuation.controller
+                problems, full_continuation.controller
             ).compile()
             compiled_normal = normal.lower(
-                problems, continuation.controller
+                problems, full_continuation.controller
             ).compile()
             bucket_diagnostic_compilation_seconds = (
                 time.perf_counter() - diagnostic_compile_start
             )
             diagnostic_execution_start = time.perf_counter()
             restoration_diagnostics = compiled_restoration(
-                problems, continuation.controller
+                problems, full_continuation.controller
             )
             normal_diagnostics = compiled_normal(
-                problems, continuation.controller
+                problems, full_continuation.controller
             )
             _block_until_ready((restoration_diagnostics, normal_diagnostics))
             bucket_diagnostic_execution_seconds = (
@@ -750,6 +1115,15 @@ def run_fixed_support_profile(
             diagnostic_seconds += (
                 bucket_diagnostic_compilation_seconds
                 + bucket_diagnostic_execution_seconds
+            )
+            continuation = _slice_valid_batch(
+                full_continuation, valid_count, batch_capacity
+            )
+            restoration_diagnostics = _slice_valid_batch(
+                restoration_diagnostics, valid_count, batch_capacity
+            )
+            normal_diagnostics = _slice_valid_batch(
+                normal_diagnostics, valid_count, batch_capacity
             )
             terminal = continuation.terminal_status
             completed_stages = continuation.completed_stage_count
@@ -769,8 +1143,8 @@ def run_fixed_support_profile(
             last_return = continuation.controller.last_return_diagnostics
             final = continuation.controller.original_state
         else:
-            terminal = result.terminal_status
-            completed_stages = result.completed_stage_count
+            terminal = result.terminal_status[:valid_count]
+            completed_stages = result.completed_stage_count[:valid_count]
             stage_statuses = None
             stage_normal_iterations = None
             stage_restoration_calls = None
@@ -779,13 +1153,34 @@ def run_fixed_support_profile(
             stage_soc_attempts = None
             stage_soc_accepted = None
             last_return = None
-            final = result.final_state
+            final = _slice_valid_batch(
+                result.final_state, valid_count, batch_capacity
+            )
+        bucket_kkt_norms = _slice_valid_batch(
+            result.final_kkt_norms, valid_count, batch_capacity
+        )
         layers = jnp.asarray(bucket.layer_indices, dtype=jnp.int32)
-        support = jnp.asarray(bucket.support_indices, dtype=jnp.int32)
         gas_log_amounts = gas_log_amounts.at[layers].set(final.q)
-        condensate_amounts = condensate_amounts.at[
-            layers[:, None], support[None, :]
-        ].set(jnp.exp(final.r))
+        physical_slot_amounts = jnp.where(
+            slot_mask[:valid_count],
+            jnp.exp(final.r),
+            jnp.zeros_like(final.r),
+        )
+        row_indices = jnp.arange(valid_count, dtype=jnp.int32)[:, None]
+        catalog_amounts = jnp.zeros(
+            (valid_count, condensate_count), dtype=ag.dtype
+        ).at[row_indices, slot_indices[:valid_count]].add(
+            physical_slot_amounts
+        )
+        catalog_support_count = jnp.zeros(
+            (valid_count, condensate_count), dtype=jnp.int32
+        ).at[row_indices, slot_indices[:valid_count]].add(
+            slot_mask[:valid_count].astype(jnp.int32)
+        )
+        catalog_support_mask = catalog_support_count > 0
+        condensate_amounts = condensate_amounts.at[layers].set(
+            catalog_amounts
+        )
         total_gas_log_amount = total_gas_log_amount.at[layers].set(final.qtot)
         element_potential = element_potential.at[layers].set(final.lambda_)
         terminal_status = terminal_status.at[layers].set(
@@ -797,12 +1192,12 @@ def run_fixed_support_profile(
         final_kkt_norms = jax.tree_util.tree_map(
             lambda current, bucket_value: current.at[layers].set(bucket_value),
             final_kkt_norms,
-            result.final_kkt_norms,
+            bucket_kkt_norms,
         )
         target_by_layer = target_by_layer.at[layers].set(
-            bucket.element_inventory_target
+            bucket.element_inventory_target[:valid_count]
         )
-        support_mask = support_mask.at[layers[:, None], support[None, :]].set(True)
+        support_mask = support_mask.at[layers].set(catalog_support_mask)
         bucket_state_finite = (
             jnp.all(jnp.isfinite(final.q), axis=1)
             & jnp.all(jnp.isfinite(final.r), axis=1)
@@ -817,12 +1212,31 @@ def run_fixed_support_profile(
         compilation_seconds += execution.compilation_seconds
         execution_seconds += execution.execution_seconds
         backend = execution.backend
+        support_union = tuple(
+            dict.fromkeys(
+                index for support in real_supports for index in support
+            )
+        )
         bucket_reports.append(
             {
-                "support_indices": tuple(
-                    int(value) for value in bucket.support_indices
-                ),
+                "support_indices": support_union,
+                "support_indices_by_layer": real_supports,
                 "layer_indices": tuple(int(value) for value in bucket.layer_indices),
+                "source_layer_indices": (
+                    tuple(
+                        int(value)
+                        for value in getattr(
+                            bucket,
+                            "source_layer_indices",
+                            (),
+                        )
+                    )
+                    if getattr(bucket, "source_layer_indices", None) is not None
+                    else tuple(int(value) for value in bucket.layer_indices)
+                ),
+                "support_capacity": int(slot_indices.shape[1]),
+                "batch_capacity": int(batch_capacity),
+                "valid_batch_size": int(valid_count),
                 "compilation_seconds": execution.compilation_seconds,
                 "execution_seconds": execution.execution_seconds,
                 "diagnostic_compilation_seconds": (
@@ -842,7 +1256,7 @@ def run_fixed_support_profile(
                 "stage_last_return_diagnostics": stage_last_return,
                 "stage_soc_attempt_counts": stage_soc_attempts,
                 "stage_soc_accepted_counts": stage_soc_accepted,
-                "final_kkt_norms": result.final_kkt_norms,
+                "final_kkt_norms": bucket_kkt_norms,
                 "terminal_restoration_diagnostics": restoration_diagnostics,
                 "terminal_normal_diagnostics": normal_diagnostics,
                 "last_return_diagnostics": last_return,
@@ -876,6 +1290,7 @@ def run_fixed_support_profile(
 
 
 __all__ = [
+    "FixedSupportV2BatchShape",
     "FixedSupportV2BucketExecution",
     "FixedSupportV2ProductionBucketResult",
     "FixedSupportV2BucketResult",

--- a/src/exogibbs/equilibrium/condensate/fixed_support/continuation.py
+++ b/src/exogibbs/equilibrium/condensate/fixed_support/continuation.py
@@ -34,13 +34,25 @@ def _validate_schedule(config: FixedSupportV2Config) -> None:
         )
 
 
-def recenter_for_epsilon(state: OriginalState, epsilon) -> OriginalState:
-    """Transfer a warm start and center bound multipliers at a new barrier."""
+def recenter_for_epsilon(
+    state: OriginalState,
+    epsilon,
+    condensate_slot_mask=None,
+) -> OriginalState:
+    """Transfer a warm start and center every slot at a new barrier."""
 
     dtype = jnp.asarray(state.q).dtype
     next_epsilon = jnp.asarray(epsilon, dtype=dtype)
+    r = jnp.asarray(state.r, dtype=dtype)
+    if condensate_slot_mask is None:
+        slot_mask = jnp.ones_like(r, dtype=jnp.bool_)
+    else:
+        slot_mask = jnp.asarray(condensate_slot_mask, dtype=jnp.bool_)
+    centered_r = jnp.where(slot_mask, r, next_epsilon)
+    centered_rho = jnp.where(slot_mask, next_epsilon - r, 0.0)
     return state._replace(
-        rho=next_epsilon - jnp.asarray(state.r, dtype=dtype),
+        r=centered_r,
+        rho=centered_rho,
         epsilon=next_epsilon,
         iteration=jnp.asarray(0, dtype=jnp.int32),
     )
@@ -55,16 +67,42 @@ def initialize_continuation(
 
     ``center`` is the normal solver policy and enforces complementarity at the
     first schedule value. ``provided`` is an audit policy: it preserves the
-    supplied ``q, r, lambda, rho, qtot, epsilon`` tuple exactly.
+    supplied real-slot ``q, r, lambda, rho, qtot, epsilon`` tuple exactly.
+    Both policies anchor synthetic slots at the unit-source barrier solution.
     """
 
     _validate_schedule(config)
     schedule = config.continuation.epsilon_schedule
     if config.continuation.initial_state_policy == "center":
-        initial_state = recenter_for_epsilon(original_state, schedule[0])
+        initial_state = recenter_for_epsilon(
+            original_state,
+            schedule[0],
+            problem.condensate_slot_mask,
+        )
     else:
+        slot_mask = (
+            jnp.ones_like(original_state.r, dtype=jnp.bool_)
+            if problem.condensate_slot_mask is None
+            else jnp.asarray(
+                problem.condensate_slot_mask,
+                dtype=jnp.bool_,
+            )
+        )
         initial_state = original_state._replace(
-            iteration=jnp.asarray(0, dtype=jnp.int32)
+            r=jnp.where(
+                slot_mask,
+                original_state.r,
+                jnp.asarray(
+                    original_state.epsilon,
+                    dtype=jnp.asarray(original_state.r).dtype,
+                ),
+            ),
+            rho=jnp.where(
+                slot_mask,
+                original_state.rho,
+                jnp.zeros_like(original_state.rho),
+            ),
+            iteration=jnp.asarray(0, dtype=jnp.int32),
         )
     controller = initialize_controller(problem, initial_state, config)
     stage_count = len(schedule)
@@ -161,7 +199,9 @@ def _advance_converged_stage(problem, state, config):
             dtype=recorded.controller.original_state.q.dtype,
         )
         warm_start = recenter_for_epsilon(
-            recorded.controller.original_state, schedule[next_index]
+            recorded.controller.original_state,
+            schedule[next_index],
+            problem.condensate_slot_mask,
         )
         return recorded._replace(
             controller=initialize_controller(problem, warm_start, config),

--- a/src/exogibbs/equilibrium/condensate/fixed_support/controller.py
+++ b/src/exogibbs/equilibrium/condensate/fixed_support/controller.py
@@ -88,6 +88,7 @@ def _empty_restoration_state(
         entry_phi=jnp.asarray(0.0, dtype=dtype),
         entry_theta=jnp.asarray(0.0, dtype=dtype),
         variable_scales=jnp.ones_like(x),
+        proximity_mask=jnp.ones_like(x, dtype=jnp.bool_),
         row_scales=jnp.ones_like(equality),
         iteration=jnp.asarray(0, dtype=jnp.int32),
         accepted_iteration_count=jnp.asarray(0, dtype=jnp.int32),

--- a/src/exogibbs/equilibrium/condensate/fixed_support/restoration.py
+++ b/src/exogibbs/equilibrium/condensate/fixed_support/restoration.py
@@ -65,6 +65,29 @@ def _validate_config(config: FixedSupportV2Config) -> None:
         raise ValueError("max_restoration_iterations must be non-negative.")
 
 
+def _anchor_dummy_slots(
+    problem: FixedSupportProblem,
+    state: OriginalState,
+) -> OriginalState:
+    """Set synthetic slots to the exact unit-source barrier solution."""
+
+    dtype = jnp.asarray(state.q).dtype
+    slot_mask = (
+        jnp.ones_like(state.r, dtype=jnp.bool_)
+        if problem.condensate_slot_mask is None
+        else jnp.asarray(problem.condensate_slot_mask, dtype=jnp.bool_)
+    )
+    epsilon = jnp.asarray(state.epsilon, dtype=dtype)
+    return state._replace(
+        r=jnp.where(slot_mask, jnp.asarray(state.r, dtype=dtype), epsilon),
+        rho=jnp.where(
+            slot_mask,
+            jnp.asarray(state.rho, dtype=dtype),
+            jnp.asarray(0.0, dtype=dtype),
+        ),
+    )
+
+
 def restoration_constraint_jacobian(
     problem: FixedSupportProblem,
     row_scales,
@@ -110,20 +133,48 @@ def _proximity_coefficient(state: RestorationState, config) -> jax.Array:
     )
 
 
+def _restoration_proximity_mask(state: RestorationState):
+    if state.proximity_mask is None:
+        return jnp.ones_like(state.x, dtype=state.x.dtype)
+    return jnp.asarray(state.proximity_mask, dtype=state.x.dtype)
+
+
+def _restoration_proximity_mask_bool(state: RestorationState):
+    if state.proximity_mask is None:
+        return jnp.ones_like(state.x, dtype=jnp.bool_)
+    return jnp.asarray(state.proximity_mask, dtype=jnp.bool_)
+
+
+def _proximity_hessian_diagonal(state: RestorationState, config):
+    proximity_mask = _restoration_proximity_mask(state)
+    return (
+        _proximity_coefficient(state, config)
+        * proximity_mask
+        / (state.variable_scales**2)
+    )
+
+
+def _dummy_linear_coefficient(state: RestorationState):
+    proximity_mask = _restoration_proximity_mask(state)
+    return 1.0 - proximity_mask
+
+
 def restoration_elastic_objective(
     state: RestorationState,
     config,
 ):
-    """Return the elastic L1 plus scaled proximity objective."""
+    """Return elastic, real-variable proximity, and dummy-source terms."""
 
+    proximity_mask = _restoration_proximity_mask(state)
     displacement = (state.x - state.entry_x) / state.variable_scales
     proximity = 0.5 * _proximity_coefficient(state, config) * jnp.dot(
-        displacement, displacement
+        proximity_mask * displacement, displacement
     )
+    dummy_linear = jnp.dot(_dummy_linear_coefficient(state), state.x)
     elastic = jnp.asarray(config.elastic_penalty, dtype=state.x.dtype) * jnp.sum(
         state.positive_slack + state.negative_slack
     )
-    return elastic + proximity
+    return elastic + proximity + dummy_linear
 
 
 def restoration_barrier_objective(
@@ -147,9 +198,9 @@ def restoration_barrier_directional_derivative(
 ):
     """Return the internal barrier-objective directional derivative."""
 
-    zeta = _proximity_coefficient(state, config)
     gradient_x = (
-        zeta * (state.x - state.entry_x) / (state.variable_scales**2)
+        _proximity_hessian_diagonal(state, config) * (state.x - state.entry_x)
+        + _dummy_linear_coefficient(state)
         - state.restoration_mu / state.x
     )
     penalty = jnp.asarray(config.elastic_penalty, dtype=state.x.dtype)
@@ -170,11 +221,12 @@ def restoration_residuals(
     """Evaluate all seven primal-dual restoration KKT blocks."""
 
     jacobian = restoration_constraint_jacobian(problem, state.row_scales)
-    zeta = _proximity_coefficient(state, config)
     penalty = jnp.asarray(config.elastic_penalty, dtype=state.x.dtype)
     return RestorationResiduals(
         dual_x=(
-            zeta * (state.x - state.entry_x) / (state.variable_scales**2)
+            _proximity_hessian_diagonal(state, config)
+            * (state.x - state.entry_x)
+            + _dummy_linear_coefficient(state)
             + jacobian.T @ state.equality_dual
             - state.lower_bound_dual_x
         ),
@@ -253,9 +305,7 @@ def restoration_kkt_jacobian(
     jacobian = restoration_constraint_jacobian(problem, state.row_scales)
     nx, nc = x.shape[0], p.shape[0]
     zeros = lambda rows, columns: jnp.zeros((rows, columns), dtype=x.dtype)
-    hessian = jnp.diag(
-        _proximity_coefficient(state, config) / (state.variable_scales**2)
-    )
+    hessian = jnp.diag(_proximity_hessian_diagonal(state, config))
     return jnp.block(
         [
             [hessian, zeros(nx, nc), zeros(nx, nc), jacobian.T, -jnp.eye(nx), zeros(nx, nc), zeros(nx, nc)],
@@ -298,9 +348,7 @@ def restoration_direction(
     zx = state.lower_bound_dual_x
     zp = state.lower_bound_dual_positive
     zv = state.lower_bound_dual_negative
-    zeta_diagonal = _proximity_coefficient(state, config) / (
-        state.variable_scales**2
-    )
+    zeta_diagonal = _proximity_hessian_diagonal(state, config)
     # These are algebraically ``1 / (H + z/x)``, ``1 / (zp/p)`` and
     # ``1 / (zv/v)``.  Forming ``z/x`` overflows for perfectly valid trace
     # amounts (for example x=1e-300), so keep the same Schur equation in a
@@ -308,10 +356,13 @@ def restoration_direction(
     inverse_wx = x / (zeta_diagonal * x + zx)
     inverse_wp = p / zp
     inverse_wv = v / zv
-    proximity_gradient = zeta_diagonal * (x - state.entry_x)
+    objective_gradient = (
+        zeta_diagonal * (x - state.entry_x)
+        + _dummy_linear_coefficient(state)
+    )
     jacobian_dual = jacobian.T @ state.equality_dual
     scaled_ax = (
-        state.restoration_mu - x * (proximity_gradient + jacobian_dual)
+        state.restoration_mu - x * (objective_gradient + jacobian_dual)
     ) / (zeta_diagonal * x + zx)
     scaled_ap = (
         state.restoration_mu
@@ -501,6 +552,11 @@ def _trial_states(state, direction, alphas):
         entry_phi=_broadcast(state.entry_phi, count),
         entry_theta=_broadcast(state.entry_theta, count),
         variable_scales=_broadcast(state.variable_scales, count),
+        proximity_mask=(
+            None
+            if state.proximity_mask is None
+            else _broadcast(_restoration_proximity_mask_bool(state), count)
+        ),
         row_scales=_broadcast(state.row_scales, count),
         iteration=_broadcast(state.iteration + 1, count),
         accepted_iteration_count=_broadcast(
@@ -642,7 +698,15 @@ def initialize_restoration(
     """Initialize persistent state exactly once on restoration entry."""
 
     _validate_config(config)
+    original_state = _anchor_dummy_slots(problem, original_state)
     amounts = physical_amounts(original_state)
+    dtype = jnp.asarray(original_state.q).dtype
+    mu = jnp.exp(jnp.asarray(original_state.epsilon, dtype=dtype))
+    slot_mask = (
+        jnp.ones_like(original_state.r, dtype=jnp.bool_)
+        if problem.condensate_slot_mask is None
+        else jnp.asarray(problem.condensate_slot_mask, dtype=jnp.bool_)
+    )
     raw_x = jnp.concatenate(
         [amounts.gas, amounts.condensate, amounts.total_gas.reshape((1,))]
     )
@@ -676,9 +740,21 @@ def initialize_restoration(
         scale_floor_fraction * condensate_reference,
     )
     tiny = jnp.asarray(jnp.finfo(dtype).tiny, dtype=dtype)
+    condensate_scales = jnp.where(
+        slot_mask,
+        condensate_scales,
+        jnp.maximum(mu, tiny),
+    )
     variable_scales = jnp.maximum(
         jnp.concatenate([gas_scales, condensate_scales, raw_x[-1:]]),
         tiny,
+    )
+    proximity_mask = jnp.concatenate(
+        [
+            jnp.ones((ng,), dtype=jnp.bool_),
+            slot_mask,
+            jnp.ones((1,), dtype=jnp.bool_),
+        ]
     )
     # Restoration is an interior-point NLP.  Merely replacing an underflowed
     # amount by 1e-300 gives z=mu/x near 1e295 and destroys useful scaling.
@@ -694,6 +770,9 @@ def initialize_restoration(
         * variable_scales,
     )
     floored_x = jnp.maximum(raw_x, interior_floor)
+    floored_x = floored_x.at[ng : ng + nc].set(
+        jnp.where(slot_mask, floored_x[ng : ng + nc], mu)
+    )
     injection = floored_x - raw_x
     scaled_budget_injection = row_scales[:-1] * (
         ag @ injection[:ng] + ac @ injection[ng : ng + nc]
@@ -717,7 +796,6 @@ def initialize_restoration(
     jacobian = restoration_constraint_jacobian(problem, row_scales)
     offset = restoration_constraint_offset(problem, row_scales)
     c = jacobian @ x + offset
-    mu = jnp.exp(jnp.asarray(original_state.epsilon, dtype=dtype))
     slack_center = jnp.sqrt(mu)
     positive = jnp.maximum(c, 0.0) + slack_center
     negative = jnp.maximum(-c, 0.0) + slack_center
@@ -736,6 +814,7 @@ def initialize_restoration(
         entry_phi=barrier_objective(problem, original_state),
         entry_theta=filter_violation(problem, original_state),
         variable_scales=variable_scales,
+        proximity_mask=proximity_mask,
         row_scales=row_scales,
         iteration=jnp.asarray(0, dtype=jnp.int32),
         accepted_iteration_count=jnp.asarray(0, dtype=jnp.int32),

--- a/src/exogibbs/equilibrium/condensate/fixed_support/return_map.py
+++ b/src/exogibbs/equilibrium/condensate/fixed_support/return_map.py
@@ -26,13 +26,22 @@ def _bound_multiplier_return(
     barrier,
     fraction_to_boundary,
     reset_threshold,
+    active_mask=None,
 ):
     """Apply the Ipopt linearized bound-multiplier restoration return."""
 
     dtype = entry_amount.dtype
+    if active_mask is None:
+        active_mask = jnp.ones_like(entry_multiplier, dtype=jnp.bool_)
+    else:
+        active_mask = jnp.asarray(active_mask, dtype=jnp.bool_)
     delta = (barrier - restored_amount * entry_multiplier) / entry_amount
     alpha_bound = jnp.min(
-        jnp.where(delta < 0.0, -entry_multiplier / delta, jnp.inf),
+        jnp.where(
+            active_mask & (delta < 0.0),
+            -entry_multiplier / delta,
+            jnp.inf,
+        ),
         initial=jnp.asarray(jnp.inf, dtype=dtype),
     )
     alpha = jnp.minimum(
@@ -40,11 +49,15 @@ def _bound_multiplier_return(
         jnp.asarray(fraction_to_boundary, dtype=dtype) * alpha_bound,
     )
     candidate = entry_multiplier + alpha * delta
-    reset = (~jnp.all(jnp.isfinite(candidate))) | (
-        jnp.max(candidate, initial=0.0)
+    reset = (~jnp.all(jnp.where(active_mask, jnp.isfinite(candidate), True))) | (
+        jnp.max(jnp.where(active_mask, candidate, 0.0), initial=0.0)
         > jnp.asarray(reset_threshold, dtype=dtype)
     )
-    returned = jnp.where(reset, jnp.ones_like(candidate), candidate)
+    returned = jnp.where(
+        active_mask,
+        jnp.where(reset, jnp.ones_like(candidate), candidate),
+        jnp.ones_like(candidate),
+    )
     return returned, alpha, reset
 
 
@@ -69,6 +82,13 @@ def apply_restoration_return(
     ng = entry.q.shape[0]
     nc = entry.r.shape[0]
     dtype = restoration_state.x.dtype
+    slot_mask = (
+        jnp.ones_like(entry.r, dtype=jnp.bool_)
+        if problem.condensate_slot_mask is None
+        else jnp.asarray(problem.condensate_slot_mask, dtype=jnp.bool_)
+    )
+    dummy_mask = ~slot_mask
+    dummy_amount = jnp.exp(jnp.asarray(entry.epsilon, dtype=dtype))
     floor = jnp.asarray(config.restoration.representation_floor, dtype=dtype)
     floored_x = jnp.maximum(restoration_state.x, floor)
     injection = floored_x - restoration_state.x
@@ -102,27 +122,44 @@ def apply_restoration_return(
         )
     )
 
-    q = jnp.log(floored_x[:ng])
-    r = jnp.log(floored_x[ng : ng + nc])
+    returned_x = floored_x.at[ng : ng + nc].set(
+        jnp.where(slot_mask, floored_x[ng : ng + nc], dummy_amount)
+    )
+    q = jnp.log(returned_x[:ng])
+    r = jnp.where(
+        slot_mask,
+        jnp.log(returned_x[ng : ng + nc]),
+        jnp.asarray(entry.epsilon, dtype=dtype),
+    )
     qtot = jnp.log(floored_x[-1])
-    entry_m = restoration_state.entry_x[ng : ng + nc]
-    entry_eta = jnp.exp(entry.rho)
+    entry_m = jnp.where(
+        slot_mask,
+        restoration_state.entry_x[ng : ng + nc],
+        dummy_amount,
+    )
+    entry_eta = jnp.where(slot_mask, jnp.exp(entry.rho), 1.0)
+    restored_m = jnp.where(
+        slot_mask,
+        returned_x[ng : ng + nc],
+        dummy_amount,
+    )
     restored_eta, alpha_dual, bound_reset = _bound_multiplier_return(
         entry_amount=entry_m,
-        restored_amount=floored_x[ng : ng + nc],
+        restored_amount=restored_m,
         entry_multiplier=entry_eta,
         barrier=restoration_state.restoration_mu,
         fraction_to_boundary=(
             config.restoration.return_dual_fraction_to_boundary
         ),
         reset_threshold=config.restoration.bound_multiplier_reset_threshold,
+        active_mask=slot_mask,
     )
-    rho = jnp.log(restored_eta)
+    rho = jnp.where(slot_mask, jnp.log(restored_eta), 0.0)
     pre_return_state = OriginalState(
         q=q,
         r=r,
         lambda_=entry.lambda_,
-        rho=entry.rho,
+        rho=jnp.where(slot_mask, entry.rho, 0.0),
         qtot=qtot,
         epsilon=entry.epsilon,
         iteration=entry.iteration,
@@ -136,6 +173,28 @@ def apply_restoration_return(
         epsilon=entry.epsilon,
         iteration=entry.iteration,
     )
+    hcond = jnp.asarray(problem.condensate_standard_source, dtype=dtype)
+    dummy_contract_ok = (
+        jnp.all(jnp.where(dummy_mask[None, :], ac == 0.0, True))
+        & jnp.all(jnp.where(dummy_mask, hcond == 1.0, True))
+        & jnp.all(
+            jnp.where(
+                dummy_mask,
+                jnp.asarray(restoration_state.restoration_mu, dtype=dtype)
+                == dummy_amount,
+                True,
+            )
+        )
+    )
+    dummy_stationarity = hcond - ac.T @ returned_state.lambda_ - jnp.exp(rho)
+    dummy_complementarity = r + rho - jnp.asarray(entry.epsilon, dtype=dtype)
+    dummy_anchor_ok = (
+        jnp.all(jnp.isfinite(jnp.where(dummy_mask, dummy_stationarity, 0.0)))
+        & jnp.all(jnp.isfinite(jnp.where(dummy_mask, dummy_complementarity, 0.0)))
+        & jnp.all(jnp.where(dummy_mask, dummy_stationarity == 0.0, True))
+        & jnp.all(jnp.where(dummy_mask, dummy_complementarity == 0.0, True))
+    )
+    return_contract_ok = dummy_contract_ok & dummy_anchor_ok
     diagnostics = RestorationReturnDiagnostics(
         alpha_dual=alpha_dual,
         bound_multiplier_reset=bound_reset,
@@ -149,13 +208,20 @@ def apply_restoration_return(
     return RestorationReturnResult(
         original_state=returned_state,
         diagnostics=diagnostics,
-        accepted=floor_audit_ok,
+        accepted=floor_audit_ok & return_contract_ok,
         status=jnp.where(
-            floor_audit_ok,
-            jnp.asarray(TerminalStatus.NOT_TERMINATED, dtype=jnp.int32),
+            ~return_contract_ok,
             jnp.asarray(
-                TerminalStatus.RETURN_REPRESENTATION_FLOOR_FAILED,
+                TerminalStatus.INTERNAL_CONTRACT_ERROR,
                 dtype=jnp.int32,
+            ),
+            jnp.where(
+                floor_audit_ok,
+                jnp.asarray(TerminalStatus.NOT_TERMINATED, dtype=jnp.int32),
+                jnp.asarray(
+                    TerminalStatus.RETURN_REPRESENTATION_FLOOR_FAILED,
+                    dtype=jnp.int32,
+                ),
             ),
         ),
     )

--- a/src/exogibbs/equilibrium/condensate/fixed_support/types.py
+++ b/src/exogibbs/equilibrium/condensate/fixed_support/types.py
@@ -176,6 +176,8 @@ class FixedSupportProblem(NamedTuple):
     independent of the current iterate.  ``budget_row_scale`` and
     ``total_density_row_scale`` are the fixed multipliers ``Wb`` and ``wt``
     used by the filter for the complete fixed-epsilon solve.
+    ``condensate_slot_mask`` is dynamic boolean data: false slots are
+    synthetic unit-source columns with zero elemental formula.
     """
 
     gas_formula_matrix: Array
@@ -186,6 +188,7 @@ class FixedSupportProblem(NamedTuple):
     support_indices: Array
     budget_row_scale: Array
     total_density_row_scale: Array
+    condensate_slot_mask: Any = None
 
 
 class OriginalState(NamedTuple):
@@ -331,7 +334,12 @@ class FilterUpdateResult(NamedTuple):
 
 
 class RestorationState(NamedTuple):
-    """Complete persistent state of one restoration NLP."""
+    """Complete persistent state of one restoration NLP.
+
+    ``proximity_mask`` selects variables governed by the usual restoration
+    proximity term.  Synthetic condensate slots instead use their independent
+    linear source and bound barrier.
+    """
 
     x: Array
     positive_slack: Array
@@ -349,6 +357,7 @@ class RestorationState(NamedTuple):
     row_scales: Array
     iteration: Array
     accepted_iteration_count: Array
+    proximity_mask: Any = None
 
 
 class RestorationResiduals(NamedTuple):

--- a/src/exogibbs/equilibrium/condensate/lifecycle.py
+++ b/src/exogibbs/equilibrium/condensate/lifecycle.py
@@ -778,8 +778,10 @@ def _head_v2_prepared_buckets(
     b: Array,
     Pref: float,
     states: Sequence[_HeadV2LayerState],
+    fixed_shape: Any | None = None,
+    source_layer_indices: Sequence[int] | None = None,
 ) -> tuple[Any, ...]:
-    """Group pending v2 lifecycle states by exact fixed support."""
+    """Prepare pending v2 lifecycle states with an optional fixed shape."""
 
     from exogibbs.equilibrium.condensate.fixed_support.batch import (
         PreparedFixedSupportV2LayerState,
@@ -829,6 +831,8 @@ def _head_v2_prepared_buckets(
                 for pressure in pressures
             ]
         ),
+        fixed_shape=fixed_shape,
+        source_layer_indices=source_layer_indices,
     )
 
 
@@ -902,6 +906,7 @@ def _run_head_v2_profile(
         fixed_support_v2_production_policy,
     )
     from exogibbs.equilibrium.condensate.fixed_support.batch import (
+        FixedSupportV2BatchShape,
         run_fixed_support_profile,
     )
     from exogibbs.equilibrium.condensate.fixed_support.types import (
@@ -939,10 +944,21 @@ def _run_head_v2_profile(
         "public_result_gauge": "caller_element_inventory",
     }
     n_layers = int(temperatures.shape[0])
+    fixed_batch_shape = FixedSupportV2BatchShape(
+        support_capacity=max(
+            1,
+            min(
+                policy.support_limit,
+                len(setup.condensate_species),
+            ),
+        ),
+        batch_capacity=n_layers,
+    )
     records: list[dict[str, Any]] = [
         {"layer_index": index, "rounds": []} for index in range(n_layers)
     ]
     pending: dict[int, _HeadV2LayerState] = {}
+    gas_only_states: dict[int, _HeadV2LayerState] = {}
     gas_only_layers: set[int] = set()
     initial_guesses: list[CondensateEquilibriumInit] = []
     for layer_index in range(n_layers):
@@ -1040,6 +1056,19 @@ def _run_head_v2_profile(
         if not initial_support:
             records[layer_index]["outcome"] = "gas_only_no_candidate"
             gas_only_layers.add(layer_index)
+            gas_only_states[layer_index] = _head_v2_initial_state(
+                setup=setup,
+                T=float(temperatures[layer_index]),
+                P=float(pressures[layer_index]),
+                b=b,
+                Pref=Pref,
+                support_indices=(),
+                support_amounts=(),
+                initial_guess=initial_guess,
+                first_epsilon=(
+                    policy.solver_config.continuation.epsilon_schedule[0]
+                ),
+            )
             continue
         pending[layer_index] = _head_v2_initial_state(
             setup=setup,
@@ -1183,6 +1212,83 @@ def _run_head_v2_profile(
     diagnostic_compilation_seconds = 0.0
     diagnostic_execution_seconds = 0.0
     backend = jax.default_backend()
+
+    def accumulate_solver_timing(raw: Mapping[str, Any]) -> None:
+        nonlocal compilation_seconds
+        nonlocal execution_seconds
+        nonlocal diagnostic_seconds
+        nonlocal diagnostic_compilation_seconds
+        nonlocal diagnostic_execution_seconds
+        nonlocal backend
+
+        compilation_seconds += float(raw["compilation_seconds"])
+        execution_seconds += float(raw["execution_seconds"])
+        round_diagnostic_seconds = float(raw["diagnostic_seconds"])
+        diagnostic_seconds += round_diagnostic_seconds
+        round_diagnostic_compilation = raw.get(
+            "diagnostic_compilation_seconds"
+        )
+        round_diagnostic_execution = raw.get(
+            "diagnostic_execution_seconds"
+        )
+        if (
+            round_diagnostic_compilation is None
+            and round_diagnostic_execution is None
+        ):
+            diagnostic_execution_seconds += round_diagnostic_seconds
+        else:
+            if round_diagnostic_compilation is None:
+                round_diagnostic_compilation = (
+                    round_diagnostic_seconds
+                    - float(round_diagnostic_execution)
+                )
+            if round_diagnostic_execution is None:
+                round_diagnostic_execution = (
+                    round_diagnostic_seconds
+                    - float(round_diagnostic_compilation)
+                )
+            diagnostic_compilation_seconds += float(
+                round_diagnostic_compilation
+            )
+            diagnostic_execution_seconds += float(
+                round_diagnostic_execution
+            )
+        backend = str(raw["backend"])
+
+    if (
+        not pending
+        and gas_only_states
+        and setup.condensate_species
+    ):
+        source_indices = tuple(sorted(gas_only_states))
+        warmup = run_fixed_support_profile(
+            buckets=_head_v2_prepared_buckets(
+                setup=setup,
+                temperatures=tuple(
+                    float(temperatures[index]) for index in source_indices
+                ),
+                pressures=tuple(
+                    float(pressures[index]) for index in source_indices
+                ),
+                b=b,
+                Pref=Pref,
+                states=tuple(
+                    gas_only_states[index] for index in source_indices
+                ),
+                fixed_shape=fixed_batch_shape,
+                source_layer_indices=source_indices,
+            ),
+            formula_matrix=setup.formula_matrix,
+            layer_count=len(source_indices),
+            condensate_count=len(setup.condensate_species),
+            config=policy.solver_config,
+            budget_relative_floor=policy.budget_relative_floor,
+            include_terminal_diagnostics=return_diagnostics,
+        )
+        accumulate_solver_timing(warmup)
+        for source_index in source_indices:
+            records[source_index]["fixed_shape_warmup"] = True
+
     for round_index in range(policy.lifecycle_max_rounds):
         if not pending:
             break
@@ -1201,6 +1307,8 @@ def _run_head_v2_profile(
             b=b,
             Pref=Pref,
             states=round_states,
+            fixed_shape=fixed_batch_shape,
+            source_layer_indices=source_indices,
         )
         hcond_full = jnp.stack(
             [
@@ -1246,37 +1354,7 @@ def _run_head_v2_profile(
             budget_relative_floor=policy.budget_relative_floor,
             support_closure_tolerance=policy.support_closure_tolerance,
         )
-        compilation_seconds += float(raw["compilation_seconds"])
-        execution_seconds += float(raw["execution_seconds"])
-        round_diagnostic_seconds = float(raw["diagnostic_seconds"])
-        diagnostic_seconds += round_diagnostic_seconds
-        round_diagnostic_compilation = raw.get(
-            "diagnostic_compilation_seconds"
-        )
-        round_diagnostic_execution = raw.get("diagnostic_execution_seconds")
-        if (
-            round_diagnostic_compilation is None
-            and round_diagnostic_execution is None
-        ):
-            diagnostic_execution_seconds += round_diagnostic_seconds
-        else:
-            if round_diagnostic_compilation is None:
-                round_diagnostic_compilation = (
-                    round_diagnostic_seconds
-                    - float(round_diagnostic_execution)
-                )
-            if round_diagnostic_execution is None:
-                round_diagnostic_execution = (
-                    round_diagnostic_seconds
-                    - float(round_diagnostic_compilation)
-                )
-            diagnostic_compilation_seconds += float(
-                round_diagnostic_compilation
-            )
-            diagnostic_execution_seconds += float(
-                round_diagnostic_execution
-            )
-        backend = str(raw["backend"])
+        accumulate_solver_timing(raw)
         converged = np.asarray(
             jax.device_get(raw["fixed_support_converged"]), dtype=bool
         )
@@ -1563,6 +1641,9 @@ def _run_head_v2_profile(
             "preset": policy.name,
             "outcome": records[layer_index].get(
                 "outcome", "internal_missing_outcome"
+            ),
+            "fixed_shape_warmup": bool(
+                records[layer_index].get("fixed_shape_warmup", False)
             ),
             "rounds": tuple(records[layer_index]["rounds"]),
             "compilation_seconds_total": compilation_seconds,

--- a/tests/unittests/api/condensate_equilibrium_profile_test.py
+++ b/tests/unittests/api/condensate_equilibrium_profile_test.py
@@ -84,6 +84,19 @@ def _amount_gauge_fake_setup() -> CondensateChemicalSetup:
     )
 
 
+def _prepared_real_support(bucket, row: int = 0) -> tuple[int, ...]:
+    indices = np.asarray(bucket.support_indices)
+    mask = getattr(bucket, "condensate_slot_mask", None)
+    if indices.ndim == 1:
+        return tuple(int(index) for index in indices)
+    if mask is None:
+        return tuple(int(index) for index in indices[row])
+    return tuple(
+        int(index)
+        for index in indices[row][np.asarray(mask, dtype=bool)[row]]
+    )
+
+
 def test_amount_gauge_scale_and_initializer_normalization() -> None:
     setup = SimpleNamespace(elements=("H", "O", "e-"))
     scale = _lifecycle._inventory_amount_gauge_scale(
@@ -196,8 +209,11 @@ def test_head_v2_uses_one_canonical_amount_gauge_and_rescales_results(
             bucket.element_inventory_target
         )
         captured["bucket_gas"] = np.exp(np.asarray(bucket.ln_nk_init))
-        captured["bucket_condensate"] = np.exp(
-            np.asarray(bucket.ln_mk_init)
+        slot_amounts = np.exp(np.asarray(bucket.ln_mk_init))
+        slot_mask = np.asarray(bucket.condensate_slot_mask, dtype=bool)
+        captured["bucket_condensate"] = tuple(
+            tuple(row[row_mask])
+            for row, row_mask in zip(slot_amounts, slot_mask)
         )
         zeros = jnp.zeros((1,), dtype=jnp.float64)
         return {
@@ -365,7 +381,7 @@ def test_head_v2_profile_expands_support_outside_solver_until_closed(
 
     def fake_run_fixed_support_profile(**kwargs):
         calls.append(kwargs)
-        support = tuple(kwargs["buckets"][0].support_indices)
+        support = _prepared_real_support(kwargs["buckets"][0])
         closed = len(support) == 2
         condensate_amounts = (
             jnp.asarray([[0.2, 0.1]], dtype=jnp.float64)
@@ -527,8 +543,10 @@ def test_head_v2_profile_expands_support_outside_solver_until_closed(
     assert [
         tuple(call["support_indices"]) for call in exact_calls
     ] == [(0,), (0, 1)]
-    assert tuple(calls[0]["buckets"][0].support_indices) == (0,)
-    assert tuple(calls[1]["buckets"][0].support_indices) == (0, 1)
+    assert _prepared_real_support(calls[0]["buckets"][0]) == (0,)
+    assert _prepared_real_support(calls[1]["buckets"][0]) == (0, 1)
+    assert calls[0]["buckets"][0].support_indices.shape == (1, 2)
+    assert calls[1]["buckets"][0].support_indices.shape == (1, 2)
     np.testing.assert_allclose(
         np.exp(np.asarray(calls[1]["buckets"][0].ln_nk_init)),
         [[0.4, 0.4]],
@@ -1031,6 +1049,7 @@ def test_head_v2_empty_initial_support_uses_gas_only_outcome(
 ):
     setup = _fake_setup()
     gas_ln_n = jnp.log(jnp.asarray([0.5, 0.5], dtype=jnp.float64))
+    warmup_calls = []
 
     monkeypatch.setattr(
         "exogibbs.equilibrium.gas.solve.equilibrium",
@@ -1038,6 +1057,25 @@ def test_head_v2_empty_initial_support_uses_gas_only_outcome(
             ln_n=gas_ln_n,
             ntot=jnp.asarray(1.0, dtype=jnp.float64),
         ),
+    )
+
+    def fake_run_fixed_support_profile(**kwargs):
+        warmup_calls.append(kwargs)
+        return {
+            "compilation_seconds": 0.25,
+            "execution_seconds": 0.5,
+            "diagnostic_seconds": 0.0,
+            "diagnostic_compilation_seconds": 0.0,
+            "diagnostic_execution_seconds": 0.0,
+            "backend": "cpu",
+        }
+
+    monkeypatch.setattr(
+        (
+            "exogibbs.equilibrium.condensate.fixed_support.batch."
+            "run_fixed_support_profile"
+        ),
+        fake_run_fixed_support_profile,
     )
     monkeypatch.setattr(
         (
@@ -1061,9 +1099,56 @@ def test_head_v2_empty_initial_support_uses_gas_only_outcome(
     assert layer.converged
     assert layer.selected_route == "head_v2_gas_only_no_candidate"
     assert layer.condensate_support_indices.size == 0
+    assert len(warmup_calls) == 1
+    warmup_bucket = warmup_calls[0]["buckets"][0]
+    assert warmup_bucket.support_indices.shape == (1, 2)
+    assert not np.any(np.asarray(warmup_bucket.condensate_slot_mask))
     assert layer.diagnostics["fixed_support_v2"]["outcome"] == (
         "gas_only_no_candidate"
     )
+    assert layer.diagnostics["fixed_support_v2"]["fixed_shape_warmup"]
+
+
+def test_head_v2_empty_catalog_skips_unnecessary_fixed_shape_warmup(
+    monkeypatch,
+):
+    base = _fake_setup()
+    empty_condensates = ChemicalSetup(
+        formula_matrix=jnp.zeros((2, 0), dtype=jnp.float64),
+        hvector_func=lambda temperature: jnp.zeros((0,), dtype=jnp.float64),
+        elements=base.elements,
+        species=(),
+        metadata={},
+    )
+    setup = CondensateChemicalSetup(
+        gas_setup=base.gas_setup,
+        condensate_setup=empty_condensates,
+        formula_matrix=base.formula_matrix,
+        formula_matrix_cond=empty_condensates.formula_matrix,
+        gas_species=base.gas_species,
+        condensate_species=(),
+        elements=base.elements,
+    )
+    gas_ln_n = jnp.log(jnp.asarray([0.5, 0.5], dtype=jnp.float64))
+    monkeypatch.setattr(
+        "exogibbs.equilibrium.gas.solve.equilibrium",
+        lambda *args, **kwargs: SimpleNamespace(
+            ln_n=gas_ln_n,
+            ntot=jnp.asarray(1.0, dtype=jnp.float64),
+        ),
+    )
+
+    result = condmod.condensate_equilibrium_profile(
+        setup,
+        T=np.asarray([1000.0]),
+        P=np.asarray([1.0]),
+        b=jnp.asarray([0.5, 0.5], dtype=jnp.float64),
+    )
+
+    assert result.layers[0].converged
+    assert not result.layers[0].diagnostics["fixed_support_v2"][
+        "fixed_shape_warmup"
+    ]
 
 
 def test_head_v2_grid_like_gas_init_seeds_exact_gas_solves(

--- a/tests/unittests/benchmarks/documented_examples_benchmark_test.py
+++ b/tests/unittests/benchmarks/documented_examples_benchmark_test.py
@@ -222,8 +222,13 @@ def test_timing_collector_aggregates_and_restores_hooks(
         "diagnostic_execution_seconds": 0.04,
         "bucket_reports": (
             {
-                "support_indices": (2,),
+                "support_indices": (2, 3),
+                "support_indices_by_layer": ((2,), (3,)),
                 "layer_indices": (0, 1),
+                "source_layer_indices": (4, 7),
+                "support_capacity": 8,
+                "batch_capacity": 4,
+                "valid_batch_size": 2,
                 "compilation_seconds": 0.2,
                 "execution_seconds": 0.3,
                 "diagnostic_compilation_seconds": 0.06,
@@ -309,8 +314,12 @@ def test_timing_collector_aggregates_and_restores_hooks(
     assert summary["pdipm"]["shape_compilation"][0]["invocation_count"] == 2
     assert summary["pdipm"]["shape_compilation"][0]["signature"] == (
         "backend=cpu,dtype=float64,config=dc937b598926,elements=3,gas=5,"
-        "support=1,batch=2,diagnostics=1"
+        "support=8,batch=4,diagnostics=1"
     )
+    bucket_record = summary["pdipm"]["calls"][0]["buckets"][0]
+    assert bucket_record["support_indices_by_layer"] == ((2,), (3,))
+    assert bucket_record["source_layer_indices"] == (4, 7)
+    assert bucket_record["valid_batch_size"] == 2
     assert summary["zero_barrier"]["host_wall_seconds"] == 1.0
     assert summary["zero_barrier"]["function_evaluations"] == 7
     assert summary["zero_barrier"]["calls"][0]["active_set_round_count"] == 2

--- a/tests/unittests/benchmarks/ldwarf_repeated_benchmark_test.py
+++ b/tests/unittests/benchmarks/ldwarf_repeated_benchmark_test.py
@@ -99,6 +99,42 @@ def test_pdipm_support_signature_detects_identity_not_only_shape() -> None:
     assert signature != _pdipm_support_signature(same_shape_different_support)
 
 
+def test_pdipm_support_signature_uses_real_support_for_each_padded_row() -> None:
+    first = (
+        {
+            "buckets": (
+                {
+                    "layer_indices": (0, 1),
+                    "source_layer_indices": (2, 7),
+                    "support_indices": (2, 3, 4),
+                    "support_indices_by_layer": ((2,), (3, 4)),
+                    "support_capacity": 128,
+                    "batch_capacity": 13,
+                },
+            )
+        },
+    )
+    changed = (
+        {
+            "buckets": (
+                {
+                    "layer_indices": (0, 1),
+                    "source_layer_indices": (2, 7),
+                    "support_indices": (2, 3, 4),
+                    "support_indices_by_layer": ((3,), (2, 4)),
+                    "support_capacity": 128,
+                    "batch_capacity": 13,
+                },
+            )
+        },
+    )
+
+    assert _pdipm_support_signature(first) == (
+        (((2,), (2,)), ((7,), (3, 4))),
+    )
+    assert _pdipm_support_signature(first) != _pdipm_support_signature(changed)
+
+
 def test_new_shape_and_validation_fail_closed() -> None:
     cold = {
         "pdipm": {"shape_compilation": ({"signature": "shape-a"},)}
@@ -121,6 +157,7 @@ def test_new_shape_and_validation_fail_closed() -> None:
         _result_status(
             all_evaluations_accepted=False,
             timing_attribution_consistent=True,
+            no_new_pdipm_executable_shapes_after_cold=True,
         )
         == "fail_validation"
     )
@@ -128,8 +165,17 @@ def test_new_shape_and_validation_fail_closed() -> None:
         _result_status(
             all_evaluations_accepted=True,
             timing_attribution_consistent=False,
+            no_new_pdipm_executable_shapes_after_cold=True,
         )
         == "fail_timing"
+    )
+    assert (
+        _result_status(
+            all_evaluations_accepted=True,
+            timing_attribution_consistent=True,
+            no_new_pdipm_executable_shapes_after_cold=False,
+        )
+        == "fail_recompilation"
     )
 
 

--- a/tests/unittests/equilibrium/condensate/fixed_support/continuation_test.py
+++ b/tests/unittests/equilibrium/condensate/fixed_support/continuation_test.py
@@ -37,6 +37,7 @@ def _equilibrium_fixture():
         support_indices=jnp.asarray([0], dtype=jnp.int32),
         budget_row_scale=jnp.asarray([1.0]),
         total_density_row_scale=jnp.asarray(1.0 / 0.8),
+        condensate_slot_mask=jnp.asarray([True]),
     )
     state = OriginalState(
         q=jnp.log(jnp.asarray([0.8])),
@@ -79,6 +80,29 @@ def test_recenter_for_epsilon_preserves_warm_primal_and_centers_complementarity(
     assert residual.complementarity == pytest.approx(jnp.zeros((1,)))
 
 
+def test_recenter_for_epsilon_anchors_dummy_slots_at_unit_source_solution():
+    _problem, state = _equilibrium_fixture()
+    padded = state._replace(
+        r=jnp.asarray([state.r[0], 3.0]),
+        rho=jnp.asarray([state.rho[0], -4.0]),
+    )
+    epsilon = -7.0
+
+    centered = jax.jit(recenter_for_epsilon)(
+        padded,
+        epsilon,
+        jnp.asarray([True, False]),
+    )
+
+    assert centered.r[0] == state.r[0]
+    assert centered.rho[0] == pytest.approx(epsilon - state.r[0])
+    assert centered.r[1] == epsilon
+    assert centered.rho[1] == 0.0
+    assert centered.r + centered.rho == pytest.approx(
+        jnp.full((2,), epsilon)
+    )
+
+
 def test_provided_initial_state_policy_preserves_exact_solver_state():
     problem, state = _equilibrium_fixture()
     supplied = state._replace(
@@ -107,6 +131,33 @@ def test_provided_initial_state_policy_preserves_exact_solver_state():
         initial.controller.original_state.epsilon, supplied.epsilon
     )
     assert int(initial.controller.original_state.iteration) == 0
+
+
+def test_provided_initial_state_policy_preserves_real_slot_dtypes():
+    problem, state = _equilibrium_fixture()
+    supplied = state._replace(
+        r=jnp.asarray(state.r, dtype=jnp.float32),
+        rho=jnp.asarray(state.rho, dtype=jnp.float32),
+        epsilon=jnp.asarray(state.epsilon, dtype=jnp.float32),
+    )
+    config = FixedSupportV2Config(
+        continuation=ContinuationConfig(
+            epsilon_schedule=(float(state.epsilon),),
+            initial_state_policy="provided",
+        ),
+        soc=SOCConfig(enabled=False),
+        limits=SolverLimitConfig(max_normal_iterations=0),
+    )
+
+    initial = initialize_continuation(problem, supplied, config)
+    preserved = initial.controller.original_state
+
+    assert preserved.r.dtype == supplied.r.dtype
+    assert preserved.rho.dtype == supplied.rho.dtype
+    assert preserved.epsilon.dtype == supplied.epsilon.dtype
+    assert jnp.array_equal(preserved.r, supplied.r)
+    assert jnp.array_equal(preserved.rho, supplied.rho)
+    assert jnp.array_equal(preserved.epsilon, supplied.epsilon)
 
 
 def test_continuation_rejects_unknown_initial_state_policy():

--- a/tests/unittests/equilibrium/condensate/fixed_support/controller_test.py
+++ b/tests/unittests/equilibrium/condensate/fixed_support/controller_test.py
@@ -40,6 +40,7 @@ def _equilibrium_fixture():
         support_indices=jnp.asarray([0], dtype=jnp.int32),
         budget_row_scale=jnp.asarray([1.0]),
         total_density_row_scale=jnp.asarray(1.0 / 0.8),
+        condensate_slot_mask=jnp.asarray([True]),
     )
     state = OriginalState(
         q=jnp.log(jnp.asarray([0.8])),
@@ -63,6 +64,7 @@ def _infeasible_fixture():
         support_indices=jnp.asarray([0], dtype=jnp.int32),
         budget_row_scale=jnp.asarray([1.0]),
         total_density_row_scale=jnp.asarray(1.0 / 0.8),
+        condensate_slot_mask=jnp.asarray([True]),
     )
     state = OriginalState(
         q=jnp.log(jnp.asarray([0.05, 0.05])),
@@ -90,6 +92,22 @@ def _controller_config(**kwargs):
     )
 
 
+def _padded_equilibrium_fixture():
+    problem, state = _equilibrium_fixture()
+    return (
+        problem._replace(
+            condensate_formula_matrix=jnp.asarray([[1.0, 0.0]]),
+            condensate_standard_source=jnp.asarray([0.5, 1.0]),
+            support_indices=jnp.asarray([0, 0], dtype=jnp.int32),
+            condensate_slot_mask=jnp.asarray([True, False]),
+        ),
+        state._replace(
+            r=jnp.asarray([state.r[0], 3.0]),
+            rho=jnp.asarray([state.rho[0], -4.0]),
+        ),
+    )
+
+
 def test_return_map_uses_linearized_bound_update_and_zero_lambda():
     problem, entry = _equilibrium_fixture()
     config = _controller_config()
@@ -106,6 +124,68 @@ def test_return_map_uses_linearized_bound_update_and_zero_lambda():
     assert float(result.diagnostics.alpha_dual) == pytest.approx(1.0)
     assert bool(result.diagnostics.equality_multiplier_reset)
     assert not bool(result.diagnostics.bound_multiplier_reset)
+
+
+def test_return_map_reanchors_dummy_and_rejects_invalid_dummy_source():
+    problem, entry = _padded_equilibrium_fixture()
+    config = _controller_config()
+    restoration = initialize_restoration(problem, entry, config)._replace(
+        x=jnp.asarray([0.8, 0.1, 3.0, 0.8])
+    )
+
+    result = apply_restoration_return(problem, restoration, config)
+    invalid = apply_restoration_return(
+        problem._replace(condensate_standard_source=jnp.asarray([0.5, 0.9])),
+        restoration,
+        config,
+    )
+
+    assert bool(result.accepted)
+    assert result.original_state.r[1] == entry.epsilon
+    assert result.original_state.rho[1] == 0.0
+    assert result.diagnostics.post_return_norms.condensate_stationarity == (
+        pytest.approx(0.25)
+    )
+    assert not bool(invalid.accepted)
+    assert int(invalid.status) == TerminalStatus.INTERNAL_CONTRACT_ERROR
+
+
+def test_forced_restoration_padding_matches_unpadded_trajectory_and_status():
+    problem, entry = _infeasible_fixture()
+    padded_problem = problem._replace(
+        condensate_formula_matrix=jnp.asarray([[1.0, 0.0]]),
+        condensate_standard_source=jnp.asarray([0.0, 1.0]),
+        support_indices=jnp.asarray([0, 0], dtype=jnp.int32),
+        condensate_slot_mask=jnp.asarray([True, False]),
+    )
+    padded_entry = entry._replace(
+        r=jnp.asarray([entry.r[0], 2.0]),
+        rho=jnp.asarray([entry.rho[0], -3.0]),
+    )
+    config = _controller_config()
+    state = initialize_restoration(problem, entry, config)
+    padded_state = initialize_restoration(
+        padded_problem, padded_entry, config
+    )
+    filter_state = empty_filter(
+        config.limits.filter_capacity, dtype=state.x.dtype
+    )
+
+    result = solve_restoration(problem, state, filter_state, config)
+    padded_result = solve_restoration(
+        padded_problem, padded_state, filter_state, config
+    )
+    real_x_indices = jnp.asarray([0, 1, 2, 4])
+
+    assert int(padded_result.status) == int(result.status)
+    assert bool(padded_result.return_accepted) == bool(result.return_accepted)
+    assert int(padded_result.state.iteration) == int(result.state.iteration)
+    assert padded_result.state.x[real_x_indices] == pytest.approx(
+        result.state.x
+    )
+    assert padded_result.state.x[3] == pytest.approx(
+        jnp.exp(entry.epsilon)
+    )
 
 
 def test_return_map_resets_all_bound_multipliers_above_global_threshold():

--- a/tests/unittests/equilibrium/condensate/fixed_support/m1_test.py
+++ b/tests/unittests/equilibrium/condensate/fixed_support/m1_test.py
@@ -54,6 +54,7 @@ def _fixture():
         support_indices=jnp.asarray([2, 5], dtype=jnp.int32),
         budget_row_scale=1.0 / target,
         total_density_row_scale=1.0 / jnp.exp(qtot),
+        condensate_slot_mask=jnp.asarray([True, True]),
     )
     state = OriginalState(
         q=q,
@@ -103,6 +104,7 @@ def test_singular_reduced_system_returns_typed_linear_failure():
         support_indices=jnp.asarray([0], dtype=jnp.int32),
         budget_row_scale=jnp.ones((1,)),
         total_density_row_scale=jnp.asarray(1.0),
+        condensate_slot_mask=jnp.asarray([True]),
     )
     state = OriginalState(
         q=jnp.log(jnp.asarray([0.4, 0.6])),

--- a/tests/unittests/equilibrium/condensate/fixed_support/problem_test.py
+++ b/tests/unittests/equilibrium/condensate/fixed_support/problem_test.py
@@ -43,6 +43,7 @@ def deterministic_fixture():
         support_indices=jnp.asarray([2, 5], dtype=jnp.int32),
         budget_row_scale=1.0 / target,
         total_density_row_scale=1.0 / jnp.exp(qtot),
+        condensate_slot_mask=jnp.asarray([True, True]),
     )
     state = OriginalState(
         q=q,

--- a/tests/unittests/equilibrium/condensate/fixed_support/profile_test.py
+++ b/tests/unittests/equilibrium/condensate/fixed_support/profile_test.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 import math
 from types import SimpleNamespace
 
@@ -20,9 +20,12 @@ from exogibbs.equilibrium.condensate.fixed_support.types import (
     TerminalStatus,
 )
 from exogibbs.equilibrium.condensate.fixed_support.batch import (
+    FixedSupportV2BatchShape,
+    PreparedFixedSupportV2LayerState,
     _compiled_solver_factory,
     _prepared_original_state_batch,
     _prepared_problem_batch,
+    prepare_fixed_support_v2_buckets,
     run_fixed_support_profile,
 )
 from exogibbs.equilibrium.condensate.support import (
@@ -66,6 +69,41 @@ def _bucket():
         hvector_cond_active=jnp.full((2, 1), 0.5),
         ln_normalized_pressure=jnp.zeros((2,)),
     )
+
+
+def _fixed_shape_prepare_kwargs():
+    return {
+        "init_states": (
+            PreparedFixedSupportV2LayerState(
+                ln_nk=jnp.log(jnp.asarray([0.8])),
+                ln_mk=jnp.log(jnp.asarray([0.2])),
+                ln_ntot=jnp.log(jnp.asarray(0.8)),
+                element_potential=jnp.zeros((1,)),
+            ),
+            PreparedFixedSupportV2LayerState(
+                ln_nk=jnp.log(jnp.asarray([0.8])),
+                ln_mk=jnp.log(jnp.asarray([0.2])),
+                ln_ntot=jnp.log(jnp.asarray(0.8)),
+                element_potential=jnp.zeros((1,)),
+            ),
+        ),
+        "support_indices_by_layer": ((0,), (1,)),
+        "formula_matrix_cond": jnp.asarray([[1.0, 1.0]]),
+        "element_inventory_target_by_layer": jnp.ones((2, 1)),
+        "hvector_by_layer": jnp.zeros((2, 1)),
+        "hvector_cond_by_layer": jnp.asarray([[0.5, 2.0], [2.0, 0.5]]),
+        "ln_normalized_pressure_by_layer": jnp.zeros((2,)),
+    }
+
+
+def _fixed_shape_bucket():
+    return prepare_fixed_support_v2_buckets(
+        **_fixed_shape_prepare_kwargs(),
+        fixed_shape=FixedSupportV2BatchShape(
+            support_capacity=2,
+            batch_capacity=3,
+        ),
+    )[0]
 
 
 def _config():
@@ -175,6 +213,229 @@ def test_fixed_support_batch_does_not_own_full_catalog_closure():
     assert "support_expansion_mask" not in result
     assert "support_closed" not in result
     assert result["support_mask"].shape == (2, 2)
+
+
+def test_fixed_shape_preparation_builds_heterogeneous_anchored_slots():
+    bucket = _fixed_shape_bucket()
+    problems = _prepared_problem_batch(
+        bucket,
+        jnp.asarray([[1.0]]),
+        budget_relative_floor=1.0e-6,
+    )
+    states = _prepared_original_state_batch(bucket, problems, _config())
+    epsilon = math.log(0.1)
+
+    assert bucket.valid_batch_size == 2
+    assert bucket.layer_indices == (0, 1)
+    assert bucket.support_indices.tolist() == [[0, 0], [1, 0], [1, 0]]
+    assert bucket.condensate_slot_mask.tolist() == [
+        [True, False],
+        [True, False],
+        [True, False],
+    ]
+    assert bucket.formula_matrix_cond_active.shape == (3, 1, 2)
+    assert bucket.hvector_cond_active == pytest.approx(
+        jnp.asarray([[0.5, 1.0], [0.5, 1.0], [0.5, 1.0]])
+    )
+    assert problems.condensate_formula_matrix[:, :, 1] == pytest.approx(
+        jnp.zeros((3, 1))
+    )
+    assert states.r[:, 1] == pytest.approx(jnp.full((3,), epsilon))
+    assert states.rho[:, 1] == pytest.approx(jnp.zeros((3,)))
+
+
+def test_fixed_shape_problem_leaves_do_not_depend_on_real_support_count():
+    shape = FixedSupportV2BatchShape(support_capacity=2, batch_capacity=3)
+    first = _fixed_shape_bucket()
+    changed_kwargs = _fixed_shape_prepare_kwargs()
+    changed_kwargs["support_indices_by_layer"] = ((0, 1), (1,))
+    changed_kwargs["init_states"] = (
+        replace(
+            changed_kwargs["init_states"][0],
+            ln_mk=jnp.log(jnp.asarray([0.1, 0.1])),
+        ),
+        changed_kwargs["init_states"][1],
+    )
+    changed = prepare_fixed_support_v2_buckets(
+        **changed_kwargs,
+        fixed_shape=shape,
+    )[0]
+
+    def problem_signature(bucket):
+        problem = _prepared_problem_batch(
+            bucket,
+            jnp.asarray([[1.0]]),
+            budget_relative_floor=1.0e-6,
+        )
+        return tuple(
+            (tuple(leaf.shape), leaf.dtype)
+            for leaf in jax.tree_util.tree_leaves(problem)
+        )
+
+    assert problem_signature(first) == problem_signature(changed)
+
+
+def test_fixed_shape_profile_scatter_excludes_dummy_slots_and_batch_rows():
+    result = run_fixed_support_profile(
+        buckets=(_fixed_shape_bucket(),),
+        formula_matrix=jnp.asarray([[1.0]]),
+        layer_count=2,
+        condensate_count=2,
+        config=_config(),
+        include_terminal_diagnostics=False,
+    )
+
+    assert jnp.all(result["fixed_support_converged"])
+    assert result["condensate_amounts"] == pytest.approx(
+        jnp.asarray([[0.2, 0.0], [0.0, 0.2]])
+    )
+    assert result["support_mask"].tolist() == [
+        [True, False],
+        [False, True],
+    ]
+    report = result["bucket_reports"][0]
+    assert report["support_indices_by_layer"] == ((0,), (1,))
+    assert report["support_capacity"] == 2
+    assert report["batch_capacity"] == 3
+    assert report["valid_batch_size"] == 2
+    assert report["terminal_status"].shape == (2,)
+    assert report["final_kkt_norms"].budget_scaled.shape == (2,)
+
+
+def test_fixed_shape_all_dummy_bucket_warms_gas_only_executable():
+    bucket = prepare_fixed_support_v2_buckets(
+        init_states=(
+            PreparedFixedSupportV2LayerState(
+                ln_nk=jnp.log(jnp.asarray([1.0])),
+                ln_mk=jnp.asarray([], dtype=jnp.float64),
+                ln_ntot=jnp.asarray(0.0),
+                element_potential=jnp.zeros((1,)),
+            ),
+        ),
+        support_indices_by_layer=((),),
+        formula_matrix_cond=jnp.asarray([[1.0]]),
+        element_inventory_target_by_layer=jnp.ones((1, 1)),
+        hvector_by_layer=jnp.zeros((1, 1)),
+        hvector_cond_by_layer=jnp.zeros((1, 1)),
+        ln_normalized_pressure_by_layer=jnp.zeros((1,)),
+        fixed_shape=FixedSupportV2BatchShape(
+            support_capacity=2,
+            batch_capacity=1,
+        ),
+    )[0]
+
+    result = run_fixed_support_profile(
+        buckets=(bucket,),
+        formula_matrix=jnp.asarray([[1.0]]),
+        layer_count=1,
+        condensate_count=1,
+        config=_config(),
+        include_terminal_diagnostics=False,
+    )
+
+    assert jnp.all(result["fixed_support_converged"])
+    assert result["condensate_amounts"] == pytest.approx(jnp.zeros((1, 1)))
+    assert not jnp.any(result["support_mask"])
+    assert result["bucket_reports"][0]["support_indices_by_layer"] == ((),)
+
+
+def test_all_dummy_and_real_support_share_one_compiled_shape():
+    config = _config()
+    shape = FixedSupportV2BatchShape(support_capacity=2, batch_capacity=1)
+
+    def bucket_for(support, ln_mk):
+        return prepare_fixed_support_v2_buckets(
+            init_states=(
+                PreparedFixedSupportV2LayerState(
+                    ln_nk=jnp.log(jnp.asarray([1.0])),
+                    ln_mk=jnp.asarray(ln_mk, dtype=jnp.float64),
+                    ln_ntot=jnp.asarray(0.0),
+                    element_potential=jnp.zeros((1,)),
+                ),
+            ),
+            support_indices_by_layer=(support,),
+            formula_matrix_cond=jnp.asarray([[1.0]]),
+            element_inventory_target_by_layer=jnp.ones((1, 1)),
+            hvector_by_layer=jnp.zeros((1, 1)),
+            hvector_cond_by_layer=jnp.asarray([[0.5]]),
+            ln_normalized_pressure_by_layer=jnp.zeros((1,)),
+            fixed_shape=shape,
+        )[0]
+
+    dummy_bucket = bucket_for((), ())
+    real_bucket = bucket_for((0,), (math.log(0.2),))
+    compiled = _compiled_solver_factory(config, False)
+    compiled.clear_cache()
+
+    def run(bucket):
+        problems = _prepared_problem_batch(
+            bucket,
+            jnp.asarray([[1.0]]),
+            budget_relative_floor=1.0e-6,
+        )
+        states = _prepared_original_state_batch(bucket, problems, config)
+        result = compiled(problems, states)
+        jax.block_until_ready(result)
+
+    run(dummy_bucket)
+    cache_size_after_dummy = compiled._cache_size()
+    run(real_bucket)
+
+    assert cache_size_after_dummy == 1
+    assert compiled._cache_size() == cache_size_after_dummy
+
+
+@pytest.mark.parametrize(
+    ("fixed_shape", "message"),
+    [
+        (
+            FixedSupportV2BatchShape(support_capacity=1, batch_capacity=2),
+            "support exceeds fixed support capacity",
+        ),
+        (
+            FixedSupportV2BatchShape(support_capacity=2, batch_capacity=1),
+            "layer count exceeds fixed batch capacity",
+        ),
+    ],
+)
+def test_fixed_shape_capacity_overflow_fails_without_resizing(
+    fixed_shape,
+    message,
+):
+    kwargs = _fixed_shape_prepare_kwargs()
+    if fixed_shape.support_capacity == 1:
+        kwargs["support_indices_by_layer"] = ((0, 1), (1,))
+        kwargs["init_states"] = (
+            replace(
+                kwargs["init_states"][0],
+                ln_mk=jnp.log(jnp.asarray([0.1, 0.1])),
+            ),
+            kwargs["init_states"][1],
+        )
+
+    with pytest.raises(ValueError, match=message):
+        prepare_fixed_support_v2_buckets(
+            **kwargs,
+            fixed_shape=fixed_shape,
+        )
+
+
+def test_fixed_shape_rejects_negative_padding_sentinel():
+    bucket = _fixed_shape_bucket()
+    invalid = replace(
+        bucket,
+        support_indices=bucket.support_indices.at[0, 1].set(-1),
+    )
+
+    with pytest.raises(ValueError, match="must not use -1 sentinels"):
+        run_fixed_support_profile(
+            buckets=(invalid,),
+            formula_matrix=jnp.asarray([[1.0]]),
+            layer_count=2,
+            condensate_count=2,
+            config=_config(),
+            include_terminal_diagnostics=False,
+        )
 
 
 def test_historical_profile_adapter_retains_closure_report():

--- a/tests/unittests/equilibrium/condensate/fixed_support/restoration_test.py
+++ b/tests/unittests/equilibrium/condensate/fixed_support/restoration_test.py
@@ -47,6 +47,7 @@ def _fixture(*, epsilon=1.0e-7):
         support_indices=jnp.asarray([0], dtype=jnp.int32),
         budget_row_scale=1.0 / target,
         total_density_row_scale=jnp.asarray(1.0 / 0.8),
+        condensate_slot_mask=jnp.asarray([True]),
     )
     original = OriginalState(
         q=q,
@@ -64,8 +65,82 @@ def _flat_direction(direction):
     return jnp.concatenate([jnp.ravel(block) for block in direction])
 
 
+def _padded_fixture(*, epsilon=1.0e-7):
+    problem, original = _fixture(epsilon=epsilon)
+    padded_problem = problem._replace(
+        condensate_formula_matrix=jnp.asarray([[1.0, 0.0]]),
+        condensate_standard_source=jnp.asarray([0.0, 1.0]),
+        support_indices=jnp.asarray([0, 0], dtype=jnp.int32),
+        condensate_slot_mask=jnp.asarray([True, False]),
+    )
+    padded_original = original._replace(
+        r=jnp.asarray([original.r[0], 3.0]),
+        rho=jnp.asarray([original.rho[0], -4.0]),
+    )
+    return padded_problem, padded_original
+
+
 def test_default_restoration_limit_covers_large_support_recovery():
     assert SolverLimitConfig().max_restoration_iterations == 100
+
+
+def test_legacy_restoration_state_without_slot_mask_remains_jittable():
+    problem, original = _fixture()
+    config = FixedSupportV2Config()
+    state = initialize_restoration(problem, original, config)._replace(
+        proximity_mask=None
+    )
+
+    result = jax.jit(
+        lambda current: restoration_iteration(problem, current, config)
+    )(state)
+
+    assert result.state.proximity_mask is None
+
+
+def test_dummy_restoration_block_is_exact_and_independent_of_real_direction():
+    problem, original = _fixture(epsilon=1.0e-2)
+    padded_problem, padded_original = _padded_fixture(epsilon=1.0e-2)
+    config = FixedSupportV2Config(
+        restoration=RestorationConfig(elastic_penalty=2.0)
+    )
+    state = initialize_restoration(problem, original, config)
+    padded_state = initialize_restoration(
+        padded_problem, padded_original, config
+    )
+    direction = restoration_direction(problem, state, config.restoration)
+    padded_direction = restoration_direction(
+        padded_problem, padded_state, config.restoration
+    )
+    residual = restoration_residuals(
+        padded_problem, padded_state, config.restoration
+    )
+    mu = jnp.exp(padded_original.epsilon)
+    real_x_indices = jnp.asarray([0, 1, 2, 4])
+
+    assert padded_state.x[3] == pytest.approx(mu)
+    assert padded_state.lower_bound_dual_x[3] == pytest.approx(1.0)
+    assert jnp.array_equal(
+        padded_state.proximity_mask,
+        jnp.asarray([True, True, True, False, True]),
+    )
+    assert residual.dual_x[3] == pytest.approx(0.0)
+    assert residual.complementarity_x[3] == pytest.approx(0.0)
+    assert padded_direction.direction.x[3] == pytest.approx(0.0)
+    assert padded_direction.direction.lower_bound_dual_x[3] == pytest.approx(
+        0.0
+    )
+    assert padded_direction.direction.x[real_x_indices] == pytest.approx(
+        direction.direction.x
+    )
+
+    def dummy_barrier_objective(amount):
+        trial_x = padded_state.x.at[3].set(amount)
+        return restoration_barrier_objective(
+            padded_state._replace(x=trial_x), config.restoration
+        )
+
+    assert jax.grad(dummy_barrier_objective)(mu) == pytest.approx(0.0)
 
 
 def test_restoration_schur_direction_matches_dense_kkt():

--- a/tests/unittests/equilibrium/condensate/fixed_support/soc_test.py
+++ b/tests/unittests/equilibrium/condensate/fixed_support/soc_test.py
@@ -47,6 +47,7 @@ def _fixture():
         support_indices=jnp.asarray([2, 5], dtype=jnp.int32),
         budget_row_scale=1.0 / target,
         total_density_row_scale=1.0 / jnp.exp(qtot),
+        condensate_slot_mask=jnp.asarray([True, True]),
     )
     state = OriginalState(
         q=jnp.log(jnp.asarray([0.21, 0.18, 0.04])),
@@ -70,6 +71,7 @@ def _infeasible_fixture():
         support_indices=jnp.asarray([0], dtype=jnp.int32),
         budget_row_scale=jnp.asarray([1.0]),
         total_density_row_scale=jnp.asarray(1.0 / 0.8),
+        condensate_slot_mask=jnp.asarray([True]),
     )
     state = OriginalState(
         q=jnp.log(jnp.asarray([0.05, 0.05])),
@@ -95,6 +97,7 @@ def _finite_soc_fixture():
         support_indices=jnp.asarray([0], dtype=jnp.int32),
         budget_row_scale=jnp.asarray([1.0 / 0.7417846284038427]),
         total_density_row_scale=jnp.asarray(1.0 / 0.8277107516608474),
+        condensate_slot_mask=jnp.asarray([True]),
     )
     state = OriginalState(
         q=jnp.log(jnp.asarray([0.43966721008714027, 0.14666067254281664])),


### PR DESCRIPTION
## Motivation

Benchmark #159 showed that repeated production-profile evaluations could spend most of their time compiling. Physical support changes altered the support dimension or exact-support bucket size, producing previously unseen JAX input shapes during steady evaluations.

## Changes

- Keep the production finite-barrier PD-IPM executable shape fixed at `(B, K)` for one profile invocation while carrying heterogeneous physical supports as dynamic values.
- Add an explicit condensate slot mask and regular synthetic slots with `Ac = 0`, `hcond = 1`, `r = epsilon`, and `rho = 0`.
- Preserve the dummy anchor through continuation, restoration, and the restoration return map.
- Exclude synthetic support slots and repeated batch rows from catalog scatter, closure, zero-barrier refinement, diagnostics, and public physical results.
- Warm nonempty all-gas cold profiles with the same executable; reject capacity overflow instead of truncating or resizing.
- Make the repeated L-dwarf benchmark fail on any unseen post-cold PD-IPM executable shape.
- Update solver design documentation.

## Impact

Physical condensate support remains adaptive, but support identity and count no longer change the finite-barrier executable shape. This removes late compilation spikes without treating padding as physical condensates. The change does not smooth zero-barrier phase transitions or differentiate through discrete support selection.

## Validation

- Full unit suite: `572 passed`.
- Targeted fixed-support/API/benchmark suite: `219 passed`.
- Canonical documented-example GPU matrix: `10/10 passed`.
- Repeated L-dwarf GPU benchmark, default and `disable_most_optimizations`: passed with zero new PD-IPM executable shapes after cold.
- `git diff --check`.
