### PR TITLE
equilibrium: support warm-started gas profiles

### DIFF
--- a/documents/equilibrium_solvers.rst
+++ b/documents/equilibrium_solvers.rst
@@ -33,6 +33,14 @@ For ``N`` layers and ``K`` gas species, ``result.ln_n``, ``result.n``, and
 One-layer :func:`exogibbs.api.gas.solve` returns the corresponding ``(K,)``
 arrays and scalar total.
 
+The optional ``init=EquilibriumInit(...)`` keyword supplies an explicit gas
+state.  With the default initializer, scan methods use it for the first
+scheduled layer and warm-start later layers from the preceding solution;
+``vmap_cold`` uses the same state for every independent layer.  A custom
+initializer receives the value as ``request.user_init`` and controls its own
+precedence.  The effective convergence tolerance is the larger of the
+requested ``epsilon_crit`` and eight machine epsilons in the solver dtype.
+
 Condensate Quick Start
 ----------------------
 

--- a/documents/magma_gas_interface.rst
+++ b/documents/magma_gas_interface.rst
@@ -267,6 +267,9 @@ Units and logarithm bases
      - Natural logarithm of a dimensionless fugacity coefficient.
    * - ``gas_log_mole_fractions`` and ``root_variables``
      - Natural logarithms.
+   * - ``gas_ln_n`` and ``gas_ntot``
+     - Raw gas solver amounts in the :math:`b_{\rm H}=1` gauge.  ``gas_ln_n``
+       contains natural logarithms; ``gas_ntot`` is linear.
    * - IW helper output and ``delta_iw``
      - Dimensionless base-10 logarithms; one unit is one decade.
    * - Empirical solubility-law pressures
@@ -297,6 +300,12 @@ Gas arrays use ``CANONICAL_SPECIES`` order and melt arrays use
    * - ``element_abundances``
      - Inferred ``(H, C, O, N, He)`` amounts in the :math:`b_{\rm H}=1`
        gauge.
+   * - ``gas_ln_n``
+     - Natural logarithms of the nine raw gas solver amounts in the
+       :math:`b_{\rm H}=1` gauge.
+   * - ``gas_ntot``
+     - Sum of the nine raw gas solver amounts in the same gauge.  This is not
+       a physical number density or mass density.
    * - ``gas_log_mole_fractions``
      - Natural logarithms of the nine gas mole fractions.
    * - ``gas_mole_fractions``

--- a/src/exogibbs/equilibrium/gas/profile.py
+++ b/src/exogibbs/equilibrium/gas/profile.py
@@ -73,24 +73,46 @@ def _get_profile_scan_body(
 
     species_count = int(setup.formula_matrix.shape[1])
 
+    def resolve_scheduled_init(carry, temperature, pressure, use_seed):
+        ln_nk_previous, ln_ntot_previous = carry
+        scheduled_init = resolve_initial_guess(
+            initializer,
+            EquilibriumInitRequest(
+                setup=setup,
+                T=temperature,
+                P=pressure,
+                b=b,
+                K=species_count,
+                previous_solution=EquilibriumInit(
+                    ln_nk=ln_nk_previous,
+                    ln_ntot=ln_ntot_previous,
+                ),
+            ),
+        )
+        ln_nk_scheduled, ln_ntot_scheduled = prepare_init(
+            scheduled_init,
+            b,
+            species_count,
+        )
+        return EquilibriumInit(
+            ln_nk=jnp.where(use_seed, ln_nk_previous, ln_nk_scheduled),
+            ln_ntot=jnp.where(
+                use_seed,
+                ln_ntot_previous,
+                ln_ntot_scheduled,
+            ),
+        )
+
     if return_diagnostics:
 
         def scan_body(carry, tp_pair):
             ln_nk_previous, ln_ntot_previous = carry
-            temperature, pressure = tp_pair
-            solver_init = resolve_initial_guess(
-                initializer,
-                EquilibriumInitRequest(
-                    setup=setup,
-                    T=temperature,
-                    P=pressure,
-                    b=b,
-                    K=species_count,
-                    previous_solution=EquilibriumInit(
-                        ln_nk=ln_nk_previous,
-                        ln_ntot=ln_ntot_previous,
-                    ),
-                ),
+            temperature, pressure, use_seed = tp_pair
+            solver_init = resolve_scheduled_init(
+                carry,
+                temperature,
+                pressure,
+                use_seed,
             )
             result, diagnostics = equilibrium(
                 setup,
@@ -110,20 +132,12 @@ def _get_profile_scan_body(
 
         def scan_body(carry, tp_pair):
             ln_nk_previous, ln_ntot_previous = carry
-            temperature, pressure = tp_pair
-            solver_init = resolve_initial_guess(
-                initializer,
-                EquilibriumInitRequest(
-                    setup=setup,
-                    T=temperature,
-                    P=pressure,
-                    b=b,
-                    K=species_count,
-                    previous_solution=EquilibriumInit(
-                        ln_nk=ln_nk_previous,
-                        ln_ntot=ln_ntot_previous,
-                    ),
-                ),
+            temperature, pressure, use_seed = tp_pair
+            solver_init = resolve_scheduled_init(
+                carry,
+                temperature,
+                pressure,
+                use_seed,
             )
             result = equilibrium(
                 setup,
@@ -150,6 +164,7 @@ def equilibrium_profile(
     b: Array,
     *,
     Pref: float = 1.0,
+    init: Optional[EquilibriumInit] = None,
     initializer: Optional[EquilibriumInitializer] = None,
     options: Optional[EquilibriumOptions] = None,
     return_diagnostics: bool = False,
@@ -157,6 +172,11 @@ def equilibrium_profile(
 ) -> Union[EquilibriumResult, Tuple[EquilibriumResult, Mapping[str, Array]]]:
     """Compute gas equilibrium along a one-dimensional profile.
 
+    With the default initializer, ``init`` seeds the first scheduled scan
+    layer and later layers use the preceding solution.  In ``vmap_cold`` mode
+    the same explicit state initializes every independent layer.  A custom
+    initializer receives ``init`` as ``request.user_init`` and controls its
+    own precedence.
     ``lnphi_func`` follows the one-layer pure-component fugacity contract.
     """
 
@@ -190,6 +210,7 @@ def equilibrium_profile(
                     pressure,
                     b,
                     Pref=Pref,
+                    init=init,
                     initializer=initializer,
                     options=active_options,
                     return_diagnostics=True,
@@ -205,6 +226,7 @@ def equilibrium_profile(
                 pressure,
                 b,
                 Pref=Pref,
+                init=init,
                 initializer=initializer,
                 options=active_options,
                 return_diagnostics=False,
@@ -230,6 +252,7 @@ def equilibrium_profile(
             P=pressures_input[0],
             b=b,
             K=species_count,
+            user_init=init,
         ),
     )
     ln_nk_init, ln_ntot_init = prepare_init(first_init, b, species_count)
@@ -242,17 +265,18 @@ def equilibrium_profile(
         lnphi_func,
         return_diagnostics,
     )
+    use_seed = jnp.arange(temperatures_input.shape[0]) == 0
     if return_diagnostics:
         _, (result_sequence, diagnostic_sequence) = lax.scan(
             scan_body,
             (ln_nk_init, ln_ntot_init),
-            (temperatures_input, pressures_input),
+            (temperatures_input, pressures_input, use_seed),
         )
     else:
         _, result_sequence = lax.scan(
             scan_body,
             (ln_nk_init, ln_ntot_init),
-            (temperatures_input, pressures_input),
+            (temperatures_input, pressures_input, use_seed),
         )
         diagnostic_sequence = None
 

--- a/src/exogibbs/equilibrium/gas/solve.py
+++ b/src/exogibbs/equilibrium/gas/solve.py
@@ -34,6 +34,15 @@ def ln_normalized_pressure(pressure: float, reference_pressure: float) -> Array:
     return jnp.log(pressure / reference_pressure)
 
 
+def _effective_equilibrium_tolerance(
+    requested: float,
+    dtype: jnp.dtype,
+) -> float:
+    """Return a convergence tolerance resolvable in the solver dtype."""
+
+    return max(requested, 8.0 * float(jnp.finfo(dtype).eps))
+
+
 def equilibrium(
     setup: ChemicalSetup,
     T: float,
@@ -88,6 +97,20 @@ def equilibrium(
         lnphi_func,
         mole_fractions=None,
     )
+    solver_dtype = jnp.result_type(
+        ln_nk_init,
+        ln_ntot_init,
+        formula_matrix,
+        hvector,
+        b,
+        state.temperature,
+        state.ln_normalized_pressure,
+        jnp.float32,
+    )
+    epsilon_crit = _effective_equilibrium_tolerance(
+        opts.epsilon_crit,
+        solver_dtype,
+    )
     if return_diagnostics:
         ln_n, diagnostics = minimize_gibbs_with_diagnostics(
             state,
@@ -95,7 +118,7 @@ def equilibrium(
             ln_ntot_init,
             formula_matrix,
             hvector,
-            epsilon_crit=opts.epsilon_crit,
+            epsilon_crit=epsilon_crit,
             max_iter=opts.max_iter,
         )
     else:
@@ -105,7 +128,7 @@ def equilibrium(
             ln_ntot_init,
             formula_matrix,
             hvector,
-            epsilon_crit=opts.epsilon_crit,
+            epsilon_crit=epsilon_crit,
             max_iter=opts.max_iter,
         )
         diagnostics = None

--- a/src/exogibbs/equilibrium/gas/types.py
+++ b/src/exogibbs/equilibrium/gas/types.py
@@ -39,7 +39,11 @@ class ThermoState:
 
 @dataclass(frozen=True)
 class EquilibriumOptions:
-    """Solver and profile scheduling options for gas equilibrium."""
+    """Solver and profile scheduling options for gas equilibrium.
+
+    The solver floors ``epsilon_crit`` at eight machine epsilons in its
+    effective floating-point dtype.
+    """
 
     epsilon_crit: float = 1.0e-10
     max_iter: int = 1000

--- a/src/exogibbs/experimental/magma_gas/solve.py
+++ b/src/exogibbs/experimental/magma_gas/solve.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import replace
 import math
 from numbers import Integral
 from typing import Callable, NamedTuple, Optional
@@ -66,6 +65,8 @@ class _InterfaceParameters(NamedTuple):
 
 class _InterfaceEvaluation(NamedTuple):
     element_abundances: jax.Array
+    gas_ln_n: jax.Array
+    gas_ntot: jax.Array
     gas_log_mole_fractions: jax.Array
     gas_mole_fractions: jax.Array
     log_partial_pressures_bar: jax.Array
@@ -238,23 +239,6 @@ def _evaluate_lnphi(
     return lnphi
 
 
-def _effective_equilibrium_options(
-    options: MagmaAtmosphereInterfaceOptions,
-    dtype: jnp.dtype,
-):
-    """Use an inner tolerance that is meaningful for the active dtype."""
-
-    roundoff_floor = 8.0 * float(jnp.finfo(dtype).eps)
-    epsilon_crit = max(
-        options.equilibrium_options.epsilon_crit,
-        roundoff_floor,
-    )
-    return replace(
-        options.equilibrium_options,
-        epsilon_crit=epsilon_crit,
-    )
-
-
 def _evaluate_interface(
     chemistry: PreparedMagmaGasChemistry,
     options: MagmaAtmosphereInterfaceOptions,
@@ -276,7 +260,7 @@ def _evaluate_interface(
         parameters.temperature_melt_k,
         parameters.pressure_melt_bar,
         element_abundances,
-        options=_effective_equilibrium_options(options, dtype),
+        options=options.equilibrium_options,
         lnphi_func=evaluated_lnphi_func,
     )
     gas_log_mole_fractions = gas_result.ln_n - logsumexp(gas_result.ln_n)
@@ -361,6 +345,8 @@ def _evaluate_interface(
     )
     return _InterfaceEvaluation(
         element_abundances=element_abundances,
+        gas_ln_n=gas_result.ln_n,
+        gas_ntot=gas_result.ntot,
         gas_log_mole_fractions=gas_log_mole_fractions,
         gas_mole_fractions=gas_mole_fractions,
         log_partial_pressures_bar=log_partial_pressures_bar,
@@ -398,7 +384,7 @@ def _inner_root_diagnostics(
         audit_parameters.temperature_melt_k,
         audit_parameters.pressure_melt_bar,
         element_abundances,
-        options=_effective_equilibrium_options(options, dtype),
+        options=options.equilibrium_options,
         return_diagnostics=True,
         lnphi_func=evaluated_lnphi_func,
     )
@@ -766,6 +752,8 @@ def solve_magma_atmosphere_interface(
     )
     return MagmaAtmosphereInterfaceState(
         element_abundances=evaluated.element_abundances,
+        gas_ln_n=evaluated.gas_ln_n,
+        gas_ntot=evaluated.gas_ntot,
         gas_log_mole_fractions=evaluated.gas_log_mole_fractions,
         gas_mole_fractions=evaluated.gas_mole_fractions,
         partial_pressures_bar=evaluated.partial_pressures_bar,

--- a/src/exogibbs/experimental/magma_gas/types.py
+++ b/src/exogibbs/experimental/magma_gas/types.py
@@ -70,6 +70,8 @@ class MagmaAtmosphereInterfaceState(NamedTuple):
 
     Element abundances follow ``(H, C, O, N, He)`` order.  Gas arrays follow
     the canonical species order of the prepared chemistry.
+    ``gas_ln_n`` and ``gas_ntot`` use the interface's ``b_H = 1`` amount gauge;
+    they are numerical equilibrium amounts, not a physical number density.
     ``melt_volatile_mole_ratios`` follows ``MELTYQ_MELT_QUANTITIES``.  These
     values mix native mole-fraction outputs for H2 and CH4 with MELTYQ's
     dilute 60 g/mol matrix conversion for H2O, CO, CO2, and N.  The vector is
@@ -77,6 +79,8 @@ class MagmaAtmosphereInterfaceState(NamedTuple):
     """
 
     element_abundances: Array
+    gas_ln_n: Array
+    gas_ntot: Array
     gas_log_mole_fractions: Array
     gas_mole_fractions: Array
     partial_pressures_bar: Array

--- a/tests/unittests/api/equilibrium_api_test.py
+++ b/tests/unittests/api/equilibrium_api_test.py
@@ -588,6 +588,73 @@ def test_equilibrium_return_diagnostics(monkeypatch):
     assert int(diagnostics["n_iter"]) == 7
     assert int(diagnostics["max_iter"]) == 50
 
+
+@pytest.mark.parametrize("return_diagnostics", [False, True])
+@pytest.mark.parametrize(
+    "dtype,requested_tolerance,expected_tolerance",
+    [
+        (
+            jnp.float32,
+            1.0e-11,
+            8.0 * float(jnp.finfo(jnp.float32).eps),
+        ),
+        (jnp.float32, 1.0e-4, 1.0e-4),
+        (jnp.float64, 1.0e-11, 1.0e-11),
+    ],
+)
+def test_equilibrium_uses_dtype_resolvable_tolerance(
+    monkeypatch,
+    return_diagnostics,
+    dtype,
+    requested_tolerance,
+    expected_tolerance,
+):
+    class DtypedSetup:
+        def __init__(self):
+            self.formula_matrix = jnp.eye(2, dtype=dtype)
+
+        def hvector_func(self, temperature):
+            del temperature
+            return jnp.zeros((2,), dtype=dtype)
+
+    captured = {}
+
+    def stub_minimize_gibbs(
+        state,
+        ln_nk0,
+        ln_ntot0,
+        formula_matrix,
+        hvector,
+        **kwargs,
+    ):
+        del state, ln_ntot0, formula_matrix, hvector
+        captured["epsilon_crit"] = kwargs["epsilon_crit"]
+        result = jnp.zeros_like(ln_nk0)
+        if return_diagnostics:
+            return result, {}
+        return result
+
+    target = (
+        "exogibbs.equilibrium.gas.solve.minimize_gibbs_with_diagnostics"
+        if return_diagnostics
+        else "exogibbs.equilibrium.gas.solve.minimize_gibbs"
+    )
+    monkeypatch.setattr(target, stub_minimize_gibbs, raising=True)
+
+    output = eqmod.equilibrium(
+        DtypedSetup(),
+        T=jnp.asarray(1000.0, dtype=dtype),
+        P=jnp.asarray(1.0, dtype=dtype),
+        b=jnp.ones((2,), dtype=dtype),
+        options=EquilibriumOptions(epsilon_crit=requested_tolerance),
+        return_diagnostics=return_diagnostics,
+    )
+
+    if return_diagnostics:
+        output = output[0]
+    assert output.ln_n.dtype == dtype
+    assert captured["epsilon_crit"] == pytest.approx(expected_tolerance)
+
 if __name__ == "__main__":
     chemsetup = chemsetup()
     b_vec = chemsetup.element_vector_reference

--- a/tests/unittests/api/equilibrium_profile_test.py
+++ b/tests/unittests/api/equilibrium_profile_test.py
@@ -299,6 +299,170 @@ def test_equilibrium_profile_scan_hot_from_bottom_uses_previous_layer_init(monke
     assert jnp.all(diag["converged"])
 
 
+def test_equilibrium_profile_scan_hot_from_bottom_uses_explicit_seed_then_carry(monkeypatch):
+    K, N = 2, 4
+    A = jnp.eye(K, dtype=jnp.float32)
+    setup = FakeSetup(A)
+
+    def stub_minimize_gibbs(state, ln_nk0, ln_ntot0, A_in, hfunc, **kwargs):
+        return ln_nk0 + 1.0
+
+    monkeypatch.setattr(
+        "exogibbs.equilibrium.gas.solve.minimize_gibbs",
+        stub_minimize_gibbs,
+        raising=True,
+    )
+
+    T = jnp.linspace(1000.0, 1300.0, N)
+    P = jnp.linspace(0.1, 1.0, N)
+    b = jnp.ones((K,), dtype=jnp.float32)
+    seed = EquilibriumInit(
+        ln_nk=jnp.full((K,), 10.0, dtype=jnp.float32),
+        ln_ntot=jnp.asarray(jnp.log(K), dtype=jnp.float32),
+    )
+    out = eqmod.equilibrium_profile(
+        setup,
+        T,
+        P,
+        b,
+        init=seed,
+        options=EquilibriumOptions(method="scan_hot_from_bottom"),
+    )
+
+    expected = jnp.array([14.0, 13.0, 12.0, 11.0], dtype=jnp.float32)
+    assert jnp.allclose(out.ln_n, expected[:, None])
+
+
+def test_equilibrium_profile_vmap_cold_forwards_explicit_init(monkeypatch):
+    K, N = 2, 3
+    A = jnp.eye(K, dtype=jnp.float32)
+    setup = FakeSetup(A)
+
+    def stub_minimize_gibbs(state, ln_nk0, ln_ntot0, A_in, hfunc, **kwargs):
+        return ln_nk0
+
+    monkeypatch.setattr(
+        "exogibbs.equilibrium.gas.solve.minimize_gibbs",
+        stub_minimize_gibbs,
+        raising=True,
+    )
+
+    T = jnp.linspace(1000.0, 1200.0, N)
+    P = jnp.linspace(0.1, 1.0, N)
+    b = jnp.ones((K,), dtype=jnp.float32)
+    seed_ln_n = jnp.array([2.0, 3.0], dtype=jnp.float32)
+    seed = EquilibriumInit(
+        ln_nk=seed_ln_n,
+        ln_ntot=jnp.asarray(5.0, dtype=jnp.float32),
+    )
+    out = eqmod.equilibrium_profile(
+        setup,
+        T,
+        P,
+        b,
+        init=seed,
+        options=EquilibriumOptions(method="vmap_cold"),
+    )
+
+    assert jnp.allclose(out.ln_n, jnp.broadcast_to(seed_ln_n, (N, K)))
+
+
+def test_equilibrium_profile_custom_initializer_preserves_resolved_first_seed(
+    monkeypatch,
+):
+    K, N = 2, 3
+    setup = FakeSetup(jnp.eye(K, dtype=jnp.float32))
+
+    def stub_minimize_gibbs(state, ln_nk0, ln_ntot0, A_in, hfunc, **kwargs):
+        return ln_nk0 + 1.0
+
+    class ExplicitThenColdInitializer:
+        def __call__(self, request):
+            if request.user_init is not None:
+                return request.user_init
+            return EquilibriumInit(
+                ln_nk=jnp.zeros((K,), dtype=jnp.float32),
+                ln_ntot=jnp.asarray(jnp.log(K), dtype=jnp.float32),
+            )
+
+    monkeypatch.setattr(
+        "exogibbs.equilibrium.gas.solve.minimize_gibbs",
+        stub_minimize_gibbs,
+        raising=True,
+    )
+
+    seed = EquilibriumInit(
+        ln_nk=jnp.full((K,), 10.0, dtype=jnp.float32),
+        ln_ntot=jnp.asarray(jnp.log(K), dtype=jnp.float32),
+    )
+    out = eqmod.equilibrium_profile(
+        setup,
+        T=jnp.linspace(1000.0, 1200.0, N),
+        P=jnp.linspace(0.1, 1.0, N),
+        b=jnp.ones((K,), dtype=jnp.float32),
+        init=seed,
+        initializer=ExplicitThenColdInitializer(),
+        options=EquilibriumOptions(method="scan_hot_from_top"),
+    )
+
+    expected = jnp.asarray([11.0, 1.0, 1.0], dtype=jnp.float32)
+    assert jnp.allclose(out.ln_n, expected[:, None])
+
+
+def test_equilibrium_profile_inherits_float32_tolerance_floor(monkeypatch):
+    K, N = 2, 3
+
+    class Float32Setup:
+        formula_matrix = jnp.eye(K, dtype=jnp.float32)
+
+        def hvector_func(self, temperature):
+            del temperature
+            return jnp.zeros((K,), dtype=jnp.float32)
+
+    def stub_minimize_gibbs_with_diagnostics(
+        state,
+        ln_nk0,
+        ln_ntot0,
+        formula_matrix,
+        hvector,
+        **kwargs,
+    ):
+        del state, ln_ntot0, formula_matrix, hvector
+        diagnostics = {
+            "n_iter": jnp.asarray(1, dtype=jnp.int32),
+            "converged": jnp.asarray(True),
+            "hit_max_iter": jnp.asarray(False),
+            "final_residual": jnp.asarray(0.0, dtype=jnp.float32),
+            "epsilon_crit": jnp.asarray(
+                kwargs["epsilon_crit"],
+                dtype=jnp.float32,
+            ),
+            "max_iter": jnp.asarray(kwargs["max_iter"], dtype=jnp.int32),
+        }
+        return jnp.zeros_like(ln_nk0), diagnostics
+
+    monkeypatch.setattr(
+        "exogibbs.equilibrium.gas.solve.minimize_gibbs_with_diagnostics",
+        stub_minimize_gibbs_with_diagnostics,
+        raising=True,
+    )
+
+    _, diagnostics = eqmod.equilibrium_profile(
+        Float32Setup(),
+        T=jnp.linspace(1000.0, 1200.0, N, dtype=jnp.float32),
+        P=jnp.linspace(0.1, 1.0, N, dtype=jnp.float32),
+        b=jnp.ones((K,), dtype=jnp.float32),
+        options=EquilibriumOptions(
+            epsilon_crit=1.0e-11,
+            method="scan_hot_from_bottom",
+        ),
+        return_diagnostics=True,
+    )
+
+    expected = 8.0 * jnp.finfo(jnp.float32).eps
+    assert jnp.all(diagnostics["epsilon_crit"] == expected)
+
+
 def test_equilibrium_profile_scan_custom_initializer_receives_previous_solution(monkeypatch):
     E, K, N = 2, 2, 4
     A = jnp.array([[1, 0], [0, 1]], dtype=jnp.float32)

--- a/tests/unittests/experimental/magma_gas/float32_test.py
+++ b/tests/unittests/experimental/magma_gas/float32_test.py
@@ -45,6 +45,8 @@ _FLOAT32_SMOKE = textwrap.dedent(
     assert bool(diagnostics.converged), diagnostics
     assert diagnostics.residual_norm <= diagnostics.root_tolerance
     assert diagnostics.inner_residual_norm <= diagnostics.inner_tolerance
+    expected_tolerance = 8.0 * jnp.finfo(jnp.float32).eps
+    assert diagnostics.inner_tolerance == expected_tolerance
     """
 )
 

--- a/tests/unittests/experimental/magma_gas/solve_test.py
+++ b/tests/unittests/experimental/magma_gas/solve_test.py
@@ -200,6 +200,30 @@ def test_state_preserves_pressure_fugacity_and_melt_contracts(
     np.testing.assert_allclose(h2_he_fraction, 0.84, rtol=1.0e-10)
 
 
+def test_state_preserves_raw_gas_amount_contracts(
+    synthetic_case,
+    solved_state,
+):
+    gas_amounts = jnp.exp(solved_state.gas_ln_n)
+    np.testing.assert_allclose(
+        solved_state.gas_ntot,
+        jnp.sum(gas_amounts),
+        rtol=1.0e-12,
+    )
+    np.testing.assert_allclose(
+        solved_state.gas_log_mole_fractions,
+        solved_state.gas_ln_n - jnp.log(solved_state.gas_ntot),
+        rtol=0.0,
+        atol=1.0e-12,
+    )
+    np.testing.assert_allclose(
+        synthetic_case.chemistry.setup.formula_matrix @ gas_amounts,
+        solved_state.element_abundances,
+        rtol=1.0e-10,
+        atol=1.0e-12,
+    )
+
+
 def test_nonideal_lnphi_is_used_end_to_end():
     lnphi_at_point = jnp.linspace(-0.08, 0.08, len(CANONICAL_SPECIES))
     hvector_temperature_slope = jnp.linspace(


### PR DESCRIPTION
## Summary

- accept an explicit `EquilibriumInit` in gas profile solves
- preserve the resolved seed for the first scheduled scan layer, including with custom initializers
- floor gas-equilibrium convergence tolerances at eight machine epsilons in the solver dtype
- expose magma-gas `gas_ln_n` and `gas_ntot` as reusable warm-start state

## Motivation

The MELTYQ-equivalent application needs to reuse the magma-gas interface equilibrium state when solving a deeper TCE profile, while keeping the MELTYQ-specific T(P) parameterization and package orchestration in the application layer. ExoGibbs therefore only provides the generic profile initialization path and solver state.

The previous profile API could not seed its first scheduled layer explicitly, and the magma-gas interface discarded the raw gas amounts needed for a consistent warm start. In float32, the default requested tolerance could also be below the numerical resolution of the solver.

## Impact

The new profile keyword is optional and existing profile calls retain their behavior. `MagmaAtmosphereInterfaceState` gains two fields in the interface's `b_H = 1` amount gauge; these are solver amounts, not physical number or mass density.

## Validation

- `pytest tests/unittests`: 727 passed
- `./update_doc.sh`: succeeded (83 existing documentation warnings)
- `git diff --check origin/develop...HEAD`: clean
