### PR TITLE
solubility: add MELTYQ volatile laws

### DIFF
--- a/documents/index.rst
+++ b/documents/index.rst
@@ -30,6 +30,12 @@ Contents
 
 .. toctree::
    :maxdepth: 1
+   :caption: AUXILIARY:
+
+   solubility.rst
+
+.. toctree::
+   :maxdepth: 1
    :caption: EXAMPLES:
 
    visscher_2006_na2s_morley_2012_kcl

--- a/documents/solubility.rst
+++ b/documents/solubility.rst
@@ -1,0 +1,80 @@
+Magma--atmosphere solubility
+============================
+
+``exogibbs.solubility`` is an auxiliary package.  It is independent of the
+Gibbs-energy minimization solvers and provides empirical volatile-solubility
+laws for magma--atmosphere boundary calculations.
+
+The initial implementation contains the six laws selected by MELTYQ (Ito &
+Changeat 2026):
+
+.. list-table:: Native inputs and outputs
+   :header-rows: 1
+
+   * - Function
+     - Pressure input
+     - Output
+   * - ``h2_hirschmann2012``
+     - H2 fugacity in bar; melt pressure in GPa
+     - H2 mole fraction
+   * - ``h2o_lichtenberg2021``
+     - H2O partial pressure in Pa
+     - H2O mass fraction
+   * - ``co2_lichtenberg2021``
+     - CO2 partial pressure in Pa
+     - CO2 mass fraction
+   * - ``co_yoshioka2019``
+     - CO fugacity in bar
+     - Elemental-C mass fraction dissolved as CO
+   * - ``ch4_ardia2013``
+     - CH4 fugacity in GPa; melt pressure in GPa
+     - CH4 mole fraction
+   * - ``n2_dasgupta2022``
+     - N2 partial pressure and total melt pressure in GPa
+     - Total elemental-N mass fraction
+
+For example:
+
+.. code-block:: python
+
+   from exogibbs.solubility import h2_hirschmann2012
+
+   x_h2 = h2_hirschmann2012(
+       hydrogen_fugacity_bar=1000.0,
+       melt_pressure_gpa=1.0,
+   )
+
+All functions accept broadcast-compatible JAX arrays and support JIT
+compilation and automatic differentiation.  A zero driving partial pressure
+or fugacity returns zero; a nonphysical input returns ``nan``.  Values outside
+the experimental calibration ranges are evaluated without clipping.  Inspect
+``MELTYQ_SOLUBILITY_METADATA`` before extrapolating a law.  Automatic
+derivatives are finite at positive interior pressures.  At zero pressure, the
+fractional-power H2O, CO, and N2 laws retain their singular derivatives.
+
+Source-consistent corrections
+-----------------------------
+
+The implementation follows the cited experimental or formulation source when
+the MELTYQ appendix is inconsistent with it:
+
+* CO uses fugacity in bar with the corrected ``-7.2`` elemental-carbon
+  mass-fraction intercept from Yoshioka et al. (2019).
+* CH4 uses fugacity in GPa, as in Seo et al. (2024), Equation 17.
+* The first N term uses the square root of total melt pressure, as in Dasgupta
+  et al. (2022), Equation 10.
+
+These differences are also recorded in ``MELTYQ_SOLUBILITY_METADATA``.  The
+N2 law takes :math:`\Delta\mathrm{IW}` directly; calculation of the IW buffer
+from absolute oxygen fugacity is deliberately outside this package.
+
+References
+----------
+
+* Ito, Y. & Changeat, Q. (2026), arXiv:2605.08752.
+* Seo, C., Ito, Y. & Fujii, Y. (2024), doi:10.3847/1538-4357/ad7461.
+* Hirschmann, M. M. et al. (2012), doi:10.1016/j.epsl.2012.06.031.
+* Lichtenberg, T. et al. (2021), doi:10.1029/2020JE006711.
+* Yoshioka, T. et al. (2019), doi:10.1016/j.gca.2019.06.007.
+* Ardia, P. et al. (2013), doi:10.1016/j.gca.2013.03.028.
+* Dasgupta, R. et al. (2022), doi:10.1016/j.gca.2022.09.012.

--- a/src/exogibbs/solubility/__init__.py
+++ b/src/exogibbs/solubility/__init__.py
@@ -1,0 +1,24 @@
+"""Auxiliary volatile-solubility laws for magma-atmosphere boundaries."""
+
+from exogibbs.solubility.meltyq import (
+    MELTYQ_SOLUBILITY_METADATA,
+    SolubilityMetadata,
+    ch4_ardia2013,
+    co2_lichtenberg2021,
+    co_yoshioka2019,
+    h2_hirschmann2012,
+    h2o_lichtenberg2021,
+    n2_dasgupta2022,
+)
+
+
+__all__ = (
+    "MELTYQ_SOLUBILITY_METADATA",
+    "SolubilityMetadata",
+    "ch4_ardia2013",
+    "co2_lichtenberg2021",
+    "co_yoshioka2019",
+    "h2_hirschmann2012",
+    "h2o_lichtenberg2021",
+    "n2_dasgupta2022",
+)

--- a/src/exogibbs/solubility/meltyq.py
+++ b/src/exogibbs/solubility/meltyq.py
@@ -1,0 +1,318 @@
+"""Volatile-solubility laws selected by MELTYQ.
+
+The functions use the source-consistent units and fraction bases of the
+selected empirical laws.  Where the MELTYQ appendix conflicts with its cited
+formulation or experimental source, the discrepancy is recorded in metadata.
+Inputs are not clipped to the experimental calibration ranges.  MELTYQ's later
+conversion of mass fractions to a common mole-fraction basis is outside the
+scope of these empirical laws.  Automatic derivatives are finite at positive
+interior pressures; fractional-power laws retain their singular derivative at
+zero pressure.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Mapping, Tuple
+
+import jax.numpy as jnp
+from jax.typing import ArrayLike
+
+
+__all__ = (
+    "MELTYQ_SOLUBILITY_METADATA",
+    "SolubilityMetadata",
+    "ch4_ardia2013",
+    "co2_lichtenberg2021",
+    "co_yoshioka2019",
+    "h2_hirschmann2012",
+    "h2o_lichtenberg2021",
+    "n2_dasgupta2022",
+)
+
+
+@dataclass(frozen=True)
+class SolubilityMetadata:
+    """Provenance and calibration range for one solubility law."""
+
+    species: str
+    output_quantity: str
+    output_basis: str
+    calibration_temperature_k: Tuple[float, float]
+    calibration_total_pressure_gpa: Tuple[float, float]
+    experimental_reference: str
+    experimental_doi: str
+    formulation_reference: str
+    formulation_doi: str
+    implementation_reference: str
+    implementation_doi: str
+    notes: str = ""
+
+
+MELTYQ_SOLUBILITY_METADATA: Mapping[str, SolubilityMetadata] = MappingProxyType({
+    "h2_hirschmann2012": SolubilityMetadata(
+        species="H2",
+        output_quantity="H2",
+        output_basis="mole_fraction",
+        calibration_temperature_k=(1673.0, 1773.0),
+        calibration_total_pressure_gpa=(0.7, 3.0),
+        experimental_reference="Hirschmann et al. (2012)",
+        experimental_doi="10.1016/j.epsl.2012.06.031",
+        formulation_reference="Seo et al. (2024), Eq. 6",
+        formulation_doi="10.3847/1538-4357/ad7461",
+        implementation_reference="Ito & Changeat (2026), Eq. A3",
+        implementation_doi="10.48550/arXiv.2605.08752",
+        notes=(
+            "Retained for MELTYQ compatibility. Chaudhari et al. (2025) "
+            "report that the older infrared calibration may overestimate H2 "
+            "solubility by about one order of magnitude "
+            "(doi:10.1007/s00410-025-02272-y)."
+        ),
+    ),
+    "h2o_lichtenberg2021": SolubilityMetadata(
+        species="H2O",
+        output_quantity="H2O",
+        output_basis="mass_fraction",
+        calibration_temperature_k=(973.0, 1723.0),
+        calibration_total_pressure_gpa=(1.0e-4, 0.8),
+        experimental_reference=(
+            "Petrological datasets compiled by Lichtenberg et al. (2021), "
+            "Table 1"
+        ),
+        experimental_doi="10.1029/2020JE006711",
+        formulation_reference="Lichtenberg et al. (2021), Eq. 9 and Table 1",
+        formulation_doi="10.1029/2020JE006711",
+        implementation_reference="Ito & Changeat (2026), Eq. A1",
+        implementation_doi="10.48550/arXiv.2605.08752",
+    ),
+    "co2_lichtenberg2021": SolubilityMetadata(
+        species="CO2",
+        output_quantity="CO2",
+        output_basis="mass_fraction",
+        calibration_temperature_k=(1123.0, 1923.0),
+        calibration_total_pressure_gpa=(1.0e-2, 3.0),
+        experimental_reference=(
+            "Petrological datasets compiled by Lichtenberg et al. (2021), "
+            "Table 1"
+        ),
+        experimental_doi="10.1029/2020JE006711",
+        formulation_reference="Lichtenberg et al. (2021), Eq. 9 and Table 1",
+        formulation_doi="10.1029/2020JE006711",
+        implementation_reference="Ito & Changeat (2026), Eq. A2",
+        implementation_doi="10.48550/arXiv.2605.08752",
+    ),
+    "co_yoshioka2019": SolubilityMetadata(
+        species="CO",
+        output_quantity="elemental C dissolved as CO",
+        output_basis="mass_fraction",
+        calibration_temperature_k=(1523.0, 1873.0),
+        calibration_total_pressure_gpa=(0.2, 3.0),
+        experimental_reference="Yoshioka et al. (2019)",
+        experimental_doi="10.1016/j.gca.2019.06.007",
+        formulation_reference=(
+            "Yoshioka et al. (2019), Eq. 6; wt.% C converted to mass fraction"
+        ),
+        formulation_doi="10.1016/j.gca.2019.06.007",
+        implementation_reference="Ito & Changeat (2026), Eq. A5",
+        implementation_doi="10.48550/arXiv.2605.08752",
+        notes=(
+            "Uses the corrected -7.2 mass-fraction intercept on an elemental-C "
+            "basis with fugacity in bar, following Yoshioka et al. (2019). The "
+            "MELTYQ appendix labels fugacity as GPa, while that intercept and "
+            "the experimental source require bar."
+        ),
+    ),
+    "ch4_ardia2013": SolubilityMetadata(
+        species="CH4",
+        output_quantity="CH4",
+        output_basis="mole_fraction",
+        calibration_temperature_k=(1673.0, 1723.0),
+        calibration_total_pressure_gpa=(0.7, 3.0),
+        experimental_reference="Ardia et al. (2013)",
+        experimental_doi="10.1016/j.gca.2013.03.028",
+        formulation_reference="Seo et al. (2024), Eq. 17",
+        formulation_doi="10.3847/1538-4357/ad7461",
+        implementation_reference="Ito & Changeat (2026), Eq. A4",
+        implementation_doi="10.48550/arXiv.2605.08752",
+        notes=(
+            "Uses fugacity in GPa as in Seo et al. (2024), Eq. 17. The "
+            "MELTYQ appendix labels the same term as bar."
+        ),
+    ),
+    "n2_dasgupta2022": SolubilityMetadata(
+        species="N2",
+        output_quantity="total elemental N",
+        output_basis="mass_fraction",
+        calibration_temperature_k=(1323.0, 2600.0),
+        calibration_total_pressure_gpa=(1.0e-4, 8.2),
+        experimental_reference="Dasgupta et al. (2022)",
+        experimental_doi="10.1016/j.gca.2022.09.012",
+        formulation_reference="Dasgupta et al. (2022), Eq. 10",
+        formulation_doi="10.1016/j.gca.2022.09.012",
+        implementation_reference="Ito & Changeat (2026), Eq. A6",
+        implementation_doi="10.48550/arXiv.2605.08752",
+        notes=(
+            "The source reports total dissolved N in ppm by mass. Uses "
+            "sqrt(melt pressure) as in Dasgupta et al. (2022), Eq. 10; the "
+            "MELTYQ appendix typesets this pressure without the square root. "
+            "Default oxide mole fractions reproduce its basaltic melt."
+        ),
+    ),
+})
+
+
+def _valid_nonnegative(*values: jnp.ndarray) -> jnp.ndarray:
+    """Return a broadcast validity mask for finite, nonnegative values."""
+
+    valid = jnp.asarray(True)
+    for value in values:
+        valid = valid & jnp.isfinite(value) & (value >= 0.0)
+    return valid
+
+
+def h2_hirschmann2012(
+    hydrogen_fugacity_bar: ArrayLike,
+    melt_pressure_gpa: ArrayLike,
+) -> jnp.ndarray:
+    """Return dissolved H2 mole fraction from MELTYQ equation A3.
+
+    Non-finite inputs and negative pressures or fugacities return ``nan``.
+    """
+
+    fugacity = jnp.asarray(hydrogen_fugacity_bar)
+    melt_pressure = jnp.asarray(melt_pressure_gpa)
+    result = fugacity * jnp.exp(-11.403 - 0.76 * melt_pressure)
+    return jnp.where(
+        _valid_nonnegative(fugacity, melt_pressure),
+        result,
+        jnp.nan,
+    )
+
+
+def h2o_lichtenberg2021(
+    water_partial_pressure_pa: ArrayLike,
+) -> jnp.ndarray:
+    """Return dissolved H2O mass fraction from MELTYQ equation A1.
+
+    Non-finite or negative partial pressures return ``nan``.  The derivative
+    with respect to partial pressure is singular at zero.
+    """
+
+    partial_pressure = jnp.asarray(water_partial_pressure_pa)
+    result = 1.033e-6 * partial_pressure ** (1.0 / 1.747)
+    return jnp.where(
+        _valid_nonnegative(partial_pressure),
+        result,
+        jnp.nan,
+    )
+
+
+def co2_lichtenberg2021(
+    carbon_dioxide_partial_pressure_pa: ArrayLike,
+) -> jnp.ndarray:
+    """Return dissolved CO2 mass fraction from MELTYQ equation A2.
+
+    Non-finite or negative partial pressures return ``nan``.
+    """
+
+    partial_pressure = jnp.asarray(carbon_dioxide_partial_pressure_pa)
+    result = 1.937e-15 * partial_pressure ** (1.0 / 0.714)
+    return jnp.where(
+        _valid_nonnegative(partial_pressure),
+        result,
+        jnp.nan,
+    )
+
+
+def co_yoshioka2019(
+    carbon_monoxide_fugacity_bar: ArrayLike,
+) -> jnp.ndarray:
+    """Return elemental-C mass fraction dissolved from CO-bearing fluid.
+
+    Non-finite or negative fugacities return ``nan``.  The derivative with
+    respect to fugacity is singular at zero.
+    """
+
+    fugacity = jnp.asarray(carbon_monoxide_fugacity_bar)
+    result = 10.0**-7.2 * fugacity**0.8
+    return jnp.where(_valid_nonnegative(fugacity), result, jnp.nan)
+
+
+def ch4_ardia2013(
+    methane_fugacity_gpa: ArrayLike,
+    melt_pressure_gpa: ArrayLike,
+) -> jnp.ndarray:
+    """Return dissolved CH4 mole fraction from Seo et al. (2024), Eq. 17.
+
+    Non-finite inputs and negative pressures or fugacities return ``nan``.
+    """
+
+    fugacity = jnp.asarray(methane_fugacity_gpa)
+    melt_pressure = jnp.asarray(melt_pressure_gpa)
+    result = fugacity * jnp.exp(-7.63 - 1.9 * melt_pressure)
+    return jnp.where(
+        _valid_nonnegative(fugacity, melt_pressure),
+        result,
+        jnp.nan,
+    )
+
+
+def n2_dasgupta2022(
+    nitrogen_partial_pressure_gpa: ArrayLike,
+    temperature_k: ArrayLike,
+    melt_pressure_gpa: ArrayLike,
+    delta_iw: ArrayLike,
+    *,
+    x_sio2: ArrayLike = 0.56,
+    x_al2o3: ArrayLike = 0.11,
+    x_tio2: ArrayLike = 0.01,
+) -> jnp.ndarray:
+    """Return total dissolved elemental-N mass fraction.
+
+    ``delta_iw`` is log10 oxygen fugacity relative to the iron-wuestite
+    buffer.  The oxide inputs are mole fractions and default to the basaltic
+    composition adopted by MELTYQ.  Dasgupta et al. (2022), Eq. 10 reports
+    this concentration as nitrogen in ppm by mass.  The function returns
+    ``nan`` unless temperature is positive, pressures and oxide fractions are
+    nonnegative, each oxide fraction is at most one, their sum is at most one,
+    and every input is finite.  The derivative with respect to nitrogen
+    partial pressure is singular at zero.
+    """
+
+    partial_pressure = jnp.asarray(nitrogen_partial_pressure_gpa)
+    temperature = jnp.asarray(temperature_k)
+    melt_pressure = jnp.asarray(melt_pressure_gpa)
+    delta_iw_array = jnp.asarray(delta_iw)
+    silica = jnp.asarray(x_sio2)
+    alumina = jnp.asarray(x_al2o3)
+    titania = jnp.asarray(x_tio2)
+
+    reduced_term = jnp.sqrt(partial_pressure) * jnp.exp(
+        5908.0 * jnp.sqrt(melt_pressure) / temperature
+        - 1.6 * delta_iw_array
+    )
+    composition_exponent = (
+        4.67 + 7.11 * silica - 13.06 * alumina - 120.67 * titania
+    )
+    molecular_term = partial_pressure * jnp.exp(composition_exponent)
+    result = 1.0e-6 * (reduced_term + molecular_term)
+
+    valid = _valid_nonnegative(
+        partial_pressure,
+        melt_pressure,
+        silica,
+        alumina,
+        titania,
+    )
+    valid = (
+        valid
+        & jnp.isfinite(temperature)
+        & (temperature > 0.0)
+        & jnp.isfinite(delta_iw_array)
+        & (silica <= 1.0)
+        & (alumina <= 1.0)
+        & (titania <= 1.0)
+        & (silica + alumina + titania <= 1.0)
+    )
+    return jnp.where(valid, result, jnp.nan)

--- a/tests/unittests/architecture/dependency_boundaries_test.py
+++ b/tests/unittests/architecture/dependency_boundaries_test.py
@@ -42,6 +42,7 @@ def test_internal_packages_do_not_import_public_api_modules() -> None:
         "equilibrium",
         "optimize",
         "presets",
+        "solubility",
         "thermo",
     ):
         observed |= _imports_under(SOURCE_ROOT / package, "exogibbs.api")

--- a/tests/unittests/solubility/meltyq_test.py
+++ b/tests/unittests/solubility/meltyq_test.py
@@ -1,0 +1,244 @@
+"""Regression tests for the volatile-solubility laws adopted by MELTYQ."""
+
+import math
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import exogibbs.solubility as solubility
+import exogibbs.solubility.meltyq as meltyq
+from exogibbs.solubility import (
+    MELTYQ_SOLUBILITY_METADATA,
+    ch4_ardia2013,
+    co2_lichtenberg2021,
+    co_yoshioka2019,
+    h2_hirschmann2012,
+    h2o_lichtenberg2021,
+    n2_dasgupta2022,
+)
+
+
+@pytest.mark.parametrize(
+    ("calculated", "expected"),
+    (
+        (
+            h2_hirschmann2012(1000.0, 1.0),
+            0.0052200686751357186,
+        ),
+        (
+            h2o_lichtenberg2021(1.0e7),
+            0.010494680939906098,
+        ),
+        (
+            co2_lichtenberg2021(1.0e8),
+            0.0003101783014529868,
+        ),
+        (
+            co_yoshioka2019(1.0),
+            6.30957344480193e-8,
+        ),
+        (
+            ch4_ardia2013(1.0, 1.0),
+            7.263962399245182e-5,
+        ),
+        (
+            n2_dasgupta2022(0.1, 2000.0, 4.0, -2.0),
+            0.0028953374853364663,
+        ),
+    ),
+)
+def test_meltyq_laws_match_independent_reference_values(
+    calculated: jnp.ndarray,
+    expected: float,
+) -> None:
+    assert calculated.shape == ()
+    np.testing.assert_allclose(calculated, expected, rtol=1.0e-6)
+
+
+def test_n2_default_basalt_matches_explicit_composition() -> None:
+    default = n2_dasgupta2022(0.1, 2000.0, 1.0, -2.0)
+    explicit = n2_dasgupta2022(
+        0.1,
+        2000.0,
+        1.0,
+        -2.0,
+        x_sio2=0.56,
+        x_al2o3=0.11,
+        x_tio2=0.01,
+    )
+
+    np.testing.assert_allclose(default, explicit, rtol=0.0, atol=0.0)
+
+
+def test_laws_broadcast_array_inputs() -> None:
+    fugacity = jnp.asarray([[100.0], [1000.0]])
+    melt_pressure = jnp.asarray([0.7, 1.0, 3.0])
+
+    calculated = h2_hirschmann2012(fugacity, melt_pressure)
+    expected = np.asarray(fugacity) * np.exp(
+        -11.403 - 0.76 * np.asarray(melt_pressure)
+    )
+
+    assert calculated.shape == (2, 3)
+    np.testing.assert_allclose(calculated, expected, rtol=1.0e-6)
+
+
+@pytest.mark.parametrize(
+    "calculated",
+    (
+        h2_hirschmann2012(0.0, 1.0),
+        h2o_lichtenberg2021(0.0),
+        co2_lichtenberg2021(0.0),
+        co_yoshioka2019(0.0),
+        ch4_ardia2013(0.0, 1.0),
+        n2_dasgupta2022(0.0, 2000.0, 1.0, 0.0),
+    ),
+)
+def test_zero_driving_pressure_has_zero_solubility(
+    calculated: jnp.ndarray,
+) -> None:
+    assert float(calculated) == 0.0
+
+
+@pytest.mark.parametrize(
+    "calculated",
+    (
+        h2_hirschmann2012(-1.0, 1.0),
+        h2o_lichtenberg2021(-1.0),
+        co2_lichtenberg2021(-1.0),
+        co_yoshioka2019(-1.0),
+        ch4_ardia2013(-1.0, 1.0),
+        n2_dasgupta2022(-1.0, 2000.0, 1.0, 0.0),
+    ),
+)
+def test_negative_driving_pressure_returns_nan(
+    calculated: jnp.ndarray,
+) -> None:
+    assert math.isnan(float(calculated))
+
+
+@pytest.mark.parametrize(
+    "calculated",
+    (
+        h2_hirschmann2012(1.0, -1.0),
+        h2o_lichtenberg2021(jnp.inf),
+        co2_lichtenberg2021(jnp.nan),
+        co_yoshioka2019(jnp.inf),
+        ch4_ardia2013(1.0, -1.0),
+        n2_dasgupta2022(0.1, 0.0, 1.0, 0.0),
+        n2_dasgupta2022(0.1, 2000.0, -1.0, 0.0),
+        n2_dasgupta2022(0.1, 2000.0, 1.0, jnp.nan),
+        n2_dasgupta2022(0.1, 2000.0, 1.0, 0.0, x_sio2=-0.1),
+        n2_dasgupta2022(0.1, 2000.0, 1.0, 0.0, x_sio2=1.1),
+        n2_dasgupta2022(
+            0.1,
+            2000.0,
+            1.0,
+            0.0,
+            x_sio2=0.8,
+            x_al2o3=0.3,
+        ),
+    ),
+)
+def test_nonphysical_secondary_inputs_return_nan(
+    calculated: jnp.ndarray,
+) -> None:
+    assert math.isnan(float(calculated))
+
+
+@pytest.mark.parametrize(
+    ("evaluator", "value"),
+    (
+        (lambda value: h2_hirschmann2012(value, 1.0), 1000.0),
+        (h2o_lichtenberg2021, 1.0e7),
+        (co2_lichtenberg2021, 1.0e8),
+        (co_yoshioka2019, 1.0),
+        (lambda value: ch4_ardia2013(value, 1.0), 1.0),
+        (
+            lambda value: n2_dasgupta2022(value, 2000.0, 4.0, -2.0),
+            0.1,
+        ),
+    ),
+)
+def test_laws_support_jit_and_automatic_differentiation(
+    evaluator,
+    value: float,
+) -> None:
+    calculated = jax.jit(evaluator)(value)
+    derivative = jax.grad(evaluator)(value)
+
+    assert jnp.isfinite(calculated)
+    assert jnp.isfinite(derivative)
+
+
+@pytest.mark.parametrize(
+    "evaluator",
+    (
+        h2o_lichtenberg2021,
+        co_yoshioka2019,
+        lambda value: n2_dasgupta2022(value, 2000.0, 1.0, 0.0),
+    ),
+)
+def test_fractional_power_derivative_is_singular_at_zero(evaluator) -> None:
+    assert jnp.isinf(jax.grad(evaluator)(0.0))
+
+
+def test_metadata_records_native_bases_and_provenance() -> None:
+    expected_bases = {
+        "h2_hirschmann2012": "mole_fraction",
+        "h2o_lichtenberg2021": "mass_fraction",
+        "co2_lichtenberg2021": "mass_fraction",
+        "co_yoshioka2019": "mass_fraction",
+        "ch4_ardia2013": "mole_fraction",
+        "n2_dasgupta2022": "mass_fraction",
+    }
+
+    assert {
+        name: metadata.output_basis
+        for name, metadata in MELTYQ_SOLUBILITY_METADATA.items()
+    } == expected_bases
+    assert all(
+        metadata.experimental_doi
+        and metadata.formulation_doi
+        and metadata.implementation_doi
+        for metadata in MELTYQ_SOLUBILITY_METADATA.values()
+    )
+    co_notes = MELTYQ_SOLUBILITY_METADATA["co_yoshioka2019"].notes
+    ch4_notes = MELTYQ_SOLUBILITY_METADATA["ch4_ardia2013"].notes
+    n2_notes = MELTYQ_SOLUBILITY_METADATA["n2_dasgupta2022"].notes
+    assert "-7.2" in co_notes and "bar" in co_notes
+    assert (
+        MELTYQ_SOLUBILITY_METADATA["co_yoshioka2019"].output_quantity
+        == "elemental C dissolved as CO"
+    )
+    assert "GPa" in ch4_notes
+    assert "sqrt(melt pressure)" in n2_notes
+    assert (
+        MELTYQ_SOLUBILITY_METADATA["n2_dasgupta2022"].output_quantity
+        == "total elemental N"
+    )
+
+
+def test_package_exports_are_explicit_and_unique() -> None:
+    expected_exports = (
+        "MELTYQ_SOLUBILITY_METADATA",
+        "SolubilityMetadata",
+        "ch4_ardia2013",
+        "co2_lichtenberg2021",
+        "co_yoshioka2019",
+        "h2_hirschmann2012",
+        "h2o_lichtenberg2021",
+        "n2_dasgupta2022",
+    )
+
+    assert solubility.__all__ == expected_exports
+    assert meltyq.__all__ == expected_exports
+
+
+def test_metadata_mapping_is_read_only() -> None:
+    with pytest.raises(TypeError):
+        MELTYQ_SOLUBILITY_METADATA["new_law"] = MELTYQ_SOLUBILITY_METADATA[
+            "h2_hirschmann2012"
+        ]


### PR DESCRIPTION
## Summary

- add an independent `exogibbs.solubility` auxiliary package with the six empirical laws selected by MELTYQ
- expose stateless JAX functions with explicit native units, broadcasting, JIT, and autodiff support
- add immutable calibration and provenance metadata, focused regression tests, and user documentation
- keep solubility outside the Gibbs minimization core and `exogibbs.api`

## Motivation

Magma-atmosphere boundary calculations need volatile-solubility fits, but those empirical fits are not part of ExoGibbs' core Gibbs-energy minimization responsibility. This change gives them a focused, separately importable package.

## Scientific provenance

Where the MELTYQ appendix conflicts with its cited sources, the implementation follows the source-consistent form and records the discrepancy in metadata:

- CO uses fugacity in bar and the corrected `-7.2` elemental-carbon mass-fraction intercept
- CH4 uses fugacity in GPa
- the nitrogen law uses the square root of total melt pressure and returns total elemental-N mass fraction

The nitrogen API accepts `delta_iw` directly; an IW-buffer calibration remains outside this initial scope.

## Validation

- `pytest -q tests/unittests`: 616 passed
- `JAX_ENABLE_X64=0 JAX_PLATFORMS=cpu JAX_PLATFORM_NAME=cpu pytest -q tests/unittests/solubility/meltyq_test.py`: 43 passed
- `./update_doc.sh`: build succeeded (83 pre-existing warnings)
- `git diff --check`: passed
