### PR TITLE
equilibrium: add pure fugacity coefficient support

### DIFF
--- a/documents/equilibrium_solvers.rst
+++ b/documents/equilibrium_solvers.rst
@@ -59,6 +59,44 @@ vector, the full condensate vector, the accepted active-support indices and
 names, status, route, and optional diagnostics.  Common dense arrays are also
 available in ``result.batched_arrays``.
 
+Pure-component non-ideal gas correction
+---------------------------------------
+
+Both solver modules accept an optional ``lnphi_func`` keyword:
+
+.. code-block:: python
+
+   def lnphi_func(temperature, pressure_bar, mole_fractions):
+       # Return one natural-log fugacity coefficient per gas species.
+       assert mole_fractions is None  # pure-component mode
+       return lnphi_pure
+
+   result = solve(
+       setup,
+       T=temperature,
+       P=pressure_bar,
+       b=element_vector,
+       lnphi_func=lnphi_func,
+   )
+
+The returned vector must be dimensionless, have shape ``(K,)``, and follow
+``setup.species`` order.  ``pressure_bar`` is the physical pressure in bar,
+independent of ``Pref``.  ExoGibbs adds the correction once to the standard
+gas source,
+
+.. math::
+
+   h_k^{\mathrm{eff}}(T,P)
+   = h_k^{\mathrm{ideal}}(T) + \ln \phi_k^{\mathrm{pure}}(T,P).
+
+Omitting ``lnphi_func`` preserves ideal-gas behavior.  The third callable
+argument reserves the composition-dependent interface; the current
+pure-component implementation always passes ``None``.  Mixture fugacity
+coefficients are not yet supported because their composition derivatives must
+be included in the equilibrium Jacobian rather than evaluated once and held
+fixed.  The gas solver's custom reverse-mode derivative includes the
+temperature and pressure dependence of a JAX-differentiable callback.
+
 Condensate Rainout
 ------------------
 

--- a/documents/index.rst
+++ b/documents/index.rst
@@ -46,6 +46,12 @@ Contents
 
 .. toctree::
    :maxdepth: 1
+   :caption: OPTIONAL EXAMPLES:
+
+   examples/index
+
+.. toctree::
+   :maxdepth: 1
    :caption: VJP RETRIEVALS:
 
    ipynb/exojax_nuts_gas_no_grid

--- a/examples/plot_exoeos_pure_fugacity.py
+++ b/examples/plot_exoeos_pure_fugacity.py
@@ -1,0 +1,245 @@
+"""Pure-component fugacity corrections with ExoEOS
+====================================================
+
+This example connects the optional `ExoEOS <https://github.com/HajimeKawahara/exoeos>`_
+package to the gas-equilibrium solver through ``lnphi_func``.  ExoGibbs keeps
+pressure in bar, while ExoEOS expects Pa, so the unit conversion belongs in the
+adapter.  The callback returns natural-log, dimensionless fugacity coefficients
+in exactly the same order as ``ChemicalSetup.species``.
+
+The seven-species setup below deliberately uses zero standard-state chemical
+potentials.  It is a compact demonstration of the fugacity interface, not a
+thermochemical abundance model.  Consequently, the difference between the two
+solutions isolates the pure-component fugacity correction.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import jax
+from jax import config
+import jax.numpy as jnp
+import matplotlib.pyplot as plt
+import numpy as np
+
+from exogibbs.api.chemistry import ChemicalSetup
+from exogibbs.api.gas import (
+    EquilibriumOptions,
+    LogFugacityCoefficientFunction,
+    solve,
+)
+
+
+config.update("jax_enable_x64", True)
+
+SPECIES = ("CH4", "H2O", "CO2", "H2", "CO", "O2", "C2H6")
+ELEMENTS = ("C", "H", "O")
+FORMULA_MATRIX = jnp.asarray(
+    [
+        [1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 2.0],
+        [4.0, 2.0, 0.0, 2.0, 0.0, 0.0, 6.0],
+        [0.0, 1.0, 2.0, 0.0, 1.0, 2.0, 0.0],
+    ],
+    dtype=jnp.float64,
+)
+ELEMENT_INVENTORY = jnp.asarray([1.0, 4.0, 2.0], dtype=jnp.float64)
+TEMPERATURE_K = 1500.0
+PRESSURES_BAR = jnp.geomspace(100.0, 5000.0, 6)
+BAR_TO_PA = 1.0e5
+
+_EXOEOS_INSTALL_HINT = (
+    "Install a current ExoEOS checkout with "
+    "`python -m pip install -e /path/to/exoeos` to run this optional example."
+)
+
+try:
+    from exoeos import ZhangDuanEOS, state_tp
+except ImportError as exc:
+    ZhangDuanEOS = None
+    state_tp = None
+    _EXOEOS_IMPORT_ERROR: Optional[ImportError] = exc
+else:
+    _EXOEOS_IMPORT_ERROR = None
+
+
+# %%
+# Build a deliberately small ExoGibbs problem
+# --------------------------------------------
+#
+# Both the thermochemical vector and the EOS component arrays follow ``SPECIES``
+# order.  Keeping that mapping explicit is important because ExoEOS EOS objects
+# store numerical component arrays, not species labels.
+
+
+def build_reduced_setup() -> ChemicalSetup:
+    """Return the seven-species illustrative C-H-O setup."""
+
+    def hvector_func(temperature: Any) -> jax.Array:
+        dtype = jnp.result_type(jnp.asarray(temperature), jnp.float64)
+        return jnp.zeros((len(SPECIES),), dtype=dtype)
+
+    return ChemicalSetup(
+        formula_matrix=FORMULA_MATRIX,
+        hvector_func=hvector_func,
+        elements=ELEMENTS,
+        species=SPECIES,
+        element_vector_reference=ELEMENT_INVENTORY,
+        metadata={
+            "source": "illustrative zero standard-state chemical potentials",
+            "nonideal_backend": "optional ExoEOS Zhang-Duan 2009",
+        },
+    )
+
+
+# %%
+# Adapt the ExoEOS pure-component states
+# --------------------------------------
+#
+# ``state_tp`` evaluates one scalar state.  Mapping it over the pure-composition
+# basis evaluates every species at the same temperature and pressure.  At
+# ``x=e_i``, ``gres_RT = x @ lnphi`` is exactly ``ln(phi_i_pure)``, so the scalar
+# ``gres_RT`` field directly produces the desired vector without materializing
+# a matrix of all cross-component fugacity coefficients.
+
+
+def make_pure_lnphi_func(eos: Any) -> LogFugacityCoefficientFunction:
+    """Return an ExoGibbs-compatible pure-component ExoEOS callback."""
+
+    pure_compositions = jnp.eye(len(SPECIES), dtype=jnp.float64)
+
+    def lnphi_func(
+        temperature: Any,
+        pressure_bar: Any,
+        mole_fractions: Optional[jax.Array],
+    ) -> jax.Array:
+        if mole_fractions is not None:
+            raise ValueError(
+                "This example implements pure-component fugacity only; "
+                "mole_fractions must be None."
+            )
+        pressure_pa = jnp.asarray(pressure_bar) * BAR_TO_PA
+        return jax.vmap(
+            lambda pure_x: state_tp(
+                eos,
+                temperature,
+                pressure_pa,
+                pure_x,
+                phase="vapor",
+            ).gres_RT
+        )(pure_compositions)
+
+    return lnphi_func
+
+
+def solve_pressure_profile(
+    setup: ChemicalSetup,
+    pressures_bar: jax.Array,
+    *,
+    lnphi_func: Optional[LogFugacityCoefficientFunction] = None,
+) -> jax.Array:
+    """Solve independent layers and return their gas mole fractions."""
+
+    options = EquilibriumOptions(epsilon_crit=1.0e-11, max_iter=1000)
+    compositions = []
+    for pressure_bar in np.asarray(pressures_bar, dtype=np.float64):
+        result = solve(
+            setup,
+            TEMPERATURE_K,
+            pressure_bar,
+            ELEMENT_INVENTORY,
+            Pref=1.0,
+            options=options,
+            lnphi_func=lnphi_func,
+        )
+        compositions.append(result.x)
+    return jnp.stack(compositions)
+
+
+# %%
+# Compare ideal and pure-fugacity solutions
+# -----------------------------------------
+
+
+def main() -> None:
+    """Run the optional ExoEOS comparison and draw the gallery figure."""
+
+    if _EXOEOS_IMPORT_ERROR is not None:
+        print(f"Skipping the ExoEOS fugacity example. {_EXOEOS_INSTALL_HINT}")
+        print(f"Original import error: {_EXOEOS_IMPORT_ERROR}")
+        return
+
+    setup = build_reduced_setup()
+    eos = ZhangDuanEOS.from_species(SPECIES)
+    lnphi_func = make_pure_lnphi_func(eos)
+
+    ideal_x = solve_pressure_profile(setup, PRESSURES_BAR)
+    nonideal_x = solve_pressure_profile(
+        setup,
+        PRESSURES_BAR,
+        lnphi_func=lnphi_func,
+    )
+    pure_lnphi = jax.vmap(
+        lambda pressure_bar: lnphi_func(
+            TEMPERATURE_K,
+            pressure_bar,
+            None,
+        )
+    )(PRESSURES_BAR)
+
+    highest_pressure = float(PRESSURES_BAR[-1])
+    print(f"T = {TEMPERATURE_K:.0f} K, P = {highest_pressure:.0f} bar")
+    print("species      ideal x       pure-fugacity x       ln(phi_pure)")
+    for index, species in enumerate(SPECIES):
+        print(
+            f"{species:>5s}  "
+            f"{float(ideal_x[-1, index]):12.5e}  "
+            f"{float(nonideal_x[-1, index]):17.5e}  "
+            f"{float(pure_lnphi[-1, index]):13.6f}"
+        )
+
+    figure, axes = plt.subplots(1, 2, figsize=(11.0, 4.2))
+    colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
+    for index, species in enumerate(SPECIES):
+        color = colors[index % len(colors)]
+        axes[0].plot(
+            PRESSURES_BAR,
+            ideal_x[:, index],
+            linestyle="--",
+            color=color,
+            alpha=0.7,
+        )
+        axes[0].plot(
+            PRESSURES_BAR,
+            nonideal_x[:, index],
+            label=species,
+            color=color,
+        )
+        axes[1].plot(
+            PRESSURES_BAR,
+            pure_lnphi[:, index],
+            label=species,
+            color=color,
+        )
+
+    axes[0].plot([], [], "k--", label="ideal")
+    axes[0].plot([], [], "k-", label="pure fugacity")
+    axes[0].set_xscale("log")
+    axes[0].set_yscale("log")
+    axes[0].set_xlabel("Pressure (bar)")
+    axes[0].set_ylabel("Gas mole fraction")
+    axes[0].set_title("ExoGibbs equilibrium")
+    axes[0].legend(fontsize=8, ncol=3)
+
+    axes[1].set_xscale("log")
+    axes[1].axhline(0.0, color="0.5", linewidth=0.8)
+    axes[1].set_xlabel("Pressure (bar)")
+    axes[1].set_ylabel(r"$\ln(\phi_i^{\mathrm{pure}})$")
+    axes[1].set_title("Zhang-Duan pure-component correction")
+    axes[1].legend(fontsize=8, ncol=2)
+    figure.tight_layout()
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/exogibbs/api/__init__.py
+++ b/src/exogibbs/api/__init__.py
@@ -3,7 +3,11 @@
 from importlib import import_module
 from typing import Final
 
-from .chemistry import ChemicalSetup, ThermoState
+from .chemistry import (
+    ChemicalSetup,
+    LogFugacityCoefficientFunction,
+    ThermoState,
+)
 
 
 _MODULE_EXPORTS: Final = {
@@ -107,6 +111,7 @@ _ATTRIBUTE_EXPORTS: Final = {
 
 __all__ = [
     "ChemicalSetup",
+    "LogFugacityCoefficientFunction",
     "ThermoState",
     "condensate",
     "condensate_equilibrium",

--- a/src/exogibbs/api/chemistry.py
+++ b/src/exogibbs/api/chemistry.py
@@ -7,6 +7,7 @@ from exogibbs.thermo.composition import (
     element_indices_by_name,
     update_element_vector,
 )
+from exogibbs.thermo.fugacity import LogFugacityCoefficientFunction
 from exogibbs.thermo.models import ChemicalSetup, setup_float_dtype
 
 
@@ -16,6 +17,7 @@ Array = jnp.ndarray
 __all__ = (
     "Array",
     "ChemicalSetup",
+    "LogFugacityCoefficientFunction",
     "ThermoState",
     "element_indices_by_name",
     "setup_float_dtype",

--- a/src/exogibbs/api/condensate.py
+++ b/src/exogibbs/api/condensate.py
@@ -28,6 +28,7 @@ from exogibbs.equilibrium.condensate.types import (
     CondensateFixedSupportV2Preset,
     CondensateProfileMethod,
 )
+from exogibbs.thermo.fugacity import LogFugacityCoefficientFunction
 
 
 solve = condensate_equilibrium
@@ -51,6 +52,7 @@ __all__ = (
     "DefaultCondensateEquilibriumInitializer",
     "FixedSupportCondensateEquilibriumGrid",
     "GridCondensateEquilibriumInitializer",
+    "LogFugacityCoefficientFunction",
     "build_condensate_chemical_setup",
     "solve",
     "solve_profile",

--- a/src/exogibbs/api/equilibrium.py
+++ b/src/exogibbs/api/equilibrium.py
@@ -20,6 +20,7 @@ from exogibbs.equilibrium.gas.types import (
     EquilibriumOptions,
     EquilibriumResult,
 )
+from exogibbs.thermo.fugacity import LogFugacityCoefficientFunction
 
 __all__ = (
     "DefaultEquilibriumInitializer",
@@ -30,6 +31,7 @@ __all__ = (
     "EquilibriumResult",
     "GridEquilibriumInitializer",
     "LearnedEquilibriumInitializer",
+    "LogFugacityCoefficientFunction",
     "equilibrium",
     "equilibrium_profile",
 )

--- a/src/exogibbs/api/gas.py
+++ b/src/exogibbs/api/gas.py
@@ -16,6 +16,7 @@ from exogibbs.equilibrium.gas.types import (
     EquilibriumOptions,
     EquilibriumResult,
 )
+from exogibbs.thermo.fugacity import LogFugacityCoefficientFunction
 
 
 solve = equilibrium
@@ -31,6 +32,7 @@ __all__ = (
     "EquilibriumResult",
     "GridEquilibriumInitializer",
     "LearnedEquilibriumInitializer",
+    "LogFugacityCoefficientFunction",
     "solve",
     "solve_profile",
 )

--- a/src/exogibbs/equilibrium/condensate/lifecycle.py
+++ b/src/exogibbs/equilibrium/condensate/lifecycle.py
@@ -61,6 +61,10 @@ from exogibbs.equilibrium.condensate.types import (
     HeadV2LayerState,
 )
 from exogibbs.equilibrium.gas.types import EquilibriumInit, ThermoState
+from exogibbs.thermo.fugacity import (
+    LogFugacityCoefficientFunction,
+    effective_gas_hvector,
+)
 
 
 _ExperimentalProfileFixedSupportBatchPlan = (
@@ -393,6 +397,7 @@ def _native_activity_expanded_profile_support_payload(
     activity_gas_ntot: Sequence[float] | Array | float | None = None,
     activity_gas_stationarity_source: Sequence[float] | Array | None = None,
     gas_equilibrium_init: EquilibriumInit | None = None,
+    lnphi_func: LogFugacityCoefficientFunction | None = None,
 ) -> tuple[tuple[int, ...], tuple[float, ...], Mapping[str, Any]]:
     from exogibbs.equilibrium.gas.solve import equilibrium
     from exogibbs.equilibrium.gas.types import EquilibriumOptions
@@ -428,9 +433,14 @@ def _native_activity_expanded_profile_support_payload(
                     gas_ntot = jnp.sum(jnp.exp(candidate_ln_n))
                 else:
                     gas_ntot = jnp.asarray(activity_gas_ntot, dtype=jnp.float64)
-                gas_stationarity_source = setup.gas_setup.hvector_func(float(T)) + (
-                    _ln_normalized_pressure(P, Pref)
-                ) - jnp.log(jnp.clip(gas_ntot, 1.0e-300))
+                gas_stationarity_source = effective_gas_hvector(
+                    setup.gas_setup,
+                    float(T),
+                    float(P),
+                    lnphi_func,
+                ) + _ln_normalized_pressure(P, Pref) - jnp.log(
+                    jnp.clip(gas_ntot, 1.0e-300)
+                )
     if gas_ln_n_for_activity is None or gas_stationarity_source is None:
         activity_source = "gas_only_full_budget"
         gas_result = equilibrium(
@@ -442,11 +452,17 @@ def _native_activity_expanded_profile_support_payload(
             init=gas_equilibrium_init,
             options=EquilibriumOptions(),
             return_diagnostics=False,
+            lnphi_func=lnphi_func,
         )
         gas_ln_n_for_activity = jnp.asarray(gas_result.ln_n, dtype=jnp.float64)
-        gas_stationarity_source = setup.gas_setup.hvector_func(float(T)) + (
-            _ln_normalized_pressure(P, Pref)
-        ) - jnp.log(jnp.asarray(gas_result.ntot, dtype=jnp.float64))
+        gas_stationarity_source = effective_gas_hvector(
+            setup.gas_setup,
+            float(T),
+            float(P),
+            lnphi_func,
+        ) + _ln_normalized_pressure(P, Pref) - jnp.log(
+            jnp.asarray(gas_result.ntot, dtype=jnp.float64)
+        )
     element_potential = _least_squares_element_potential(
         formula_matrix=setup.formula_matrix,
         gas_ln_n=gas_ln_n_for_activity,
@@ -603,6 +619,7 @@ def _head_v2_best_residual_element_potential(
     gas_ln_n: Array,
     total_gas_log_amount: Array,
     epsilon: float,
+    lnphi_func: LogFugacityCoefficientFunction | None = None,
 ) -> Array:
     """Return the validated global best-residual multiplier initializer."""
 
@@ -615,7 +632,13 @@ def _head_v2_best_residual_element_potential(
     r = jnp.log(jnp.asarray(support_amounts, dtype=jnp.float64))
     qtot = jnp.asarray(total_gas_log_amount, dtype=jnp.float64)
     gamma = jnp.asarray(
-        setup.gas_setup.hvector_func(float(T)), dtype=jnp.float64
+        effective_gas_hvector(
+            setup.gas_setup,
+            float(T),
+            float(P),
+            lnphi_func,
+        ),
+        dtype=jnp.float64,
     ) + _ln_normalized_pressure(P, Pref)
     hcond = jnp.asarray(
         setup.condensate_setup.hvector_func(float(T)), dtype=jnp.float64
@@ -701,6 +724,7 @@ def _head_v2_initial_state(
     support_amounts: Sequence[float],
     initial_guess: CondensateEquilibriumInit | None,
     first_epsilon: float,
+    lnphi_func: LogFugacityCoefficientFunction | None = None,
 ) -> _HeadV2LayerState:
     """Build one v2 lifecycle state from gas equilibrium and support seeds."""
 
@@ -719,6 +743,7 @@ def _head_v2_initial_state(
             Pref=Pref,
             options=EquilibriumOptions(),
             return_diagnostics=False,
+            lnphi_func=lnphi_func,
         )
         q = jnp.asarray(gas_result.ln_n, dtype=jnp.float64)
         qtot = jnp.log(jnp.asarray(gas_result.ntot, dtype=jnp.float64))
@@ -749,6 +774,7 @@ def _head_v2_initial_state(
             gas_ln_n=q,
             total_gas_log_amount=qtot,
             epsilon=first_epsilon,
+            lnphi_func=lnphi_func,
         )
     else:
         element_potential = jnp.asarray(
@@ -780,6 +806,7 @@ def _head_v2_prepared_buckets(
     states: Sequence[_HeadV2LayerState],
     fixed_shape: Any | None = None,
     source_layer_indices: Sequence[int] | None = None,
+    lnphi_func: LogFugacityCoefficientFunction | None = None,
 ) -> tuple[Any, ...]:
     """Prepare pending v2 lifecycle states with an optional fixed shape."""
 
@@ -810,10 +837,15 @@ def _head_v2_prepared_buckets(
         hvector_by_layer=jnp.stack(
             [
                 jnp.asarray(
-                    setup.gas_setup.hvector_func(float(temperature)),
+                    effective_gas_hvector(
+                        setup.gas_setup,
+                        float(temperature),
+                        float(pressure),
+                        lnphi_func,
+                    ),
                     dtype=jnp.float64,
                 )
-                for temperature in temperatures
+                for temperature, pressure in zip(temperatures, pressures)
             ]
         ),
         hvector_cond_by_layer=jnp.stack(
@@ -894,6 +926,7 @@ def _run_head_v2_profile(
     support_amounts_init: Sequence[float] | None,
     options: CondensateEquilibriumOptions,
     return_diagnostics: bool,
+    lnphi_func: LogFugacityCoefficientFunction | None = None,
 ) -> CondensateEquilibriumProfileResult:
     """Run the production v2 route and its external support lifecycle."""
 
@@ -1041,6 +1074,7 @@ def _run_head_v2_profile(
             activity_gas_ntot=None,
             activity_gas_stationarity_source=None,
             gas_equilibrium_init=gas_equilibrium_init,
+            lnphi_func=lnphi_func,
         )
         base_amount_by_index = {
             int(index): float(amount)
@@ -1068,6 +1102,7 @@ def _run_head_v2_profile(
                 first_epsilon=(
                     policy.solver_config.continuation.epsilon_schedule[0]
                 ),
+                lnphi_func=lnphi_func,
             )
             continue
         pending[layer_index] = _head_v2_initial_state(
@@ -1080,6 +1115,7 @@ def _run_head_v2_profile(
             support_amounts=initial_amounts,
             initial_guess=initial_guess,
             first_epsilon=policy.solver_config.continuation.epsilon_schedule[0],
+            lnphi_func=lnphi_func,
         )
 
     def polish_layer_state(
@@ -1098,7 +1134,12 @@ def _run_head_v2_profile(
             condensate_formula_matrix_full=setup.formula_matrix_cond,
             target_inventory=b,
             gas_standard_source=(
-                setup.gas_setup.hvector_func(temperature)
+                effective_gas_hvector(
+                    setup.gas_setup,
+                    temperature,
+                    float(pressures[layer_index]),
+                    lnphi_func,
+                )
                 + _ln_normalized_pressure(
                     float(pressures[layer_index]), Pref
                 )
@@ -1141,7 +1182,12 @@ def _run_head_v2_profile(
                 caller_inventory, dtype=np.float64
             ),
             gas_standard_source=np.asarray(
-                setup.gas_setup.hvector_func(temperature)
+                effective_gas_hvector(
+                    setup.gas_setup,
+                    temperature,
+                    float(pressures[layer_index]),
+                    lnphi_func,
+                )
                 + _ln_normalized_pressure(
                     float(pressures[layer_index]), Pref
                 ),
@@ -1277,6 +1323,7 @@ def _run_head_v2_profile(
                 ),
                 fixed_shape=fixed_batch_shape,
                 source_layer_indices=source_indices,
+                lnphi_func=lnphi_func,
             ),
             formula_matrix=setup.formula_matrix,
             layer_count=len(source_indices),
@@ -1309,6 +1356,7 @@ def _run_head_v2_profile(
             states=round_states,
             fixed_shape=fixed_batch_shape,
             source_layer_indices=source_indices,
+            lnphi_func=lnphi_func,
         )
         hcond_full = jnp.stack(
             [
@@ -1671,6 +1719,7 @@ def _run_head_v2_profile(
                 init=gas_equilibrium_init,
                 options=EquilibriumOptions(),
                 return_diagnostics=False,
+                lnphi_func=lnphi_func,
             )
             result = _build_empty_support_gas_result(
                 setup=setup,
@@ -1958,6 +2007,7 @@ def _prepare_experimental_profile_fixed_support_batch_plan(
     support_amounts_init: Optional[Sequence[float]],
     max_iter: int,
     min_seed_amount: float,
+    lnphi_func: LogFugacityCoefficientFunction | None = None,
 ) -> _ExperimentalProfileFixedSupportBatchPlan | None:
     n_layers = int(temperatures.shape[0])
     solver_inits = []
@@ -2023,18 +2073,34 @@ def _prepare_experimental_profile_fixed_support_batch_plan(
     )
 
     temperature_array = jnp.asarray(temperatures, dtype=jnp.float64)
-    hvector_by_layer = jnp.asarray(
-        setup.gas_setup.hvector_func(temperature_array),
-        dtype=jnp.float64,
-    )
-    if hvector_by_layer.ndim != 2 or hvector_by_layer.shape[0] != n_layers:
+    if lnphi_func is None:
+        hvector_by_layer = jnp.asarray(
+            setup.gas_setup.hvector_func(temperature_array),
+            dtype=jnp.float64,
+        )
+        if hvector_by_layer.ndim != 2 or hvector_by_layer.shape[0] != n_layers:
+            hvector_by_layer = jnp.stack(
+                [
+                    jnp.asarray(
+                        setup.gas_setup.hvector_func(float(temperature)),
+                        dtype=jnp.float64,
+                    )
+                    for temperature in temperatures
+                ]
+            )
+    else:
         hvector_by_layer = jnp.stack(
             [
                 jnp.asarray(
-                    setup.gas_setup.hvector_func(float(temperature)),
+                    effective_gas_hvector(
+                        setup.gas_setup,
+                        float(temperature),
+                        float(pressure),
+                        lnphi_func,
+                    ),
                     dtype=jnp.float64,
                 )
-                for temperature in temperatures
+                for temperature, pressure in zip(temperatures, pressures)
             ]
         )
     hvector_cond_by_layer = jnp.asarray(
@@ -2098,6 +2164,7 @@ def prepare_experimental_profile_fixed_support_batch_plan(
     initializer: Optional[CondensateEquilibriumInitializer] = None,
     max_iter: int = 100,
     min_seed_amount: float = 1.0e-300,
+    lnphi_func: LogFugacityCoefficientFunction | None = None,
 ) -> ExperimentalCondensateProfileFixedSupportBatchPlan:
     """Prepare a reusable experimental fixed-support batch profile plan.
 
@@ -2140,6 +2207,7 @@ def prepare_experimental_profile_fixed_support_batch_plan(
         support_amounts_init=support_amounts_init,
         max_iter=int(max_iter),
         min_seed_amount=float(min_seed_amount),
+        lnphi_func=lnphi_func,
     )
     if plan is None:
         raise ValueError(

--- a/src/exogibbs/equilibrium/condensate/profile.py
+++ b/src/exogibbs/equilibrium/condensate/profile.py
@@ -29,6 +29,7 @@ from exogibbs.equilibrium.condensate.types import (
     CondensateEquilibriumProfileResult,
     CondensateEquilibriumResult,
 )
+from exogibbs.thermo.fugacity import LogFugacityCoefficientFunction
 
 
 def _validate_rainout_inventory(
@@ -885,6 +886,7 @@ def run_rainout_profile(
     support_amounts_init: Optional[Sequence[float]],
     options: CondensateEquilibriumOptions,
     return_diagnostics: bool,
+    lnphi_func: LogFugacityCoefficientFunction | None = None,
 ) -> CondensateEquilibriumProfileResult:
     """Run dependent equilibrium layers from the bottom of a profile.
 
@@ -1003,6 +1005,7 @@ def run_rainout_profile(
                         ),
                         options=options,
                         return_diagnostics=return_diagnostics,
+                        lnphi_func=lnphi_func,
                     )
                 except (FloatingPointError, OverflowError) as error:
                     attempts.append(

--- a/src/exogibbs/equilibrium/condensate/solve.py
+++ b/src/exogibbs/equilibrium/condensate/solve.py
@@ -38,6 +38,7 @@ from exogibbs.equilibrium.condensate.types import (
     CondensateProfileMethod,
     ExperimentalCondensateProfileFixedSupportBatchPlan,
 )
+from exogibbs.thermo.fugacity import LogFugacityCoefficientFunction
 
 
 # Supported compatibility helpers remain reachable from the historical API.
@@ -78,8 +79,13 @@ def condensate_equilibrium(
     init: Optional[CondensateEquilibriumInit] = None,
     initializer: Optional[CondensateEquilibriumInitializer] = None,
     options: Optional[CondensateEquilibriumOptions] = None,
+    lnphi_func: LogFugacityCoefficientFunction | None = None,
 ) -> CondensateEquilibriumResult:
-    """Compute one layer through the production fixed-support v2 route."""
+    """Compute one layer through the production fixed-support v2 route.
+
+    ``lnphi_func`` receives ``(T, P_bar, None)`` and returns natural-log
+    fugacity coefficients in gas-species order for the current pure mode.
+    """
 
     opts = options or CondensateEquilibriumOptions()
     validate_condensate_chemical_setup(setup)
@@ -101,6 +107,7 @@ def condensate_equilibrium(
         support_amounts_init=support_amounts_init,
         options=opts,
         return_diagnostics=opts.return_diagnostics,
+        lnphi_func=lnphi_func,
     )
     return profile.layers[0]
 
@@ -119,8 +126,13 @@ def condensate_equilibrium_profile(
     options: Optional[CondensateEquilibriumOptions] = None,
     method: Optional[CondensateProfileMethod] = None,
     return_diagnostics: bool = False,
+    lnphi_func: LogFugacityCoefficientFunction | None = None,
 ) -> CondensateEquilibriumProfileResult:
-    """Compute a 1D profile through the production v2 lifecycle."""
+    """Compute a 1D profile through the production v2 lifecycle.
+
+    ``lnphi_func`` receives ``(T, P_bar, None)`` and returns natural-log
+    fugacity coefficients in gas-species order for the current pure mode.
+    """
 
     validate_condensate_chemical_setup(setup)
     temperatures = np.asarray(T, dtype=np.float64)
@@ -167,6 +179,7 @@ def condensate_equilibrium_profile(
             return_diagnostics=(
                 return_diagnostics or opts.return_diagnostics
             ),
+            lnphi_func=lnphi_func,
         )
     if requested_method not in {None, "auto", "vmap_cold"}:
         raise ValueError(
@@ -186,6 +199,7 @@ def condensate_equilibrium_profile(
         support_amounts_init=support_amounts_init,
         options=opts,
         return_diagnostics=return_diagnostics or opts.return_diagnostics,
+        lnphi_func=lnphi_func,
     )
 
 
@@ -211,6 +225,7 @@ __all__ = (
     "ExperimentalCondensateProfileFixedSupportBatchPlan",
     "FixedSupportCondensateEquilibriumGrid",
     "GridCondensateEquilibriumInitializer",
+    "LogFugacityCoefficientFunction",
     "build_condensate_chemical_setup",
     "build_condensate_equilibrium_result_from_solver_payload",
     "condensate_equilibrium",

--- a/src/exogibbs/equilibrium/gas/kernel/autodiff.py
+++ b/src/exogibbs/equilibrium/gas/kernel/autodiff.py
@@ -43,6 +43,29 @@ def vjp_temperature(
 
 
 @jit
+def vjp_hvector(
+    gvector: jnp.ndarray,
+    nspecies: jnp.ndarray,
+    formula_matrix: jnp.ndarray,
+    alpha_vector: jnp.ndarray,
+    beta_vector: jnp.ndarray,
+    element_vector: jnp.ndarray,
+    beta_dot_b_element: float,
+) -> jnp.ndarray:
+    """Compute the vector-Jacobian product for an evaluated hvector."""
+
+    dqtot_dh = (
+        nspecies * (formula_matrix.T @ beta_vector - 1.0) / beta_dot_b_element
+    )
+    return (
+        dqtot_dh
+        * (jnp.sum(gvector) - jnp.vdot(alpha_vector, element_vector))
+        + nspecies * (formula_matrix.T @ alpha_vector)
+        - gvector
+    )
+
+
+@jit
 def vjp_pressure(
     gvector: jnp.ndarray,
     ntot: jnp.ndarray,

--- a/src/exogibbs/equilibrium/gas/kernel/solver.py
+++ b/src/exogibbs/equilibrium/gas/kernel/solver.py
@@ -1,25 +1,35 @@
 import math
 import time
+from functools import partial
+from typing import Any, Callable, Dict, Tuple, Union
 
 import jax
 import jax.numpy as jnp
 import numpy as np
 from jax import custom_vjp
-from jax import jacrev
 from jax.lax import while_loop, stop_gradient
 from jax.scipy.linalg import cho_factor
 from jax.scipy.linalg import cho_solve
-from functools import partial
-from typing import Any, Tuple, Callable, Dict
 
 from exogibbs.equilibrium.gas.types import ThermoState
 from exogibbs.equilibrium.gas.kernel.equations import _A_diagn_At
 from exogibbs.equilibrium.gas.kernel.equations import _compute_gk
 from exogibbs.equilibrium.gas.kernel.autodiff import vjp_elements
+from exogibbs.equilibrium.gas.kernel.autodiff import vjp_hvector
 from exogibbs.equilibrium.gas.kernel.autodiff import vjp_pressure
-from exogibbs.equilibrium.gas.kernel.autodiff import vjp_temperature
 
 _CHO_EPS = 1.0e-18
+
+
+def _evaluate_hvector_source(
+    state: ThermoState,
+    hvector_source: Any,
+) -> jnp.ndarray:
+    """Evaluate a legacy callable source or accept an already evaluated vector."""
+
+    if callable(hvector_source):
+        return hvector_source(state.temperature)
+    return jnp.asarray(hvector_source)
 
 
 def build_minimize_gibbs_core_lnnk_output_source_trace(
@@ -445,7 +455,7 @@ def trace_minimize_gibbs_core_update_all_lnnk_new_source_components(
 ) -> dict[str, Any]:
     """Replay the core loop in Python and trace final ln_nk_new source terms."""
 
-    hvector = hvector_func(state.temperature)
+    hvector = _evaluate_hvector_source(state, hvector_func)
     gk = _compute_gk(
         state.temperature,
         ln_nk_init,
@@ -1022,7 +1032,7 @@ def profile_minimize_gibbs_iterations(
     apply_step = jax.jit(_apply_iteration_step)
     eval_state = jax.jit(_evaluate_iteration_state)
 
-    hvector = hvector_func(state.temperature)
+    hvector = _evaluate_hvector_source(state, hvector_func)
     _block(hvector)
 
     gk = _compute_gk(
@@ -1178,7 +1188,7 @@ def minimize_gibbs_core(
             - Final residual norm used in convergence checks.
     """
 
-    hvector = hvector_func(state.temperature)
+    hvector = _evaluate_hvector_source(state, hvector_func)
 
     gk = _compute_gk(
         state.temperature,
@@ -1264,7 +1274,7 @@ def _minimize_gibbs_solve_impl(
     ln_nk0: jnp.ndarray,
     ln_ntot0: float,
     formula_matrix: jnp.ndarray,
-    hvector_func: Callable[[float], jnp.ndarray],
+    hvector: jnp.ndarray,
     epsilon_crit: float,
     max_iter: int,
 ) -> jnp.ndarray:
@@ -1273,7 +1283,7 @@ def _minimize_gibbs_solve_impl(
         ln_nk0,
         ln_ntot0,
         formula_matrix,
-        hvector_func,
+        hvector,
         epsilon_crit,
         max_iter,
     )
@@ -1282,13 +1292,13 @@ def _minimize_gibbs_solve_impl(
 
 # Keep the transformed solver at module scope so repeated calls reuse the same
 # Python callable identity instead of rebuilding a new custom_vjp closure.
-@partial(custom_vjp, nondiff_argnums=(3, 4, 5, 6))
+@partial(custom_vjp, nondiff_argnums=(3, 5, 6))
 def _minimize_gibbs_solve(
     state: ThermoState,
     ln_nk0: jnp.ndarray,
     ln_ntot0: float,
     formula_matrix: jnp.ndarray,
-    hvector_func: Callable[[float], jnp.ndarray],
+    hvector: jnp.ndarray,
     epsilon_crit: float,
     max_iter: int,
 ) -> jnp.ndarray:
@@ -1297,7 +1307,7 @@ def _minimize_gibbs_solve(
         ln_nk0,
         ln_ntot0,
         formula_matrix,
-        hvector_func,
+        hvector,
         epsilon_crit,
         max_iter,
     )
@@ -1308,7 +1318,7 @@ def _minimize_gibbs_solve_fwd(
     ln_nk0: jnp.ndarray,
     ln_ntot0: float,
     formula_matrix: jnp.ndarray,
-    hvector_func: Callable[[float], jnp.ndarray],
+    hvector: jnp.ndarray,
     epsilon_crit: float,
     max_iter: int,
 ):
@@ -1317,26 +1327,23 @@ def _minimize_gibbs_solve_fwd(
         ln_nk0,
         ln_ntot0,
         formula_matrix,
-        hvector_func,
+        hvector,
         epsilon_crit,
         max_iter,
     )
-    dfunc = jacrev(hvector_func)
-    hdot = dfunc(state.temperature)
-    residuals = (ln_nk, hdot, state.element_vector, ln_ntot)
+    residuals = (ln_nk, state.temperature, state.element_vector, ln_ntot)
     return ln_nk, residuals
 
 
 def _minimize_gibbs_solve_bwd(
     formula_matrix: jnp.ndarray,
-    hvector_func: Callable[[float], jnp.ndarray],
     epsilon_crit: float,
     max_iter: int,
     res,
     g,
 ):
-    del hvector_func, epsilon_crit, max_iter
-    ln_nk, hdot, element_vector, ln_ntot = res
+    del epsilon_crit, max_iter
+    ln_nk, temperature, element_vector, ln_ntot = res
 
     nk = jnp.exp(ln_nk)
     ntot_result = jnp.exp(ln_ntot)
@@ -1347,20 +1354,25 @@ def _minimize_gibbs_solve_bwd(
     beta = cho_solve((c, lower), element_vector)
     beta_dot_b_element = jnp.vdot(beta, element_vector)
 
-    cot_T = vjp_temperature(
+    cot_hvector = vjp_hvector(
         g,
         nk,
         formula_matrix,
-        hdot,
         alpha,
         beta,
         element_vector,
         beta_dot_b_element,
     )
+    cot_T = jnp.zeros_like(temperature)
     cot_P = vjp_pressure(g, ntot_result, alpha, element_vector, beta_dot_b_element)
     cot_b = vjp_elements(g, alpha, beta, element_vector, beta_dot_b_element)
     # No gradients for initialization arguments.
-    return (ThermoState(jnp.asarray(cot_T), jnp.asarray(cot_P), cot_b), None, None)
+    return (
+        ThermoState(jnp.asarray(cot_T), jnp.asarray(cot_P), cot_b),
+        None,
+        None,
+        cot_hvector,
+    )
 
 
 _minimize_gibbs_solve.defvjp(_minimize_gibbs_solve_fwd, _minimize_gibbs_solve_bwd)
@@ -1371,7 +1383,7 @@ def minimize_gibbs(
     ln_nk_init: jnp.ndarray,
     ln_ntot_init: float,
     formula_matrix: jnp.ndarray,
-    hvector_func: Callable[[float], jnp.ndarray],
+    hvector_func: Union[Callable[[float], jnp.ndarray], jnp.ndarray],
     epsilon_crit: float = 1.0e-11,
     max_iter: int = 1000,
 ) -> jnp.ndarray:
@@ -1382,7 +1394,8 @@ def minimize_gibbs(
         ln_nk_init: Initial natural log number of species vector (n_species,).
         ln_ntot_init: Initial natural log total number of species.
         formula_matrix: Stoichiometric formula matrix (n_elements, n_species).
-        hvector_func: Function that returns chemical potential over RT vector (n_species,).
+        hvector_func: Function returning, or an evaluated, chemical potential
+            over RT vector (n_species,).
         epsilon_crit: Convergence tolerance for residual norm.
         max_iter: Maximum number of iterations allowed.
 
@@ -1392,12 +1405,13 @@ def minimize_gibbs(
     # Treat initial guesses as non-differentiable inputs
     ln_nk0 = stop_gradient(ln_nk_init)
     ln_ntot0 = stop_gradient(ln_ntot_init)
+    hvector = _evaluate_hvector_source(state, hvector_func)
     return _minimize_gibbs_solve(
         state,
         ln_nk0,
         ln_ntot0,
         formula_matrix,
-        hvector_func,
+        hvector,
         epsilon_crit,
         max_iter,
     )
@@ -1408,7 +1422,7 @@ def minimize_gibbs_with_diagnostics(
     ln_nk_init: jnp.ndarray,
     ln_ntot_init: float,
     formula_matrix: jnp.ndarray,
-    hvector_func: Callable[[float], jnp.ndarray],
+    hvector_func: Union[Callable[[float], jnp.ndarray], jnp.ndarray],
     epsilon_crit: float = 1.0e-11,
     max_iter: int = 1000,
 ) -> Tuple[jnp.ndarray, Dict[str, jnp.ndarray]]:

--- a/src/exogibbs/equilibrium/gas/profile.py
+++ b/src/exogibbs/equilibrium/gas/profile.py
@@ -20,6 +20,7 @@ from exogibbs.equilibrium.gas.types import (
     EquilibriumOptions,
     EquilibriumResult,
 )
+from exogibbs.thermo.fugacity import LogFugacityCoefficientFunction
 from exogibbs.thermo.models import ChemicalSetup
 
 
@@ -30,7 +31,7 @@ ProfileMethod = Literal[
 ]
 
 _PROFILE_SCAN_BODY_CACHE: Dict[
-    Tuple[int, int, float, int, int, bool],
+    Tuple[int, int, float, int, int, int, bool],
     Callable,
 ] = {}
 
@@ -54,6 +55,7 @@ def _get_profile_scan_body(
     reference_pressure: float,
     options: EquilibriumOptions,
     initializer: Optional[EquilibriumInitializer],
+    lnphi_func: Optional[LogFugacityCoefficientFunction],
     return_diagnostics: bool,
 ) -> Callable:
     key = (
@@ -62,6 +64,7 @@ def _get_profile_scan_body(
         float(reference_pressure),
         id(options),
         id(initializer or DEFAULT_INITIALIZER),
+        id(lnphi_func),
         return_diagnostics,
     )
     cached = _PROFILE_SCAN_BODY_CACHE.get(key)
@@ -98,6 +101,7 @@ def _get_profile_scan_body(
                 init=solver_init,
                 options=options,
                 return_diagnostics=True,
+                lnphi_func=lnphi_func,
             )
             next_total = jnp.log(jnp.clip(result.ntot, 1.0e-300))
             return (result.ln_n, next_total), (result, diagnostics)
@@ -130,6 +134,7 @@ def _get_profile_scan_body(
                 init=solver_init,
                 options=options,
                 return_diagnostics=False,
+                lnphi_func=lnphi_func,
             )
             next_total = jnp.log(jnp.clip(result.ntot, 1.0e-300))
             return (result.ln_n, next_total), result
@@ -148,8 +153,12 @@ def equilibrium_profile(
     initializer: Optional[EquilibriumInitializer] = None,
     options: Optional[EquilibriumOptions] = None,
     return_diagnostics: bool = False,
+    lnphi_func: Optional[LogFugacityCoefficientFunction] = None,
 ) -> Union[EquilibriumResult, Tuple[EquilibriumResult, Mapping[str, Array]]]:
-    """Compute gas equilibrium along a one-dimensional profile."""
+    """Compute gas equilibrium along a one-dimensional profile.
+
+    ``lnphi_func`` follows the one-layer pure-component fugacity contract.
+    """
 
     temperatures = jnp.asarray(T)
     pressures = jnp.asarray(P)
@@ -184,6 +193,7 @@ def equilibrium_profile(
                     initializer=initializer,
                     options=active_options,
                     return_diagnostics=True,
+                    lnphi_func=lnphi_func,
                 ),
                 in_axes=(0, 0),
             )
@@ -198,6 +208,7 @@ def equilibrium_profile(
                 initializer=initializer,
                 options=active_options,
                 return_diagnostics=False,
+                lnphi_func=lnphi_func,
             ),
             in_axes=(0, 0),
         )
@@ -228,6 +239,7 @@ def equilibrium_profile(
         Pref,
         active_options,
         initializer,
+        lnphi_func,
         return_diagnostics,
     )
     if return_diagnostics:

--- a/src/exogibbs/equilibrium/gas/solve.py
+++ b/src/exogibbs/equilibrium/gas/solve.py
@@ -21,6 +21,10 @@ from exogibbs.equilibrium.gas.types import (
     EquilibriumResult,
     ThermoState,
 )
+from exogibbs.thermo.fugacity import (
+    LogFugacityCoefficientFunction,
+    effective_gas_hvector,
+)
 from exogibbs.thermo.models import ChemicalSetup
 
 
@@ -41,8 +45,13 @@ def equilibrium(
     initializer: Optional[EquilibriumInitializer] = None,
     options: Optional[EquilibriumOptions] = None,
     return_diagnostics: bool = False,
+    lnphi_func: Optional[LogFugacityCoefficientFunction] = None,
 ) -> Union[EquilibriumResult, Tuple[EquilibriumResult, Mapping[str, Array]]]:
-    """Compute gas-only equilibrium at one temperature and pressure."""
+    """Compute gas-only equilibrium at one temperature and pressure.
+
+    ``lnphi_func`` supplies pure-component ``ln(phi)`` values in gas-species
+    order and is called as ``lnphi_func(T, P, None)`` with pressure in bar.
+    """
 
     opts = options or EquilibriumOptions()
     formula_matrix = setup.formula_matrix
@@ -72,13 +81,20 @@ def equilibrium(
         species_count,
     )
     state = ThermoState(T, ln_normalized_pressure(P, Pref), b)
+    hvector = effective_gas_hvector(
+        setup,
+        T,
+        P,
+        lnphi_func,
+        mole_fractions=None,
+    )
     if return_diagnostics:
         ln_n, diagnostics = minimize_gibbs_with_diagnostics(
             state,
             ln_nk_init,
             ln_ntot_init,
             formula_matrix,
-            setup.hvector_func,
+            hvector,
             epsilon_crit=opts.epsilon_crit,
             max_iter=opts.max_iter,
         )
@@ -88,7 +104,7 @@ def equilibrium(
             ln_nk_init,
             ln_ntot_init,
             formula_matrix,
-            setup.hvector_func,
+            hvector,
             epsilon_crit=opts.epsilon_crit,
             max_iter=opts.max_iter,
         )

--- a/src/exogibbs/thermo/fugacity.py
+++ b/src/exogibbs/thermo/fugacity.py
@@ -1,0 +1,53 @@
+"""Gas-phase fugacity coefficient interfaces and helpers."""
+
+from typing import Callable, Optional, Union
+
+import jax.numpy as jnp
+
+from exogibbs.thermo.models import ChemicalSetup
+
+
+Array = jnp.ndarray
+Scalar = Union[float, Array]
+LogFugacityCoefficientFunction = Callable[[Scalar, Scalar, Optional[Array]], Array]
+
+
+def effective_gas_hvector(
+    setup: ChemicalSetup,
+    temperature: Scalar,
+    pressure_bar: Scalar,
+    lnphi_func: Optional[LogFugacityCoefficientFunction] = None,
+    *,
+    mole_fractions: Optional[Array] = None,
+) -> Array:
+    """Return the ideal gas source corrected by ``ln(phi)``.
+
+    ``lnphi_func`` receives temperature, physical pressure in bar, and gas mole
+    fractions.  Pure-component mode passes ``None`` for the mole fractions.
+    Its result must follow ``setup.species`` order and contain natural-log,
+    dimensionless fugacity coefficients.
+    """
+
+    ideal_hvector = jnp.asarray(setup.hvector_func(temperature))
+    expected_shape = (int(setup.formula_matrix.shape[1]),)
+    if ideal_hvector.shape != expected_shape:
+        raise ValueError(
+            "hvector_func must return one value per gas species: "
+            f"expected shape {expected_shape}, got {ideal_hvector.shape}."
+        )
+    if lnphi_func is None:
+        return ideal_hvector
+
+    lnphi = jnp.asarray(
+        lnphi_func(temperature, pressure_bar, mole_fractions),
+        dtype=ideal_hvector.dtype,
+    )
+    if lnphi.shape != expected_shape:
+        raise ValueError(
+            "lnphi_func must return one value per gas species in setup.species "
+            f"order: expected shape {expected_shape}, got {lnphi.shape}."
+        )
+    return ideal_hvector + lnphi
+
+
+__all__ = ["LogFugacityCoefficientFunction", "effective_gas_hvector"]

--- a/tests/unittests/api/condensate_equilibrium_profile_test.py
+++ b/tests/unittests/api/condensate_equilibrium_profile_test.py
@@ -97,6 +97,94 @@ def _prepared_real_support(bucket, row: int = 0) -> tuple[int, ...]:
     )
 
 
+def test_head_v2_prepared_buckets_apply_layer_fugacity_correction(
+    monkeypatch,
+) -> None:
+    setup = _fake_setup()
+    captured = {}
+    provider_calls = []
+
+    def lnphi_func(temperature, pressure_bar, mole_fractions):
+        provider_calls.append(
+            (float(temperature), float(pressure_bar), mole_fractions)
+        )
+        return jnp.asarray(
+            [float(temperature) / 1000.0, math.log(float(pressure_bar))],
+            dtype=jnp.float64,
+        )
+
+    def fake_prepare_fixed_support_v2_buckets(**kwargs):
+        captured.update(kwargs)
+        return ("prepared",)
+
+    monkeypatch.setattr(
+        "exogibbs.equilibrium.condensate.fixed_support.batch."
+        "prepare_fixed_support_v2_buckets",
+        fake_prepare_fixed_support_v2_buckets,
+    )
+    states = tuple(
+        _lifecycle._HeadV2LayerState(
+            support_indices=(0,),
+            gas_ln_n=jnp.zeros((2,), dtype=jnp.float64),
+            condensate_log_amounts=jnp.zeros((1,), dtype=jnp.float64),
+            total_gas_log_amount=jnp.asarray(0.0, dtype=jnp.float64),
+            element_potential=jnp.zeros((2,), dtype=jnp.float64),
+        )
+        for _ in range(2)
+    )
+
+    buckets = _lifecycle._head_v2_prepared_buckets(
+        setup=setup,
+        temperatures=(800.0, 1200.0),
+        pressures=(1.0, 10.0),
+        b=jnp.asarray([1.0, 1.0], dtype=jnp.float64),
+        Pref=1.0,
+        states=states,
+        lnphi_func=lnphi_func,
+    )
+
+    assert buckets == ("prepared",)
+    assert provider_calls == [(800.0, 1.0, None), (1200.0, 10.0, None)]
+    np.testing.assert_allclose(
+        np.asarray(captured["hvector_by_layer"]),
+        [[0.8, 0.0], [1.2, math.log(10.0)]],
+    )
+
+
+def test_head_v2_element_potential_uses_fugacity_corrected_gamma() -> None:
+    setup = _fake_setup()
+    provider_calls = []
+
+    def lnphi_func(temperature, pressure_bar, mole_fractions):
+        provider_calls.append(
+            (float(temperature), float(pressure_bar), mole_fractions)
+        )
+        return jnp.asarray([0.25, -0.5], dtype=jnp.float64)
+
+    gas_amounts = jnp.asarray([0.4, 0.6], dtype=jnp.float64)
+    element_potential = _lifecycle._head_v2_best_residual_element_potential(
+        setup=setup,
+        T=900.0,
+        P=2.0,
+        Pref=1.0,
+        b=gas_amounts,
+        support_indices=(),
+        support_amounts=(),
+        gas_ln_n=jnp.log(gas_amounts),
+        total_gas_log_amount=jnp.asarray(0.0, dtype=jnp.float64),
+        epsilon=-10.0,
+        lnphi_func=lnphi_func,
+    )
+
+    assert provider_calls == [(900.0, 2.0, None)]
+    np.testing.assert_allclose(
+        np.asarray(element_potential),
+        np.log(np.asarray(gas_amounts))
+        + np.asarray([0.25, -0.5])
+        + math.log(2.0),
+    )
+
+
 def test_amount_gauge_scale_and_initializer_normalization() -> None:
     setup = SimpleNamespace(elements=("H", "O", "e-"))
     scale = _lifecycle._inventory_amount_gauge_scale(
@@ -1005,6 +1093,7 @@ def test_head_v2_rejects_hot_scan_method():
 def test_explicit_vmap_method_overrides_options_hot_scan(monkeypatch):
     setup = _fake_setup()
     expected = object()
+    lnphi_func = lambda temperature, pressure_bar, mole_fractions: jnp.zeros(2)
     calls = []
 
     def fake_run_head_v2_profile(**kwargs):
@@ -1026,10 +1115,12 @@ def test_explicit_vmap_method_overrides_options_hot_scan(monkeypatch):
         options=CondensateEquilibriumOptions(
             profile_method="scan_hot_from_bottom",
         ),
+        lnphi_func=lnphi_func,
     )
 
     assert result is expected
     assert len(calls) == 1
+    assert calls[0]["lnphi_func"] is lnphi_func
 
 
 def test_head_v2_rejects_empty_profile():

--- a/tests/unittests/api/condensate_equilibrium_test.py
+++ b/tests/unittests/api/condensate_equilibrium_test.py
@@ -102,6 +102,7 @@ def test_build_condensate_chemical_setup_validates_element_order() -> None:
 def test_one_layer_solver_forwards_initializer(monkeypatch) -> None:
     _gas, _condensate, setup = _setup_pair()
     initializer = object()
+    lnphi_func = lambda temperature, pressure_bar, mole_fractions: jnp.zeros(2)
     captured = {}
 
     def fake_profile(**kwargs):
@@ -116,10 +117,12 @@ def test_one_layer_solver_forwards_initializer(monkeypatch) -> None:
         P=1.0,
         b=jnp.asarray([1.0, 1.0]),
         initializer=initializer,
+        lnphi_func=lnphi_func,
     )
 
     assert result == "layer"
     assert captured["initializer"] is initializer
+    assert captured["lnphi_func"] is lnphi_func
 
 
 def test_condensate_chemical_setup_rejects_element_order_mismatch() -> None:

--- a/tests/unittests/api/condensate_rainout_profile_test.py
+++ b/tests/unittests/api/condensate_rainout_profile_test.py
@@ -281,6 +281,7 @@ def test_rainout_scans_bottom_to_top_and_returns_original_order(
         200.0: 0.1,
         100.0: 0.0,
     }
+    lnphi_func = lambda temperature, pressure_bar, mole_fractions: jnp.zeros(2)
     calls = []
 
     def fake_run_head_v2_profile(**kwargs):
@@ -304,6 +305,7 @@ def test_rainout_scans_bottom_to_top_and_returns_original_order(
                 "b": caller_budget,
                 "scale": abundance_scale,
                 "init": kwargs["explicit_inits"][0],
+                "lnphi_func": kwargs["lnphi_func"],
             }
         )
         return _one_layer_profile(
@@ -327,10 +329,12 @@ def test_rainout_scans_bottom_to_top_and_returns_original_order(
             return_diagnostics=True,
         ),
         return_diagnostics=True,
+        lnphi_func=lnphi_func,
     )
 
     assert [call["temperature"] for call in calls] == [300.0, 200.0, 100.0]
     assert [call["pressure"] for call in calls] == [100.0, 10.0, 1.0]
+    assert all(call["lnphi_func"] is lnphi_func for call in calls)
     np.testing.assert_allclose(calls[0]["b"], [0.6, 0.4, 0.0])
     np.testing.assert_allclose(calls[1]["b"], [0.5, 0.5, 0.0])
     np.testing.assert_allclose(calls[2]["b"], [4.0 / 9.0, 5.0 / 9.0, 0.0])

--- a/tests/unittests/api/public_import_contract_test.py
+++ b/tests/unittests/api/public_import_contract_test.py
@@ -73,6 +73,7 @@ def test_canonical_modules_alias_existing_public_callables() -> None:
         import json
         import types
 
+        import exogibbs.api as api
         from exogibbs.api import condensate, gas
         from exogibbs.api.condensate_equilibrium import (
             CondensateEquilibriumOptions,
@@ -88,6 +89,11 @@ def test_canonical_modules_alias_existing_public_callables() -> None:
         print(json.dumps({
             "gas_module": isinstance(gas, types.ModuleType),
             "condensate_module": isinstance(condensate, types.ModuleType),
+            "lnphi_type_alias": (
+                api.LogFugacityCoefficientFunction
+                is gas.LogFugacityCoefficientFunction
+                is condensate.LogFugacityCoefficientFunction
+            ),
             "gas_solve_alias": gas.solve is equilibrium,
             "gas_profile_alias": gas.solve_profile is equilibrium_profile,
             "gas_options_alias": gas.EquilibriumOptions is EquilibriumOptions,

--- a/tests/unittests/equilibrium/gas/fugacity_test.py
+++ b/tests/unittests/equilibrium/gas/fugacity_test.py
@@ -1,0 +1,187 @@
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from exogibbs.equilibrium.gas.profile import equilibrium_profile
+from exogibbs.equilibrium.gas.solve import equilibrium
+from exogibbs.equilibrium.gas.types import EquilibriumOptions
+from exogibbs.thermo.models import ChemicalSetup
+
+
+jax.config.update("jax_enable_x64", True)
+
+_B = jnp.asarray([1.0], dtype=jnp.float64)
+_OPTIONS = EquilibriumOptions(epsilon_crit=1.0e-12, max_iter=200)
+
+
+def _setup() -> ChemicalSetup:
+    return ChemicalSetup(
+        formula_matrix=jnp.asarray([[1.0, 1.0]], dtype=jnp.float64),
+        hvector_func=lambda temperature: jnp.zeros((2,), dtype=jnp.float64),
+        elements=("E",),
+        species=("A", "B"),
+    )
+
+
+def _expected_mole_fractions(delta):
+    return jax.nn.softmax(jnp.asarray([-delta, delta]))
+
+
+def test_none_and_zero_lnphi_preserve_ideal_solution():
+    setup = _setup()
+    ideal = equilibrium(setup, 900.0, 3.0, _B, options=_OPTIONS)
+    zero = equilibrium(
+        setup,
+        900.0,
+        3.0,
+        _B,
+        options=_OPTIONS,
+        lnphi_func=lambda temperature, pressure, mole_fractions: jnp.zeros((2,)),
+    )
+
+    np.testing.assert_allclose(zero.ln_n, ideal.ln_n, rtol=0.0, atol=1.0e-12)
+    np.testing.assert_allclose(ideal.x, jnp.asarray([0.5, 0.5]), atol=1.0e-12)
+
+
+def test_pure_lnphi_changes_equilibrium_and_receives_physical_state():
+    setup = _setup()
+    calls = []
+
+    def lnphi_func(temperature, pressure_bar, mole_fractions):
+        calls.append((temperature, pressure_bar, mole_fractions))
+        return jnp.asarray([0.4, -0.4])
+
+    result = equilibrium(
+        setup,
+        850.0,
+        7.5,
+        _B,
+        Pref=2.5,
+        options=_OPTIONS,
+        lnphi_func=lnphi_func,
+    )
+
+    assert calls == [(850.0, 7.5, None)]
+    np.testing.assert_allclose(result.x, _expected_mole_fractions(0.4), atol=1.0e-12)
+    assert not np.allclose(result.x, jnp.asarray([0.5, 0.5]))
+
+
+def test_jit_grad_includes_lnphi_temperature_and_pressure_derivatives():
+    setup = _setup()
+    temperature_scale = 2.0e-3
+    pressure_scale = 0.15
+
+    def lnphi_func(temperature, pressure_bar, mole_fractions):
+        del mole_fractions
+        delta = temperature_scale * temperature + pressure_scale * pressure_bar
+        return jnp.asarray([delta, -delta])
+
+    @jax.jit
+    def solve_ln_n(temperature, pressure_bar):
+        return equilibrium(
+            setup,
+            temperature,
+            pressure_bar,
+            _B,
+            options=_OPTIONS,
+            lnphi_func=lnphi_func,
+        ).ln_n
+
+    temperature = 400.0
+    pressure_bar = 2.0
+    dln_dT, dln_dP = jax.jacrev(solve_ln_n, argnums=(0, 1))(
+        temperature, pressure_bar
+    )
+    delta = temperature_scale * temperature + pressure_scale * pressure_bar
+    response = jnp.asarray([-1.0 - jnp.tanh(delta), 1.0 - jnp.tanh(delta)])
+
+    np.testing.assert_allclose(dln_dT, response * temperature_scale, atol=2.0e-11)
+    np.testing.assert_allclose(dln_dP, response * pressure_scale, atol=2.0e-11)
+
+
+def test_vmap_profile_propagates_layer_state_to_lnphi():
+    setup = _setup()
+    temperatures = jnp.asarray([300.0, 500.0, 700.0])
+    pressures = jnp.asarray([1.0, 2.0, 4.0])
+
+    def lnphi_func(temperature, pressure_bar, mole_fractions):
+        del mole_fractions
+        delta = 1.0e-3 * temperature + 0.1 * pressure_bar
+        return jnp.asarray([delta, -delta])
+
+    result = equilibrium_profile(
+        setup,
+        temperatures,
+        pressures,
+        _B,
+        options=EquilibriumOptions(
+            epsilon_crit=1.0e-12,
+            max_iter=200,
+            method="vmap_cold",
+        ),
+        lnphi_func=lnphi_func,
+    )
+    delta = 1.0e-3 * temperatures + 0.1 * pressures
+    expected = jax.vmap(_expected_mole_fractions)(delta)
+
+    np.testing.assert_allclose(result.x, expected, atol=1.0e-12)
+
+
+def test_scan_profile_cache_distinguishes_lnphi_providers():
+    setup = _setup()
+    temperatures = jnp.asarray([500.0, 600.0, 700.0])
+    pressures = jnp.asarray([1.0, 2.0, 3.0])
+    options = EquilibriumOptions(
+        epsilon_crit=1.0e-12,
+        max_iter=200,
+        method="scan_hot_from_bottom",
+    )
+
+    def positive_lnphi(temperature, pressure_bar, mole_fractions):
+        del temperature, pressure_bar, mole_fractions
+        return jnp.asarray([0.25, -0.25])
+
+    def negative_lnphi(temperature, pressure_bar, mole_fractions):
+        del temperature, pressure_bar, mole_fractions
+        return jnp.asarray([-0.35, 0.35])
+
+    positive = equilibrium_profile(
+        setup,
+        temperatures,
+        pressures,
+        _B,
+        options=options,
+        lnphi_func=positive_lnphi,
+    )
+    negative = equilibrium_profile(
+        setup,
+        temperatures,
+        pressures,
+        _B,
+        options=options,
+        lnphi_func=negative_lnphi,
+    )
+
+    np.testing.assert_allclose(
+        positive.x,
+        jnp.broadcast_to(_expected_mole_fractions(0.25), positive.x.shape),
+        atol=1.0e-12,
+    )
+    np.testing.assert_allclose(
+        negative.x,
+        jnp.broadcast_to(_expected_mole_fractions(-0.35), negative.x.shape),
+        atol=1.0e-12,
+    )
+
+
+def test_lnphi_shape_must_match_gas_species():
+    with pytest.raises(ValueError, match=r"expected shape \(2,\), got \(1,\)"):
+        equilibrium(
+            _setup(),
+            900.0,
+            1.0,
+            _B,
+            options=_OPTIONS,
+            lnphi_func=lambda temperature, pressure, mole_fractions: jnp.zeros((1,)),
+        )

--- a/tests/unittests/examples/exoeos_pure_fugacity_test.py
+++ b/tests/unittests/examples/exoeos_pure_fugacity_test.py
@@ -1,0 +1,56 @@
+"""Lightweight contracts for the optional ExoEOS gallery example."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import jax.numpy as jnp
+import numpy as np
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+EXAMPLE_PATH = REPOSITORY_ROOT / "examples" / "plot_exoeos_pure_fugacity.py"
+
+
+def _load_example():
+    spec = importlib.util.spec_from_file_location(
+        "plot_exoeos_pure_fugacity_test_module",
+        EXAMPLE_PATH,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_example_is_syntax_valid_and_uses_the_optional_public_hook() -> None:
+    source = EXAMPLE_PATH.read_text(encoding="utf-8")
+
+    compile(source, str(EXAMPLE_PATH), "exec")
+    assert "from exoeos import ZhangDuanEOS, state_tp" in source
+    assert "except ImportError" in source
+    assert "lnphi_func=lnphi_func" in source
+    assert "pressure_bar) * BAR_TO_PA" in source
+
+
+def test_reduced_setup_matches_the_zhang_duan_species_order() -> None:
+    example = _load_example()
+    setup = example.build_reduced_setup()
+
+    assert setup.species == (
+        "CH4",
+        "H2O",
+        "CO2",
+        "H2",
+        "CO",
+        "O2",
+        "C2H6",
+    )
+    assert setup.elements == ("C", "H", "O")
+    assert setup.formula_matrix.shape == (3, 7)
+    assert np.linalg.matrix_rank(np.asarray(setup.formula_matrix)) == 3
+    np.testing.assert_allclose(
+        np.asarray(setup.hvector_func(jnp.asarray(1500.0))),
+        np.zeros(7),
+    )

--- a/tests/unittests/thermo/fugacity_helper_test.py
+++ b/tests/unittests/thermo/fugacity_helper_test.py
@@ -1,0 +1,48 @@
+"""Tests for gas fugacity coefficient helpers."""
+
+import jax.numpy as jnp
+import pytest
+
+from exogibbs.thermo.fugacity import effective_gas_hvector
+from exogibbs.thermo.models import ChemicalSetup
+
+
+def _setup() -> ChemicalSetup:
+    return ChemicalSetup(
+        formula_matrix=jnp.asarray([[1.0, 2.0]]),
+        hvector_func=lambda temperature: jnp.asarray(
+            [temperature, 2.0 * temperature]
+        ),
+        species=("A", "B"),
+    )
+
+
+def test_effective_gas_hvector_defaults_to_ideal() -> None:
+    result = effective_gas_hvector(_setup(), 3.0, 10.0)
+
+    assert jnp.allclose(result, jnp.asarray([3.0, 6.0]))
+
+
+def test_effective_gas_hvector_adds_pure_lnphi() -> None:
+    def lnphi_func(temperature, pressure_bar, mole_fractions):
+        assert mole_fractions is None
+        return jnp.asarray([temperature, pressure_bar])
+
+    result = effective_gas_hvector(
+        _setup(),
+        3.0,
+        10.0,
+        lnphi_func,
+    )
+
+    assert jnp.allclose(result, jnp.asarray([6.0, 16.0]))
+
+
+def test_effective_gas_hvector_rejects_wrong_lnphi_shape() -> None:
+    with pytest.raises(ValueError, match="expected shape \\(2,\\)"):
+        effective_gas_hvector(
+            _setup(),
+            3.0,
+            10.0,
+            lambda temperature, pressure_bar, mole_fractions: jnp.zeros(1),
+        )


### PR DESCRIPTION
## Summary

- Add an optional `lnphi_func(T, P_bar, x)` interface to the gas-only and gas-plus-condensate solvers.
- Apply pure-component `ln(phi)` corrections consistently across gas profiles, condensate support selection, finite/zero-barrier solves, audits, fallbacks, rainout, and prepared plans.
- Preserve temperature and pressure derivatives through the gas solver custom VJP.
- Add an optional ExoEOS Zhang–Duan seven-species Sphinx-Gallery example without adding ExoEOS as a dependency.

## Motivation

This enables non-ideal pure-component gas calculations through

```text
h_eff(T, P) = h_ideal(T) + ln(phi_pure(T, P))
```

while keeping the thermochemistry setup independent of the EOS implementation. The callback receives physical pressure in bar and currently receives `x=None`; composition-dependent mixture fugacity remains a follow-up because it requires solver Jacobian changes.

## Impact

Existing callers are unchanged when `lnphi_func` is omitted. Provider outputs must be dimensionless natural logarithms with one value per gas species in setup order.

## Validation

- Gas/API regression suite: 85 passed.
- Condensate kernel suite: 167 passed.
- Full unit run: 628 passed; the sole gallery-manifest placement failure was corrected, and its rerun passed.
- Final fugacity/API/docs regression bundle: 23 passed.
- `./update_doc.sh`: succeeded.
- Optional ExoEOS Zhang–Duan example: executed successfully with the local ExoEOS checkout; all seven outputs were finite.
- `git diff --check`: clean.
