### PR TITLE
interop: add ExoEOS fugacity adapter

### DIFF
--- a/documents/equilibrium_solvers.rst
+++ b/documents/equilibrium_solvers.rst
@@ -107,6 +107,28 @@ Both solver modules accept an optional ``lnphi_func`` keyword:
        lnphi_func=lnphi_func,
    )
 
+A current ExoEOS checkout can supply these pure-component values through the
+optional consumer-side adapter. For example, a setup containing the nine
+MELTYQ gas species can assign one-component Zhang--Duan models to the six
+supported species; He, N2, and NH3 omitted under the explicit ``"ideal"``
+policy receive zero correction.
+
+.. code-block:: python
+
+   from exoeos import ZhangDuanEOS
+   from exogibbs.interop.exoeos import make_pure_lnphi_func
+
+   nonideal_species = ("H2", "O2", "H2O", "CO", "CO2", "CH4")
+   lnphi_func = make_pure_lnphi_func(
+       source_species=setup.species,
+       eos_by_species={
+           name: ZhangDuanEOS.from_species((name,))
+           for name in nonideal_species
+       },
+       unspecified_species="ideal",
+       phase="vapor",
+   )
+
 The returned vector must have shape ``(K,)`` and follow ``setup.species``
 order.  ``pressure_bar`` is the physical pressure in bar, independent of
 ``Pref``.  ExoGibbs adds the correction once to the standard gas source,

--- a/examples/plot_exoeos_pure_fugacity.py
+++ b/examples/plot_exoeos_pure_fugacity.py
@@ -29,6 +29,7 @@ from exogibbs.api.gas import (
     LogFugacityCoefficientFunction,
     solve,
 )
+from exogibbs.interop.exoeos import make_pure_lnphi_func
 
 
 config.update("jax_enable_x64", True)
@@ -46,7 +47,6 @@ FORMULA_MATRIX = jnp.asarray(
 ELEMENT_INVENTORY = jnp.asarray([1.0, 4.0, 2.0], dtype=jnp.float64)
 TEMPERATURE_K = 1500.0
 PRESSURES_BAR = jnp.geomspace(100.0, 5000.0, 6)
-BAR_TO_PA = 1.0e5
 
 _EXOEOS_INSTALL_HINT = (
     "Install a current ExoEOS checkout with "
@@ -54,10 +54,9 @@ _EXOEOS_INSTALL_HINT = (
 )
 
 try:
-    from exoeos import ZhangDuanEOS, state_tp
+    from exoeos import ZhangDuanEOS
 except ImportError as exc:
     ZhangDuanEOS = None
-    state_tp = None
     _EXOEOS_IMPORT_ERROR: Optional[ImportError] = exc
 else:
     _EXOEOS_IMPORT_ERROR = None
@@ -67,9 +66,9 @@ else:
 # Build a deliberately small ExoGibbs problem
 # --------------------------------------------
 #
-# Both the thermochemical vector and the EOS component arrays follow ``SPECIES``
-# order.  Keeping that mapping explicit is important because ExoEOS EOS objects
-# store numerical component arrays, not species labels.
+# The thermochemical vector follows ``SPECIES`` order. Later, ``eos_by_species``
+# explicitly labels each one-component EOS because ExoEOS models store numerical
+# component arrays rather than species names.
 
 
 def build_reduced_setup() -> ChemicalSetup:
@@ -96,40 +95,8 @@ def build_reduced_setup() -> ChemicalSetup:
 # Adapt the ExoEOS pure-component states
 # --------------------------------------
 #
-# ``state_tp`` evaluates one scalar state.  Mapping it over the pure-composition
-# basis evaluates every species at the same temperature and pressure.  At
-# ``x=e_i``, ``gres_RT = x @ lnphi`` is exactly ``ln(phi_i_pure)``, so the scalar
-# ``gres_RT`` field directly produces the desired vector without materializing
-# a matrix of all cross-component fugacity coefficients.
-
-
-def make_pure_lnphi_func(eos: Any) -> LogFugacityCoefficientFunction:
-    """Return an ExoGibbs-compatible pure-component ExoEOS callback."""
-
-    pure_compositions = jnp.eye(len(SPECIES), dtype=jnp.float64)
-
-    def lnphi_func(
-        temperature: Any,
-        pressure_bar: Any,
-        mole_fractions: Optional[jax.Array],
-    ) -> jax.Array:
-        if mole_fractions is not None:
-            raise ValueError(
-                "This example implements pure-component fugacity only; "
-                "mole_fractions must be None."
-            )
-        pressure_pa = jnp.asarray(pressure_bar) * BAR_TO_PA
-        return jax.vmap(
-            lambda pure_x: state_tp(
-                eos,
-                temperature,
-                pressure_pa,
-                pure_x,
-                phase="vapor",
-            ).gres_RT
-        )(pure_compositions)
-
-    return lnphi_func
+# Each mapping value is a one-component EOS. The adapter evaluates ``x=[1]``,
+# converts pressure from bar to Pa, and restores the source species order.
 
 
 def solve_pressure_profile(
@@ -170,8 +137,14 @@ def main() -> None:
         return
 
     setup = build_reduced_setup()
-    eos = ZhangDuanEOS.from_species(SPECIES)
-    lnphi_func = make_pure_lnphi_func(eos)
+    eos_by_species = {
+        species: ZhangDuanEOS.from_species((species,)) for species in SPECIES
+    }
+    lnphi_func = make_pure_lnphi_func(
+        source_species=setup.species,
+        eos_by_species=eos_by_species,
+        phase="vapor",
+    )
 
     ideal_x = solve_pressure_profile(setup, PRESSURES_BAR)
     nonideal_x = solve_pressure_profile(

--- a/src/exogibbs/interop/__init__.py
+++ b/src/exogibbs/interop/__init__.py
@@ -1,0 +1,1 @@
+"""Optional adapters for sibling ExoFamily packages."""

--- a/src/exogibbs/interop/exoeos.py
+++ b/src/exogibbs/interop/exoeos.py
@@ -1,0 +1,159 @@
+"""Adapt pure-component ExoEOS states to the ExoGibbs fugacity port."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional, Sequence
+
+import jax.numpy as jnp
+
+from exogibbs.thermo.fugacity import LogFugacityCoefficientFunction
+
+
+_BAR_TO_PA = 1.0e5
+_UNSPECIFIED_SPECIES_POLICIES = ("error", "ideal")
+
+
+def _load_state_tp() -> Any:
+    try:
+        from exoeos import state_tp
+    except ImportError as exc:
+        raise ImportError(
+            "make_pure_lnphi_func requires a current ExoEOS checkout with "
+            "the state_tp API."
+        ) from exc
+    return state_tp
+
+
+def _validate_species(source_species: Sequence[str]) -> tuple[str, ...]:
+    if source_species is None or isinstance(source_species, (str, bytes)):
+        raise ValueError("source_species must be a sequence of species names.")
+    species = tuple(source_species)
+    if not species:
+        raise ValueError("source_species must contain at least one species.")
+    if not all(isinstance(name, str) and name for name in species):
+        raise ValueError("source_species must contain non-empty species names.")
+    if len(set(species)) != len(species):
+        duplicates = sorted({name for name in species if species.count(name) > 1})
+        raise ValueError(
+            f"source_species names must be unique; duplicates: {duplicates}."
+        )
+    return species
+
+
+def make_pure_lnphi_func(
+    *,
+    source_species: Sequence[str],
+    eos_by_species: Mapping[str, Any],
+    unspecified_species: str = "error",
+    phase: str = "vapor",
+) -> LogFugacityCoefficientFunction:
+    """Return an ExoGibbs callback backed by one-component ExoEOS models.
+
+    ``eos_by_species`` maps names in ``source_species`` to one-component
+    ExoEOS models. Missing models are rejected unless
+    ``unspecified_species="ideal"``, which returns ``ln(phi) = 0`` for those
+    species. ExoGibbs pressure in bar is converted to Pa before each ExoEOS
+    state evaluation. ExoEOS retains ownership of state dtype promotion and
+    does not expose species labels, so model identity is a caller contract.
+    """
+
+    species = _validate_species(source_species)
+    models_by_species = dict(eos_by_species)
+    if not all(isinstance(name, str) and name for name in models_by_species):
+        raise ValueError("eos_by_species keys must be non-empty species names.")
+
+    unknown_species = sorted(set(models_by_species) - set(species))
+    if unknown_species:
+        raise ValueError(
+            "eos_by_species contains names absent from source_species: "
+            f"{unknown_species}."
+        )
+    if unspecified_species not in _UNSPECIFIED_SPECIES_POLICIES:
+        raise ValueError(
+            "unspecified_species must be 'error' or 'ideal'; "
+            f"got {unspecified_species!r}."
+        )
+    if not isinstance(phase, str) or not phase:
+        raise ValueError("phase must be a non-empty string.")
+
+    invalid_models = [
+        name for name, model in models_by_species.items() if model is None
+    ]
+    if invalid_models:
+        raise ValueError(
+            "eos_by_species values must be ExoEOS models; got None for "
+            f"{sorted(invalid_models)}."
+        )
+
+    missing_species = [name for name in species if name not in models_by_species]
+    if missing_species and unspecified_species == "error":
+        raise ValueError(
+            "eos_by_species is missing source species: "
+            f"{missing_species}. Set unspecified_species='ideal' to use "
+            "ln(phi) = 0 for them."
+        )
+
+    models = tuple(models_by_species.get(name) for name in species)
+    for name, model in zip(species, models):
+        if model is None:
+            continue
+        component_count = getattr(model, "component_count", None)
+        if component_count is not None and component_count != 1:
+            raise ValueError(
+                f"eos_by_species[{name!r}] must be a one-component EOS; "
+                f"got component_count={component_count}."
+            )
+
+    state_tp = _load_state_tp() if models_by_species else None
+
+    def lnphi_func(
+        temperature: Any,
+        pressure_bar: Any,
+        mole_fractions: Optional[jnp.ndarray],
+    ) -> jnp.ndarray:
+        if mole_fractions is not None:
+            raise ValueError(
+                "make_pure_lnphi_func supports pure-component fugacity only; "
+                "mole_fractions must be None."
+            )
+
+        temperature_array = jnp.asarray(temperature)
+        pressure_bar_array = jnp.asarray(pressure_bar)
+        dtype = jnp.result_type(
+            temperature_array,
+            pressure_bar_array,
+            jnp.float32,
+        )
+        temperature_array = temperature_array.astype(dtype)
+        pressure_pa = pressure_bar_array.astype(dtype) * jnp.asarray(
+            _BAR_TO_PA,
+            dtype=dtype,
+        )
+        pure_composition = jnp.ones((1,), dtype=dtype)
+        ideal_lnphi = jnp.zeros((), dtype=dtype)
+
+        values = []
+        for name, model in zip(species, models):
+            if model is None:
+                values.append(ideal_lnphi)
+                continue
+            state = state_tp(
+                model,
+                temperature_array,
+                pressure_pa,
+                pure_composition,
+                phase=phase,
+            )
+            model_lnphi = jnp.asarray(state.lnphi)
+            if model_lnphi.shape != (1,):
+                raise ValueError(
+                    f"ExoEOS state for {name!r} must return one fugacity "
+                    f"coefficient; got shape {model_lnphi.shape}."
+                )
+            values.append(model_lnphi[0])
+        return jnp.stack(values)
+
+    return lnphi_func
+
+
+__all__ = ["make_pure_lnphi_func"]

--- a/tests/unittests/api/public_import_contract_test.py
+++ b/tests/unittests/api/public_import_contract_test.py
@@ -58,6 +58,7 @@ def test_base_api_import_is_lazy_and_exports_are_deterministic() -> None:
         import types
 
         import exogibbs.api as api
+        import exogibbs.interop
 
         print(json.dumps({
             "condensate_loaded": (
@@ -80,6 +81,7 @@ def test_base_api_import_is_lazy_and_exports_are_deterministic() -> None:
             "magma_gas_preset_loaded": (
                 "exogibbs.presets.magma_gas" in sys.modules
             ),
+            "exoeos_loaded": "exoeos" in sys.modules,
             "all_unique": len(api.__all__) == len(set(api.__all__)),
             "child_names": [
                 name for name in (
@@ -101,6 +103,7 @@ def test_base_api_import_is_lazy_and_exports_are_deterministic() -> None:
     assert not payload["applications_loaded"]
     assert not payload["magma_gas_implementation_loaded"]
     assert not payload["magma_gas_preset_loaded"]
+    assert not payload["exoeos_loaded"]
     assert payload["all_unique"]
     assert payload["child_names"] == [
         "gas",

--- a/tests/unittests/examples/exoeos_pure_fugacity_test.py
+++ b/tests/unittests/examples/exoeos_pure_fugacity_test.py
@@ -24,14 +24,19 @@ def _load_example():
     return module
 
 
-def test_example_is_syntax_valid_and_uses_the_optional_public_hook() -> None:
+def test_example_is_syntax_valid_and_uses_the_exoeos_adapter() -> None:
     source = EXAMPLE_PATH.read_text(encoding="utf-8")
 
     compile(source, str(EXAMPLE_PATH), "exec")
-    assert "from exoeos import ZhangDuanEOS, state_tp" in source
+    assert "from exoeos import ZhangDuanEOS" in source
+    assert (
+        "from exogibbs.interop.exoeos import make_pure_lnphi_func" in source
+    )
     assert "except ImportError" in source
     assert "lnphi_func=lnphi_func" in source
-    assert "pressure_bar) * BAR_TO_PA" in source
+    assert "eos_by_species=eos_by_species" in source
+    assert "def make_pure_lnphi_func" not in source
+    assert "state_tp(" not in source
 
 
 def test_reduced_setup_matches_the_zhang_duan_species_order() -> None:

--- a/tests/unittests/interop/exoeos_test.py
+++ b/tests/unittests/interop/exoeos_test.py
@@ -1,0 +1,188 @@
+"""Tests for the optional ExoEOS fugacity adapter."""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from exogibbs.interop.exoeos import make_pure_lnphi_func
+
+
+class _FakeEOS:
+    def __init__(self, value: float, component_count: int = 1) -> None:
+        self.value = value
+        self.component_count = component_count
+
+
+def _install_fake_exoeos(monkeypatch, state_tp) -> None:
+    module = ModuleType("exoeos")
+    module.state_tp = state_tp
+    monkeypatch.setitem(sys.modules, "exoeos", module)
+
+
+def test_maps_by_source_order_and_adapts_scalar_states(monkeypatch) -> None:
+    calls = []
+
+    def state_tp(eos, temperature, pressure, composition, phase="vapor"):
+        calls.append((eos, temperature, pressure, composition, phase))
+        value = jnp.asarray(eos.value, dtype=composition.dtype)
+        value = value + pressure / jnp.asarray(1.0e5, dtype=composition.dtype)
+        return SimpleNamespace(lnphi=jnp.reshape(value, (1,)))
+
+    _install_fake_exoeos(monkeypatch, state_tp)
+    model_a = _FakeEOS(10.0)
+    model_b = _FakeEOS(20.0)
+    lnphi_func = make_pure_lnphi_func(
+        source_species=("B", "IDEAL", "A"),
+        eos_by_species={"A": model_a, "B": model_b},
+        unspecified_species="ideal",
+        phase="liquid",
+    )
+
+    result = lnphi_func(
+        jnp.asarray(1200.0, dtype=jnp.float32),
+        jnp.asarray(2.5, dtype=jnp.float32),
+        None,
+    )
+
+    np.testing.assert_allclose(result, np.asarray([22.5, 0.0, 12.5]))
+    assert result.dtype == jnp.float32
+    assert [call[0] for call in calls] == [model_b, model_a]
+    for _, temperature, pressure, composition, phase in calls:
+        assert temperature.dtype == jnp.float32
+        assert pressure.dtype == jnp.float32
+        assert phase == "liquid"
+        np.testing.assert_allclose(pressure, 2.5e5)
+        np.testing.assert_array_equal(composition, np.asarray([1.0]))
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_callback_supports_jit_vmap_grad_and_preserves_dtype(
+    monkeypatch,
+    dtype,
+) -> None:
+    def state_tp(eos, temperature, pressure, composition, phase="vapor"):
+        del phase
+        scale = jnp.asarray(eos.value, dtype=composition.dtype)
+        pressure_scale = jnp.asarray(1.0e6, dtype=composition.dtype)
+        value = scale * temperature + pressure / pressure_scale
+        return SimpleNamespace(lnphi=jnp.reshape(value, (1,)))
+
+    _install_fake_exoeos(monkeypatch, state_tp)
+    lnphi_func = make_pure_lnphi_func(
+        source_species=("active", "ideal"),
+        eos_by_species={"active": _FakeEOS(0.25)},
+        unspecified_species="ideal",
+    )
+    temperature = jnp.asarray(2.0, dtype=dtype)
+    pressure = jnp.asarray(3.0, dtype=dtype)
+
+    result = jax.jit(lambda T, P: lnphi_func(T, P, None))(
+        temperature,
+        pressure,
+    )
+    profile = jax.vmap(lambda P: lnphi_func(temperature, P, None))(
+        jnp.asarray([1.0, 3.0], dtype=dtype)
+    )
+    pressure_gradient = jax.grad(
+        lambda P: jnp.sum(lnphi_func(temperature, P, None))
+    )(pressure)
+
+    assert result.dtype == dtype
+    assert profile.dtype == dtype
+    np.testing.assert_allclose(result, np.asarray([0.8, 0.0]), rtol=1.0e-6)
+    np.testing.assert_allclose(
+        profile,
+        np.asarray([[0.6, 0.0], [0.8, 0.0]]),
+        rtol=1.0e-6,
+    )
+    np.testing.assert_allclose(pressure_gradient, 0.1, rtol=1.0e-6)
+
+
+def test_all_ideal_callback_returns_zeros_and_rejects_mixture_mode() -> None:
+    lnphi_func = make_pure_lnphi_func(
+        source_species=("He", "N2", "NH3"),
+        eos_by_species={},
+        unspecified_species="ideal",
+    )
+
+    result = lnphi_func(
+        jnp.asarray(1000.0, dtype=jnp.float32),
+        jnp.asarray(1.0, dtype=jnp.float32),
+        None,
+    )
+
+    np.testing.assert_array_equal(result, np.zeros(3))
+    assert result.dtype == jnp.float32
+    with pytest.raises(ValueError, match="mole_fractions must be None"):
+        lnphi_func(1000.0, 1.0, jnp.ones(3) / 3.0)
+
+
+def test_validates_species_mapping_and_component_count() -> None:
+    with pytest.raises(ValueError, match="must be unique"):
+        make_pure_lnphi_func(
+            source_species=("H2", "H2"),
+            eos_by_species={},
+            unspecified_species="ideal",
+        )
+    with pytest.raises(ValueError, match="absent from source_species"):
+        make_pure_lnphi_func(
+            source_species=("H2",),
+            eos_by_species={"O2": _FakeEOS(0.0)},
+        )
+    with pytest.raises(ValueError, match="missing source species"):
+        make_pure_lnphi_func(
+            source_species=("H2", "He"),
+            eos_by_species={"H2": _FakeEOS(0.0)},
+        )
+    with pytest.raises(ValueError, match="must be 'error' or 'ideal'"):
+        make_pure_lnphi_func(
+            source_species=("H2",),
+            eos_by_species={"H2": _FakeEOS(0.0)},
+            unspecified_species="zero",
+        )
+    with pytest.raises(ValueError, match="got None"):
+        make_pure_lnphi_func(
+            source_species=("H2",),
+            eos_by_species={"H2": None},
+        )
+    with pytest.raises(ValueError, match="one-component EOS"):
+        make_pure_lnphi_func(
+            source_species=("H2",),
+            eos_by_species={"H2": _FakeEOS(0.0, component_count=2)},
+        )
+
+
+def test_validates_state_lnphi_shape_when_component_count_is_unavailable(
+    monkeypatch,
+) -> None:
+    class ModelWithoutComponentCount:
+        pass
+
+    def state_tp(eos, temperature, pressure, composition, phase="vapor"):
+        del eos, temperature, pressure, composition, phase
+        return SimpleNamespace(lnphi=jnp.zeros((2,)))
+
+    _install_fake_exoeos(monkeypatch, state_tp)
+    lnphi_func = make_pure_lnphi_func(
+        source_species=("H2",),
+        eos_by_species={"H2": ModelWithoutComponentCount()},
+    )
+
+    with pytest.raises(ValueError, match="must return one fugacity coefficient"):
+        lnphi_func(1000.0, 1.0, None)
+
+
+def test_factory_reports_missing_or_outdated_exoeos(monkeypatch) -> None:
+    monkeypatch.setitem(sys.modules, "exoeos", ModuleType("exoeos"))
+
+    with pytest.raises(ImportError, match="current ExoEOS checkout"):
+        make_pure_lnphi_func(
+            source_species=("H2",),
+            eos_by_species={"H2": _FakeEOS(0.0)},
+        )


### PR DESCRIPTION
## Motivation

Provide the ExoGibbs-owned adapter required to consume pure-component fugacity coefficients from ExoEOS without introducing a core dependency on the sibling package.

## Summary

- add `exogibbs.interop.exoeos.make_pure_lnphi_func` with bar-to-Pa conversion, source-order mapping, explicit ideal fallback, validation, and JAX dtype preservation
- keep ExoEOS loading lazy and migrate the gallery example from its local adapter
- document the MELTYQ use case and add focused regression/import-boundary tests

## Testing

- `pytest -q tests/unittests` — 747 passed
- `pytest -q tests/unittests/interop/exoeos_test.py` — 7 passed
- current ExoEOS checkout smoke: legacy/new Zhang–Duan results match exactly; JIT, vmap, grad, and He/N2/NH3 ideal fallback verified
- offline wheel build succeeded and includes `exogibbs/interop`
- Sphinx dummy build succeeded (with existing documentation warnings)
